### PR TITLE
feat(rust): true drop-in clap replacement with auto .lenv/.env loading

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-04T09:57:27.191Z for PR creation at branch issue-23-139e66537421 for issue https://github.com/link-foundation/lino-arguments/issues/23

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-04T09:57:27.191Z for PR creation at branch issue-23-139e66537421 for issue https://github.com/link-foundation/lino-arguments/issues/23

--- a/experiments/test_trait_derive.rs
+++ b/experiments/test_trait_derive.rs
@@ -1,0 +1,14 @@
+// Experiment: Can we have our own Parser trait AND re-export clap's Parser derive macro?
+//
+// In Rust, `pub use clap::Parser` re-exports BOTH the derive macro and the trait
+// under the same name. Defining `pub trait Parser` causes E0255 (name conflict).
+//
+// Approaches considered:
+// 1. Shadow via submodule re-export — still conflicts (same type namespace)
+// 2. Custom derive proc-macro — too complex for this use case
+// 3. ctor crate for auto-initialization — CHOSEN SOLUTION
+//
+// Solution: Use `ctor` to run init() automatically before main().
+// This loads .lenv/.env at program startup, so `Args::parse()` (clap's)
+// sees the environment variables without any extra code.
+// User just changes `use clap::Parser` to `use lino_arguments::Parser`.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +167,7 @@ name = "lino-arguments"
 version = "0.1.1"
 dependencies = [
  "clap",
+ "dotenvy",
  "lino-env",
  "serde",
  "tempfile",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "lino-arguments"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "lino-env",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,10 +111,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "ctor"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "errno"
@@ -167,6 +198,7 @@ name = "lino-arguments"
 version = "0.1.1"
 dependencies = [
  "clap",
+ "ctor",
  "dotenvy",
  "lino-env",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lino-arguments"
-version = "0.2.0"
+version = "0.1.1"
 edition = "2021"
 authors = []
 license = "Unlicense"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.4", features = ["derive", "env", "string"] }
+ctor = "0.4.3"
 dotenvy = "0.15"
 lino-env = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,7 +18,7 @@ name = "lino-arguments"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.4", features = ["derive", "env"] }
+clap = { version = "4.4", features = ["derive", "env", "string"] }
 lino-env = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.4", features = ["derive", "env", "string"] }
+dotenvy = "0.15"
 lino-env = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lino-arguments"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = []
 license = "Unlicense"

--- a/rust/README.md
+++ b/rust/README.md
@@ -9,9 +9,10 @@ A unified configuration library combining environment variables and CLI argument
 `lino-arguments` provides a unified configuration system that automatically loads configuration from multiple sources with a clear priority chain:
 
 1. **CLI arguments** - Highest priority (manually entered options)
-2. **Environment variables** - With case-insensitive lookup
-3. **Configuration file** - Dynamic config file path via CLI
-4. **Default values** - Fallback values
+2. **Environment variables** - Already set in the process
+3. **`.lenv` file** - Links Notation environment file
+4. **`.env` file** - Standard dotenv file (for compatibility)
+5. **Default values** - Fallback values
 
 ## Installation
 
@@ -22,32 +23,87 @@ Add to your `Cargo.toml`:
 lino-arguments = "0.2"
 ```
 
-## Struct-Based Usage (like clap)
+## Struct-Based Usage (drop-in clap replacement)
 
-The `Parser` derive macro is re-exported from clap, so you can use `lino-arguments` as a drop-in replacement without depending on clap directly:
+Use `LinoParser` trait with standard clap `#[arg(env = "...")]` attributes. The `.lenv` and `.env` files are loaded automatically before parsing:
 
 ```rust
-use lino_arguments::{Parser, getenv, getenv_int, getenv_bool, load_lenv_file};
-
-// Load .lenv file (like dotenvy loads .env, but for .lenv format)
-load_lenv_file(".lenv").ok();
+use lino_arguments::{LinoParser, Parser};
 
 #[derive(Parser, Debug)]
 #[command(name = "my-app")]
 struct Args {
-    #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
+    #[arg(long, env = "PORT", default_value = "3000")]
     port: u16,
 
-    #[arg(short = 'k', long, default_value = getenv("API_KEY", ""))]
-    api_key: String,
+    #[arg(long, env = "API_KEY")]
+    api_key: Option<String>,
 
-    #[arg(short, long, default_value_t = getenv_bool("VERBOSE", false))]
+    #[arg(long, env = "VERBOSE")]
     verbose: bool,
 }
 
 fn main() {
-    let args = Args::parse();
+    // Loads .lenv + .env into process env, then parses CLI args via clap
+    let args = Args::lino_parse();
     println!("Server starting on port {}", args.port);
+}
+```
+
+With a `.lenv` file:
+```
+PORT: 8080
+API_KEY: my-secret-key
+```
+
+Or a `.env` file:
+```
+PORT=8080
+API_KEY=my-secret-key
+```
+
+The priority chain ensures CLI arguments always win:
+```bash
+# Uses default (3000)
+cargo run
+
+# Uses .lenv value (8080)
+# (if PORT: 8080 is in .lenv)
+cargo run
+
+# Uses env var (9090)
+PORT=9090 cargo run
+
+# Uses CLI argument (7070)
+cargo run -- --port 7070
+```
+
+### LinoParser Methods
+
+| Method | Description |
+|--------|-------------|
+| `lino_parse()` | Load `.lenv` + `.env`, then parse CLI args |
+| `lino_parse_with(lenv, env)` | Load specified files, then parse |
+| `lino_parse_from(args)` | Load `.lenv` + `.env`, parse custom args (for testing) |
+| `lino_parse_from_with(args, lenv, env)` | Load specified files, parse custom args |
+
+### Legacy Struct-Based Usage
+
+You can also use `getenv` helpers in `default_value` expressions with `Parser::parse()`:
+
+```rust
+use lino_arguments::{Parser, getenv, getenv_int, getenv_bool, load_lenv_file};
+
+load_lenv_file(".lenv").ok();
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
+    port: u16,
+}
+
+fn main() {
+    let args = Args::parse();
 }
 ```
 
@@ -62,6 +118,7 @@ fn main() {
     let config = make_config_from(std::env::args_os(), |c| {
         c.name("my-server")
          .lenv(".lenv")
+         .env(".env")
          .option_short("port", 'p', "Server port", "3000")
          .option_short("api-key", 'k', "API key", "")
          .flag_short("verbose", 'v', "Enable verbose logging")
@@ -86,6 +143,15 @@ fn main() {
 - `arg!` - Macro for inline argument definitions
 - `command!` - Macro for command metadata
 
+### File Loading Functions
+
+| Function | Description |
+|----------|-------------|
+| `load_lenv_file(path)` | Load `.lenv` file (won't overwrite existing env vars) |
+| `load_lenv_file_override(path)` | Load `.lenv` file (overwrites existing env vars) |
+| `load_env_file(path)` | Load `.env` file (won't overwrite existing env vars) |
+| `load_env_file_override(path)` | Load `.env` file (overwrites existing env vars) |
+
 ### Functional Configuration
 
 #### `make_config(configure)`
@@ -97,6 +163,7 @@ use lino_arguments::make_config;
 
 let config = make_config(|c| {
     c.lenv(".lenv")
+     .env(".env")
      .option("port", "Server port", "3000")
      .flag("verbose", "Enable verbose logging")
 });
@@ -124,6 +191,8 @@ assert_eq!(config.get("port"), "9090");
 | `.version(version)` | Set application version |
 | `.lenv(path)` | Load .lenv file (without overriding existing env vars) |
 | `.lenv_override(path)` | Load .lenv file (overriding existing env vars) |
+| `.env(path)` | Load .env file (without overriding existing env vars) |
+| `.env_override(path)` | Load .env file (overriding existing env vars) |
 | `.option(name, desc, default)` | Define a string option |
 | `.option_short(name, short, desc, default)` | Define a string option with short flag |
 | `.flag(name, desc)` | Define a boolean flag |

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # lino-arguments (Rust)
 
-A unified configuration library combining environment variables and CLI arguments with a clear priority chain.
+A unified configuration library combining environment variables and CLI arguments with a clear priority chain. Works like a combination of [clap](https://docs.rs/clap) and [dotenvy](https://docs.rs/dotenvy), but uses `.lenv` files via [lino-env](https://docs.rs/lino-env).
 
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
 
@@ -19,21 +19,26 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lino-arguments = "0.1"
+lino-arguments = "0.2"
 ```
 
-## Quick Start
+## Struct-Based Usage (like clap)
+
+The `Parser` derive macro is re-exported from clap, so you can use `lino-arguments` as a drop-in replacement without depending on clap directly:
 
 ```rust
-use clap::Parser;
-use lino_arguments::{getenv, getenv_int, getenv_bool};
+use lino_arguments::{Parser, getenv, getenv_int, getenv_bool, load_lenv_file};
 
-#[derive(Parser)]
+// Load .lenv file (like dotenvy loads .env, but for .lenv format)
+load_lenv_file(".lenv").ok();
+
+#[derive(Parser, Debug)]
+#[command(name = "my-app")]
 struct Args {
     #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
     port: u16,
 
-    #[arg(short, long, default_value = getenv("API_KEY", ""))]
+    #[arg(short = 'k', long, default_value = getenv("API_KEY", ""))]
     api_key: String,
 
     #[arg(short, long, default_value_t = getenv_bool("VERBOSE", false))]
@@ -46,7 +51,92 @@ fn main() {
 }
 ```
 
+## Functional Usage (like JavaScript's makeConfig)
+
+For quick scripts or when you prefer not to define structs, use the functional builder API:
+
+```rust
+use lino_arguments::make_config_from;
+
+fn main() {
+    let config = make_config_from(std::env::args_os(), |c| {
+        c.name("my-server")
+         .lenv(".lenv")
+         .option_short("port", 'p', "Server port", "3000")
+         .option_short("api-key", 'k', "API key", "")
+         .flag_short("verbose", 'v', "Enable verbose logging")
+    });
+
+    let port = config.get_int("port", 3000);
+    let api_key = config.get("api-key");
+    let verbose = config.get_bool("verbose");
+
+    println!("Server starting on port {}", port);
+}
+```
+
 ## API Reference
+
+### Re-exported Clap Types
+
+- `Parser` - Derive macro for struct-based CLI parsing
+- `Args` - Derive macro for argument groups
+- `Subcommand` - Derive macro for subcommands
+- `ValueEnum` - Derive macro for enum value arguments
+- `arg!` - Macro for inline argument definitions
+- `command!` - Macro for command metadata
+
+### Functional Configuration
+
+#### `make_config(configure)`
+
+Create configuration from CLI arguments and environment:
+
+```rust
+use lino_arguments::make_config;
+
+let config = make_config(|c| {
+    c.lenv(".lenv")
+     .option("port", "Server port", "3000")
+     .flag("verbose", "Enable verbose logging")
+});
+```
+
+#### `make_config_from(args, configure)`
+
+Same as `make_config` but accepts custom arguments (useful for testing):
+
+```rust
+use lino_arguments::make_config_from;
+
+let config = make_config_from(["app", "--port", "9090"], |c| {
+    c.option("port", "Server port", "3000")
+});
+assert_eq!(config.get("port"), "9090");
+```
+
+#### ConfigBuilder Methods
+
+| Method | Description |
+|--------|-------------|
+| `.name(name)` | Set application name |
+| `.about(description)` | Set application description |
+| `.version(version)` | Set application version |
+| `.lenv(path)` | Load .lenv file (without overriding existing env vars) |
+| `.lenv_override(path)` | Load .lenv file (overriding existing env vars) |
+| `.option(name, desc, default)` | Define a string option |
+| `.option_short(name, short, desc, default)` | Define a string option with short flag |
+| `.flag(name, desc)` | Define a boolean flag |
+| `.flag_short(name, short, desc)` | Define a boolean flag with short flag |
+
+#### Config Methods
+
+| Method | Description |
+|--------|-------------|
+| `.get(key)` | Get value as string |
+| `.get_int(key, default)` | Get value as integer |
+| `.get_bool(key)` | Get value as boolean |
+| `.has(key)` | Check if key exists |
 
 ### Environment Variable Helpers
 
@@ -90,6 +180,19 @@ assert_eq!(to_camel_case("api-key"), "apiKey");
 assert_eq!(to_kebab_case("apiKey"), "api-key");
 ```
 
+## Examples
+
+```bash
+# Run struct-based example
+cargo run --example struct_based -- --port 9090 --verbose
+
+# Run functional example
+cargo run --example functional -- --port 9090 --verbose
+
+# Use environment variables
+PORT=8080 cargo run --example struct_based
+```
+
 ## Testing
 
 ```bash
@@ -100,7 +203,7 @@ cargo test
 cargo test -- --nocapture
 
 # Run specific test
-cargo test case_conversion
+cargo test make_config
 ```
 
 ## Development

--- a/rust/README.md
+++ b/rust/README.md
@@ -25,10 +25,10 @@ lino-arguments = "0.2"
 
 ## Struct-Based Usage (drop-in clap replacement)
 
-Use `LinoParser` trait with standard clap `#[arg(env = "...")]` attributes. The `.lenv` and `.env` files are loaded automatically before parsing:
+Replace `use clap::Parser` with `use lino_arguments::Parser`, add `lino_arguments::init()` before `Args::parse()` — everything else stays the same:
 
 ```rust
-use lino_arguments::{LinoParser, Parser};
+use lino_arguments::Parser;
 
 #[derive(Parser, Debug)]
 #[command(name = "my-app")]
@@ -44,8 +44,8 @@ struct Args {
 }
 
 fn main() {
-    // Loads .lenv + .env into process env, then parses CLI args via clap
-    let args = Args::lino_parse();
+    lino_arguments::init();   // loads .lenv + .env into process env
+    let args = Args::parse(); // standard clap API — no changes needed
     println!("Server starting on port {}", args.port);
 }
 ```
@@ -78,7 +78,30 @@ PORT=9090 cargo run
 cargo run -- --port 7070
 ```
 
-### LinoParser Methods
+### init() Functions
+
+| Function | Description |
+|----------|-------------|
+| `init()` | Load `.lenv` + `.env` files into process env |
+| `init_with(lenv, env)` | Load specified files into process env |
+
+### LinoParser Trait (alternative one-liner API)
+
+For a single-call approach, use the `LinoParser` trait:
+
+```rust
+use lino_arguments::{Parser, LinoParser};
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, env = "PORT", default_value = "3000")]
+    port: u16,
+}
+
+fn main() {
+    let args = Args::lino_parse(); // loads .lenv + .env + parse in one call
+}
+```
 
 | Method | Description |
 |--------|-------------|
@@ -86,26 +109,6 @@ cargo run -- --port 7070
 | `lino_parse_with(lenv, env)` | Load specified files, then parse |
 | `lino_parse_from(args)` | Load `.lenv` + `.env`, parse custom args (for testing) |
 | `lino_parse_from_with(args, lenv, env)` | Load specified files, parse custom args |
-
-### Legacy Struct-Based Usage
-
-You can also use `getenv` helpers in `default_value` expressions with `Parser::parse()`:
-
-```rust
-use lino_arguments::{Parser, getenv, getenv_int, getenv_bool, load_lenv_file};
-
-load_lenv_file(".lenv").ok();
-
-#[derive(Parser, Debug)]
-struct Args {
-    #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
-    port: u16,
-}
-
-fn main() {
-    let args = Args::parse();
-}
-```
 
 ## Functional Usage (like JavaScript's makeConfig)
 
@@ -136,12 +139,19 @@ fn main() {
 
 ### Re-exported Clap Types
 
-- `Parser` - Derive macro for struct-based CLI parsing
+- `Parser` - Derive macro and trait for struct-based CLI parsing
 - `Args` - Derive macro for argument groups
 - `Subcommand` - Derive macro for subcommands
 - `ValueEnum` - Derive macro for enum value arguments
 - `arg!` - Macro for inline argument definitions
 - `command!` - Macro for command metadata
+
+### Initialization Functions
+
+| Function | Description |
+|----------|-------------|
+| `init()` | Load `.lenv` + `.env` files from current directory |
+| `init_with(lenv_path, env_path)` | Load specified `.lenv` and `.env` files |
 
 ### File Loading Functions
 

--- a/rust/changelog.d/added-clap-reexports-and-make-config.md
+++ b/rust/changelog.d/added-clap-reexports-and-make-config.md
@@ -1,7 +1,12 @@
 ### Added
+- `LinoParser` trait extending clap's `Parser` — `lino_parse()` automatically loads `.lenv` and `.env` files before CLI parsing
+- Full support for `#[arg(long, env = "PORT", default_value = "3000")]` with automatic `.lenv`/`.env` resolution
+- `lino_parse_with()`, `lino_parse_from()`, `lino_parse_from_with()` methods for custom file paths and testing
+- `load_env_file()` and `load_env_file_override()` for standard `.env` file support via dotenvy
+- `.env()` and `.env_override()` methods on `ConfigBuilder` for functional API
 - Re-exported clap derive macros (`Parser`, `Args`, `Subcommand`, `ValueEnum`) for struct-based CLI parsing without a separate clap dependency
-- New `make_config()` functional builder API inspired by the JavaScript `makeConfig` function
-- New `make_config_from()` for testing with custom arguments
+- `make_config()` functional builder API inspired by the JavaScript `makeConfig` function
+- `make_config_from()` for testing with custom arguments
 - `Config` type with `.get()`, `.get_int()`, `.get_bool()`, and `.has()` accessors
-- `ConfigBuilder` with chainable `.option()`, `.flag()`, `.lenv()`, `.name()`, `.about()`, `.version()` methods
+- `ConfigBuilder` with chainable `.option()`, `.flag()`, `.lenv()`, `.env()`, `.name()`, `.about()`, `.version()` methods
 - Examples for both struct-based and functional usage patterns

--- a/rust/changelog.d/added-clap-reexports-and-make-config.md
+++ b/rust/changelog.d/added-clap-reexports-and-make-config.md
@@ -1,0 +1,7 @@
+### Added
+- Re-exported clap derive macros (`Parser`, `Args`, `Subcommand`, `ValueEnum`) for struct-based CLI parsing without a separate clap dependency
+- New `make_config()` functional builder API inspired by the JavaScript `makeConfig` function
+- New `make_config_from()` for testing with custom arguments
+- `Config` type with `.get()`, `.get_int()`, `.get_bool()`, and `.has()` accessors
+- `ConfigBuilder` with chainable `.option()`, `.flag()`, `.lenv()`, `.name()`, `.about()`, `.version()` methods
+- Examples for both struct-based and functional usage patterns

--- a/rust/examples/functional.rs
+++ b/rust/examples/functional.rs
@@ -15,6 +15,7 @@ fn main() {
             .about("A web server with unified configuration")
             .version("1.0.0")
             .lenv(".lenv")
+            .env(".env")
             .option_short("port", 'p', "Server port", "3000")
             .option_short("api-key", 'k', "API key for authentication", "")
             .flag_short("verbose", 'v', "Enable verbose logging")

--- a/rust/examples/functional.rs
+++ b/rust/examples/functional.rs
@@ -1,0 +1,42 @@
+//! Functional configuration example (like the JavaScript makeConfig API)
+//!
+//! This shows the builder-style API that mirrors JavaScript's makeConfig
+//! function, useful for quick scripts or when you prefer not to define structs.
+//!
+//! Usage:
+//!   cargo run --example functional -- --port 9090 --verbose
+//!   PORT=8080 cargo run --example functional
+
+use lino_arguments::make_config_from;
+
+fn main() {
+    let config = make_config_from(std::env::args_os(), |c| {
+        c.name("my-server")
+            .about("A web server with unified configuration")
+            .version("1.0.0")
+            .lenv(".lenv")
+            .option_short("port", 'p', "Server port", "3000")
+            .option_short("api-key", 'k', "API key for authentication", "")
+            .flag_short("verbose", 'v', "Enable verbose logging")
+    });
+
+    let port = config.get_int("port", 3000);
+    let api_key = config.get("apiKey");
+    let verbose = config.get_bool("verbose");
+
+    if verbose {
+        println!("Configuration:");
+        println!("  Port: {}", port);
+        println!(
+            "  API Key: {}",
+            if api_key.is_empty() {
+                "(not set)"
+            } else {
+                &api_key
+            }
+        );
+        println!("  Verbose: {}", verbose);
+    }
+
+    println!("Server would start on port {}", port);
+}

--- a/rust/examples/struct_based.rs
+++ b/rust/examples/struct_based.rs
@@ -1,9 +1,8 @@
 //! Struct-based configuration example (drop-in clap replacement)
 //!
-//! This shows how lino-arguments works as a drop-in replacement for clap,
+//! This shows how lino-arguments works as a true drop-in replacement for clap,
 //! with built-in .lenv and .env file support. Just replace `use clap::Parser`
-//! with `use lino_arguments::Parser` and add `lino_arguments::init()` —
-//! everything else stays the same.
+//! with `use lino_arguments::Parser` — everything else stays the same.
 //!
 //! Usage:
 //!   cargo run --example struct_based -- --port 9090 --verbose
@@ -12,13 +11,14 @@
 //! With a .lenv file containing "PORT: 8080":
 //!   cargo run --example struct_based
 
+// Only change from clap: import from lino_arguments instead of clap
 use lino_arguments::Parser;
 
 /// A simple web server configuration.
 ///
-/// Uses standard clap attributes — `lino_arguments::init()` loads .lenv
-/// and .env files into the process environment before clap parses, so
-/// `env = "PORT"` automatically picks up values from .lenv/.env files.
+/// Uses standard clap attributes — lino-arguments automatically loads .lenv
+/// and .env files into the process environment at startup, so `env = "PORT"`
+/// picks up values from .lenv/.env files without any extra code.
 #[derive(Parser, Debug)]
 #[command(name = "my-server")]
 #[command(about = "A web server with unified configuration")]
@@ -42,8 +42,7 @@ struct Args {
 }
 
 fn main() {
-    // Drop-in: just add init() before parse()
-    lino_arguments::init();
+    // No init() needed — .lenv and .env are loaded automatically
     let args = Args::parse();
 
     // If --configuration was provided, load that .lenv file too

--- a/rust/examples/struct_based.rs
+++ b/rust/examples/struct_based.rs
@@ -1,0 +1,61 @@
+//! Struct-based configuration example (like clap + dotenvy)
+//!
+//! This shows how lino-arguments works as a drop-in replacement for clap,
+//! with built-in .lenv file support instead of .env files.
+//!
+//! Usage:
+//!   cargo run --example struct_based -- --port 9090 --verbose
+//!   PORT=8080 cargo run --example struct_based
+
+use lino_arguments::{getenv, getenv_bool, getenv_int, load_lenv_file, Parser};
+
+/// A simple web server configuration
+#[derive(Parser, Debug)]
+#[command(name = "my-server")]
+#[command(about = "A web server with unified configuration")]
+#[command(version)]
+struct Args {
+    /// Server port
+    #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
+    port: u16,
+
+    /// API key for authentication
+    #[arg(short = 'k', long, default_value = getenv("API_KEY", ""))]
+    api_key: String,
+
+    /// Enable verbose logging
+    #[arg(short, long, default_value_t = getenv_bool("VERBOSE", false))]
+    verbose: bool,
+
+    /// Configuration file path (.lenv format)
+    #[arg(short, long)]
+    configuration: Option<String>,
+}
+
+fn main() {
+    // Load .lenv file first (like dotenvy loads .env, but for .lenv format)
+    load_lenv_file(".lenv").ok();
+
+    // Parse CLI arguments — clap's derive macro works through lino-arguments
+    let args = Args::parse();
+
+    // Load additional config file if specified via --configuration
+    if let Some(ref config_path) = args.configuration {
+        if let Err(e) = load_lenv_file(config_path) {
+            eprintln!("Warning: Failed to load config '{}': {}", config_path, e);
+        }
+    }
+
+    println!("Configuration:");
+    println!("  Port: {}", args.port);
+    println!(
+        "  API Key: {}",
+        if args.api_key.is_empty() {
+            "(not set)"
+        } else {
+            &args.api_key
+        }
+    );
+    println!("  Verbose: {}", args.verbose);
+    println!("\nServer would start on port {}", args.port);
+}

--- a/rust/examples/struct_based.rs
+++ b/rust/examples/struct_based.rs
@@ -1,30 +1,38 @@
-//! Struct-based configuration example (like clap + dotenvy)
+//! Struct-based configuration example (drop-in clap replacement)
 //!
 //! This shows how lino-arguments works as a drop-in replacement for clap,
-//! with built-in .lenv file support instead of .env files.
+//! with built-in .lenv and .env file support. Just use `LinoParser` trait
+//! and clap's `env` attribute — .lenv/.env values are loaded automatically.
 //!
 //! Usage:
 //!   cargo run --example struct_based -- --port 9090 --verbose
 //!   PORT=8080 cargo run --example struct_based
+//!
+//! With a .lenv file containing "PORT: 8080":
+//!   cargo run --example struct_based
 
-use lino_arguments::{getenv, getenv_bool, getenv_int, load_lenv_file, Parser};
+use lino_arguments::{LinoParser, Parser};
 
-/// A simple web server configuration
+/// A simple web server configuration.
+///
+/// Uses standard clap attributes — `LinoParser::lino_parse()` loads .lenv
+/// and .env files into the process environment before clap parses, so
+/// `env = "PORT"` automatically picks up values from .lenv/.env files.
 #[derive(Parser, Debug)]
 #[command(name = "my-server")]
 #[command(about = "A web server with unified configuration")]
 #[command(version)]
 struct Args {
     /// Server port
-    #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
+    #[arg(short, long, env = "PORT", default_value = "3000")]
     port: u16,
 
     /// API key for authentication
-    #[arg(short = 'k', long, default_value = getenv("API_KEY", ""))]
-    api_key: String,
+    #[arg(short = 'k', long, env = "API_KEY")]
+    api_key: Option<String>,
 
     /// Enable verbose logging
-    #[arg(short, long, default_value_t = getenv_bool("VERBOSE", false))]
+    #[arg(short, long, env = "VERBOSE")]
     verbose: bool,
 
     /// Configuration file path (.lenv format)
@@ -33,15 +41,12 @@ struct Args {
 }
 
 fn main() {
-    // Load .lenv file first (like dotenvy loads .env, but for .lenv format)
-    load_lenv_file(".lenv").ok();
+    // lino_parse() loads .lenv + .env, then delegates to clap's parse()
+    let args = Args::lino_parse();
 
-    // Parse CLI arguments — clap's derive macro works through lino-arguments
-    let args = Args::parse();
-
-    // Load additional config file if specified via --configuration
+    // If --configuration was provided, load that .lenv file too
     if let Some(ref config_path) = args.configuration {
-        if let Err(e) = load_lenv_file(config_path) {
+        if let Err(e) = lino_arguments::load_lenv_file(config_path) {
             eprintln!("Warning: Failed to load config '{}': {}", config_path, e);
         }
     }
@@ -50,10 +55,10 @@ fn main() {
     println!("  Port: {}", args.port);
     println!(
         "  API Key: {}",
-        if args.api_key.is_empty() {
-            "(not set)"
+        if let Some(ref key) = args.api_key {
+            key.as_str()
         } else {
-            &args.api_key
+            "(not set)"
         }
     );
     println!("  Verbose: {}", args.verbose);

--- a/rust/examples/struct_based.rs
+++ b/rust/examples/struct_based.rs
@@ -1,8 +1,9 @@
 //! Struct-based configuration example (drop-in clap replacement)
 //!
 //! This shows how lino-arguments works as a drop-in replacement for clap,
-//! with built-in .lenv and .env file support. Just use `LinoParser` trait
-//! and clap's `env` attribute — .lenv/.env values are loaded automatically.
+//! with built-in .lenv and .env file support. Just replace `use clap::Parser`
+//! with `use lino_arguments::Parser` and add `lino_arguments::init()` —
+//! everything else stays the same.
 //!
 //! Usage:
 //!   cargo run --example struct_based -- --port 9090 --verbose
@@ -11,11 +12,11 @@
 //! With a .lenv file containing "PORT: 8080":
 //!   cargo run --example struct_based
 
-use lino_arguments::{LinoParser, Parser};
+use lino_arguments::Parser;
 
 /// A simple web server configuration.
 ///
-/// Uses standard clap attributes — `LinoParser::lino_parse()` loads .lenv
+/// Uses standard clap attributes — `lino_arguments::init()` loads .lenv
 /// and .env files into the process environment before clap parses, so
 /// `env = "PORT"` automatically picks up values from .lenv/.env files.
 #[derive(Parser, Debug)]
@@ -41,8 +42,9 @@ struct Args {
 }
 
 fn main() {
-    // lino_parse() loads .lenv + .env, then delegates to clap's parse()
-    let args = Args::lino_parse();
+    // Drop-in: just add init() before parse()
+    lino_arguments::init();
+    let args = Args::parse();
 
     // If --configuration was provided, load that .lenv file too
     if let Some(ref config_path) = args.configuration {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,22 +3,57 @@
 //! Combines environment variables and CLI arguments into a single
 //! easy-to-use configuration system with clear priority ordering.
 //!
+//! Works like a combination of [clap](https://docs.rs/clap) and
+//! [dotenvy](https://docs.rs/dotenvy), but uses `.lenv` files via
+//! [lino-env](https://docs.rs/lino-env) instead of `.env` files.
+//!
 //! Priority (highest to lowest):
 //! 1. CLI arguments (manually entered options)
 //! 2. Environment variables (from process.env)
 //! 3. Configuration file (lenv file specified via CLI)
 //! 4. Default values
 //!
-//! # Example
+//! # Struct-Based Usage (like clap)
 //!
 //! ```rust,ignore
-//! use lino_arguments::{getenv, load_lenv_file};
+//! use lino_arguments::{Parser, getenv, getenv_int, getenv_bool, load_lenv_file};
 //!
-//! // Load variables from a .lenv file into the environment
+//! // Load .lenv file first (like dotenvy, but for .lenv format)
 //! load_lenv_file(".lenv").ok();
 //!
-//! // Now getenv will find values from the loaded file
-//! let api_key = getenv("API_KEY", "default-key");
+//! #[derive(Parser, Debug)]
+//! #[command(name = "my-app")]
+//! struct Args {
+//!     #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
+//!     port: u16,
+//!
+//!     #[arg(short = 'k', long, default_value = getenv("API_KEY", ""))]
+//!     api_key: String,
+//!
+//!     #[arg(short, long, default_value_t = getenv_bool("VERBOSE", false))]
+//!     verbose: bool,
+//! }
+//!
+//! fn main() {
+//!     let args = Args::parse();
+//!     println!("Server starting on port {}", args.port);
+//! }
+//! ```
+//!
+//! # Functional Usage (like the JavaScript API)
+//!
+//! ```rust,ignore
+//! use lino_arguments::make_config;
+//!
+//! let config = make_config(|c| {
+//!     c.lenv(".lenv")
+//!      .option("port", "Server port", "3000")
+//!      .option("api-key", "API key", "")
+//!      .flag("verbose", "Enable verbose logging")
+//! });
+//!
+//! let port: u16 = config.get("port").parse().unwrap();
+//! let verbose: bool = config.get_bool("verbose");
 //! ```
 //!
 //! # .lenv File Format
@@ -31,8 +66,20 @@
 //! DEBUG: true
 //! ```
 
+use std::collections::HashMap;
 use std::env;
 use thiserror::Error;
+
+// Re-export clap derive macros and traits for struct-based usage.
+// This allows users to use `lino_arguments::Parser` directly without
+// depending on clap as a separate dependency.
+pub use clap::{Args, Parser, Subcommand, ValueEnum};
+
+// Re-export the arg attribute macro
+pub use clap::arg;
+
+// Re-export the command macro for #[command(...)] attribute
+pub use clap::command;
 
 // Re-export lino-env for direct file operations
 pub use lino_env::{read_lino_env, write_lino_env, LinoEnv};
@@ -395,6 +442,351 @@ pub fn getenv_bool(key: &str, default: bool) -> bool {
         "false" | "0" | "no" | "off" => false,
         _ => default,
     }
+}
+
+// ============================================================================
+// Functional Configuration API (like JavaScript's makeConfig)
+// ============================================================================
+
+/// Resolved configuration values from the functional API.
+///
+/// Contains all parsed configuration values accessible by key name.
+/// Values are stored as strings and can be retrieved with type conversion.
+#[derive(Debug, Clone)]
+pub struct Config {
+    values: HashMap<String, String>,
+}
+
+impl Config {
+    /// Get a configuration value as a string.
+    /// Returns empty string if the key is not found.
+    pub fn get(&self, key: &str) -> String {
+        let camel = to_camel_case(key);
+        self.values
+            .get(&camel)
+            .or_else(|| self.values.get(key))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Get a configuration value as an integer.
+    /// Returns the default if the key is not found or cannot be parsed.
+    pub fn get_int(&self, key: &str, default: i64) -> i64 {
+        let val = self.get(key);
+        if val.is_empty() {
+            return default;
+        }
+        val.parse().unwrap_or(default)
+    }
+
+    /// Get a configuration value as a boolean.
+    /// Accepts: "true", "false", "1", "0", "yes", "no", "on", "off" (case-insensitive).
+    /// Returns false if the key is not found.
+    pub fn get_bool(&self, key: &str) -> bool {
+        let val = self.get(key);
+        matches!(val.to_lowercase().as_str(), "true" | "1" | "yes" | "on")
+    }
+
+    /// Check if a configuration key exists.
+    pub fn has(&self, key: &str) -> bool {
+        let camel = to_camel_case(key);
+        self.values.contains_key(&camel) || self.values.contains_key(key)
+    }
+}
+
+/// Option definition for the functional configuration API.
+#[derive(Debug, Clone)]
+struct OptionDef {
+    name: String,
+    description: String,
+    default: String,
+    is_flag: bool,
+    short: Option<char>,
+}
+
+/// Builder for functional-style configuration.
+///
+/// Provides a chainable API for defining configuration options, similar to
+/// the JavaScript `makeConfig` API.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use lino_arguments::make_config;
+///
+/// let config = make_config(|c| {
+///     c.lenv(".lenv")
+///      .option("port", "Server port", "3000")
+///      .option_short("api-key", 'k', "API key", "")
+///      .flag("verbose", "Enable verbose logging")
+/// });
+/// ```
+pub struct ConfigBuilder {
+    options: Vec<OptionDef>,
+    lenv_path: Option<String>,
+    lenv_override: bool,
+    app_name: Option<String>,
+    app_about: Option<String>,
+    app_version: Option<String>,
+}
+
+impl ConfigBuilder {
+    fn new() -> Self {
+        ConfigBuilder {
+            options: Vec::new(),
+            lenv_path: None,
+            lenv_override: false,
+            app_name: None,
+            app_about: None,
+            app_version: None,
+        }
+    }
+
+    /// Set the application name for help text.
+    pub fn name(&mut self, name: &str) -> &mut Self {
+        self.app_name = Some(name.to_string());
+        self
+    }
+
+    /// Set the application description for help text.
+    pub fn about(&mut self, about: &str) -> &mut Self {
+        self.app_about = Some(about.to_string());
+        self
+    }
+
+    /// Set the application version for --version flag.
+    pub fn version(&mut self, version: &str) -> &mut Self {
+        self.app_version = Some(version.to_string());
+        self
+    }
+
+    /// Load a .lenv configuration file (without overriding existing env vars).
+    pub fn lenv(&mut self, path: &str) -> &mut Self {
+        self.lenv_path = Some(path.to_string());
+        self.lenv_override = false;
+        self
+    }
+
+    /// Load a .lenv configuration file, overriding existing env vars.
+    pub fn lenv_override(&mut self, path: &str) -> &mut Self {
+        self.lenv_path = Some(path.to_string());
+        self.lenv_override = true;
+        self
+    }
+
+    /// Define a string/number option with a long name, description, and default value.
+    pub fn option(&mut self, name: &str, description: &str, default: &str) -> &mut Self {
+        self.options.push(OptionDef {
+            name: name.to_string(),
+            description: description.to_string(),
+            default: default.to_string(),
+            is_flag: false,
+            short: None,
+        });
+        self
+    }
+
+    /// Define a string/number option with both short and long names.
+    pub fn option_short(
+        &mut self,
+        name: &str,
+        short: char,
+        description: &str,
+        default: &str,
+    ) -> &mut Self {
+        self.options.push(OptionDef {
+            name: name.to_string(),
+            description: description.to_string(),
+            default: default.to_string(),
+            is_flag: false,
+            short: Some(short),
+        });
+        self
+    }
+
+    /// Define a boolean flag (defaults to false).
+    pub fn flag(&mut self, name: &str, description: &str) -> &mut Self {
+        self.options.push(OptionDef {
+            name: name.to_string(),
+            description: description.to_string(),
+            default: String::new(),
+            is_flag: true,
+            short: None,
+        });
+        self
+    }
+
+    /// Define a boolean flag with a short name.
+    pub fn flag_short(&mut self, name: &str, short: char, description: &str) -> &mut Self {
+        self.options.push(OptionDef {
+            name: name.to_string(),
+            description: description.to_string(),
+            default: String::new(),
+            is_flag: true,
+            short: Some(short),
+        });
+        self
+    }
+
+    /// Build the configuration from the defined options.
+    ///
+    /// This parses CLI arguments using clap and resolves values from:
+    /// 1. CLI arguments (highest priority)
+    /// 2. Environment variables
+    /// 3. .lenv file
+    /// 4. Default values (lowest priority)
+    fn build(&self) -> Config {
+        self.build_from(env::args_os().collect())
+    }
+
+    /// Build the configuration from custom arguments (for testing).
+    fn build_from(&self, args: Vec<std::ffi::OsString>) -> Config {
+        // Step 1: Load .lenv file if configured
+        if let Some(ref path) = self.lenv_path {
+            if self.lenv_override {
+                let _ = load_lenv_file_override(path);
+            } else {
+                let _ = load_lenv_file(path);
+            }
+        }
+
+        // Step 2: Build clap command dynamically
+        let mut cmd = clap::Command::new(
+            self.app_name.clone().unwrap_or_else(|| "app".to_string()),
+        );
+
+        if let Some(ref about) = self.app_about {
+            cmd = cmd.about(about.clone());
+        }
+
+        if let Some(ref version) = self.app_version {
+            cmd = cmd.version(version.clone());
+        }
+
+        // Add --configuration option for dynamic .lenv loading
+        cmd = cmd.arg(
+            clap::Arg::new("configuration")
+                .long("configuration")
+                .short('c')
+                .help("Path to configuration .lenv file")
+                .value_name("PATH"),
+        );
+
+        // Add user-defined options
+        for opt in &self.options {
+            let kebab_name = to_kebab_case(&opt.name);
+
+            let mut arg = clap::Arg::new(kebab_name.clone()).long(kebab_name.clone());
+
+            // Set help text
+            arg = arg.help(opt.description.clone());
+
+            if let Some(short) = opt.short {
+                arg = arg.short(short);
+            }
+
+            if opt.is_flag {
+                arg = arg.action(clap::ArgAction::SetTrue);
+            } else {
+                // Resolve default: env var (with case-insensitive lookup) > .lenv > default
+                let env_default = getenv(&opt.name, &opt.default);
+                arg = arg.default_value(env_default);
+            }
+
+            cmd = cmd.arg(arg);
+        }
+
+        // Step 3: Parse arguments
+        let matches = cmd.get_matches_from(args);
+
+        // Step 4: Load --configuration file if provided
+        if let Some(config_path) = matches.get_one::<String>("configuration") {
+            let _ = load_lenv_file_override(config_path);
+        }
+
+        // Step 5: Collect values into Config
+        let mut values = HashMap::new();
+
+        for opt in &self.options {
+            let kebab_name = to_kebab_case(&opt.name);
+            let camel_name = to_camel_case(&opt.name);
+
+            if opt.is_flag {
+                let val = matches.get_flag(&kebab_name);
+                values.insert(camel_name, val.to_string());
+            } else if let Some(val) = matches.get_one::<String>(&kebab_name) {
+                values.insert(camel_name, val.clone());
+            }
+        }
+
+        Config { values }
+    }
+}
+
+/// Create a unified configuration using a functional builder API.
+///
+/// This is the Rust equivalent of the JavaScript `makeConfig` function.
+/// It combines .lenv file loading, environment variables, and CLI argument
+/// parsing into a single configuration step.
+///
+/// Priority (highest to lowest):
+/// 1. CLI arguments
+/// 2. Environment variables
+/// 3. .lenv file (via `--configuration` flag or builder `.lenv()`)
+/// 4. Default values
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use lino_arguments::make_config;
+///
+/// let config = make_config(|c| {
+///     c.lenv(".lenv")
+///      .option("port", "Server port", "3000")
+///      .option_short("api-key", 'k', "API key", "")
+///      .flag("verbose", "Enable verbose logging")
+/// });
+///
+/// let port: u16 = config.get("port").parse().unwrap();
+/// let api_key = config.get("api-key");
+/// let verbose = config.get_bool("verbose");
+/// ```
+pub fn make_config<F>(configure: F) -> Config
+where
+    F: FnOnce(&mut ConfigBuilder) -> &mut ConfigBuilder,
+{
+    let mut builder = ConfigBuilder::new();
+    configure(&mut builder);
+    builder.build()
+}
+
+/// Create a unified configuration using a functional builder API with custom arguments.
+///
+/// Same as `make_config` but accepts custom arguments for testing purposes.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use lino_arguments::make_config_from;
+///
+/// let args = vec!["my-app", "--port", "9090", "--verbose"];
+/// let config = make_config_from(args, |c| {
+///     c.option("port", "Server port", "3000")
+///      .flag("verbose", "Enable verbose logging")
+/// });
+///
+/// assert_eq!(config.get("port"), "9090");
+/// assert!(config.get_bool("verbose"));
+/// ```
+pub fn make_config_from<I, T, F>(args: I, configure: F) -> Config
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString>,
+    F: FnOnce(&mut ConfigBuilder) -> &mut ConfigBuilder,
+{
+    let mut builder = ConfigBuilder::new();
+    configure(&mut builder);
+    builder.build_from(args.into_iter().map(|a| a.into()).collect())
 }
 
 // ============================================================================

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -651,9 +651,8 @@ impl ConfigBuilder {
         }
 
         // Step 2: Build clap command dynamically
-        let mut cmd = clap::Command::new(
-            self.app_name.clone().unwrap_or_else(|| "app".to_string()),
-        );
+        let mut cmd =
+            clap::Command::new(self.app_name.clone().unwrap_or_else(|| "app".to_string()));
 
         if let Some(ref about) = self.app_about {
             cmd = cmd.about(about.clone());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -10,33 +10,37 @@
 //! Priority (highest to lowest):
 //! 1. CLI arguments (manually entered options)
 //! 2. Environment variables (from process.env)
-//! 3. Configuration file (lenv file specified via CLI)
-//! 4. Default values
+//! 3. Configuration file (.lenv file specified via `--configuration` or `.lenv()`)
+//! 4. `.lenv` file (local environment overrides)
+//! 5. `.env` file (standard dotenv, for compatibility)
+//! 6. Default values
 //!
-//! # Struct-Based Usage (like clap)
+//! # Drop-in Replacement for clap
+//!
+//! The `LinoParser` trait extends clap's `Parser` so that `#[arg(env = "PORT")]`
+//! automatically reads from `.lenv` files, `.env` files, and real environment
+//! variables — with no extra boilerplate:
 //!
 //! ```rust,ignore
-//! use lino_arguments::{Parser, getenv, getenv_int, getenv_bool, load_lenv_file};
-//!
-//! // Load .lenv file first (like dotenvy, but for .lenv format)
-//! load_lenv_file(".lenv").ok();
+//! use lino_arguments::{LinoParser, Parser};
 //!
 //! #[derive(Parser, Debug)]
 //! #[command(name = "my-app")]
 //! struct Args {
-//!     #[arg(short, long, default_value_t = getenv_int("PORT", 3000) as u16)]
+//!     #[arg(long, env = "PORT", default_value = "3000")]
 //!     port: u16,
 //!
-//!     #[arg(short = 'k', long, default_value = getenv("API_KEY", ""))]
-//!     api_key: String,
+//!     #[arg(long, env = "API_KEY")]
+//!     api_key: Option<String>,
 //!
-//!     #[arg(short, long, default_value_t = getenv_bool("VERBOSE", false))]
+//!     #[arg(long, env = "VERBOSE")]
 //!     verbose: bool,
 //! }
 //!
 //! fn main() {
-//!     let args = Args::parse();
-//!     println!("Server starting on port {}", args.port);
+//!     // Loads .lenv, .env into process env, then parses CLI args via clap
+//!     let args = Args::lino_parse();
+//!     println!("port = {}", args.port);
 //! }
 //! ```
 //!
@@ -103,6 +107,102 @@ pub enum ConfigError {
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
 }
+
+// ============================================================================
+// LinoParser Trait — drop-in replacement for clap::Parser
+// ============================================================================
+
+/// Extension trait for clap's `Parser` that automatically loads `.lenv` and
+/// `.env` files into the process environment before parsing CLI arguments.
+///
+/// This enables `#[arg(long, env = "PORT", default_value = "3000")]` to
+/// automatically resolve values from `.lenv` files, `.env` files, real
+/// environment variables, and defaults — with no extra boilerplate.
+///
+/// # Priority (highest to lowest)
+///
+/// 1. CLI arguments (`--port 8080`)
+/// 2. Environment variables already set in the process
+/// 3. Values from `.lenv` file (loaded into env, won't overwrite existing)
+/// 4. Values from `.env` file (loaded into env, won't overwrite existing)
+/// 5. `default_value` from the `#[arg(...)]` attribute
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use lino_arguments::{LinoParser, Parser};
+///
+/// #[derive(Parser, Debug)]
+/// struct Args {
+///     #[arg(long, env = "PORT", default_value = "3000")]
+///     port: u16,
+/// }
+///
+/// let args = Args::lino_parse();
+/// ```
+pub trait LinoParser: Parser {
+    /// Parse CLI arguments after loading `.lenv` and `.env` files.
+    ///
+    /// Equivalent to calling:
+    /// ```rust,ignore
+    /// load_lenv_file(".lenv").ok();
+    /// load_env_file(".env").ok();
+    /// Args::parse()
+    /// ```
+    fn lino_parse() -> Self {
+        load_lenv_file(".lenv").ok();
+        load_env_file(".env").ok();
+        Self::parse()
+    }
+
+    /// Parse CLI arguments after loading specified `.lenv` and `.env` files.
+    ///
+    /// # Arguments
+    ///
+    /// * `lenv_path` - Path to the `.lenv` file (or `None` to skip)
+    /// * `env_path` - Path to the `.env` file (or `None` to skip)
+    fn lino_parse_with(lenv_path: Option<&str>, env_path: Option<&str>) -> Self {
+        if let Some(path) = lenv_path {
+            load_lenv_file(path).ok();
+        }
+        if let Some(path) = env_path {
+            load_env_file(path).ok();
+        }
+        Self::parse()
+    }
+
+    /// Parse from custom arguments after loading `.lenv` and `.env` files.
+    /// Useful for testing.
+    fn lino_parse_from<I, T>(args: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        load_lenv_file(".lenv").ok();
+        load_env_file(".env").ok();
+        Self::parse_from(args)
+    }
+
+    /// Parse from custom arguments after loading specified config files.
+    /// Useful for testing.
+    fn lino_parse_from_with<I, T>(args: I, lenv_path: Option<&str>, env_path: Option<&str>) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        if let Some(path) = lenv_path {
+            load_lenv_file(path).ok();
+        }
+        if let Some(path) = env_path {
+            load_env_file(path).ok();
+        }
+        Self::parse_from(args)
+    }
+}
+
+/// Blanket implementation: any type that implements clap's `Parser`
+/// automatically gets `LinoParser` methods.
+impl<T: Parser> LinoParser for T {}
 
 // ============================================================================
 // .lenv File Loading
@@ -175,6 +275,81 @@ pub fn load_lenv_file_override(file_path: &str) -> Result<usize, ConfigError> {
         if let Some(value) = lenv.get(&key) {
             env::set_var(&key, &value);
             loaded_count += 1;
+        }
+    }
+
+    Ok(loaded_count)
+}
+
+// ============================================================================
+// .env File Loading (standard dotenv format, for compatibility)
+// ============================================================================
+
+/// Load environment variables from a `.env` file (standard `KEY=VALUE` format).
+///
+/// Uses the [dotenvy](https://docs.rs/dotenvy) crate under the hood.
+/// Existing environment variables are NOT overwritten.
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the `.env` file
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use lino_arguments::load_env_file;
+///
+/// // Load from default .env file
+/// load_env_file(".env").ok();
+/// ```
+pub fn load_env_file(file_path: &str) -> Result<usize, ConfigError> {
+    let path = std::path::Path::new(file_path);
+    if !path.exists() {
+        return Ok(0);
+    }
+
+    let iter = dotenvy::from_path_iter(path)
+        .map_err(|e| ConfigError::FileError(format!("Failed to read {}: {}", file_path, e)))?;
+
+    let mut loaded_count = 0;
+    for item in iter {
+        match item {
+            Ok((key, value)) => {
+                // Only set if not already present in environment
+                if env::var(&key).is_err() {
+                    env::set_var(&key, &value);
+                    loaded_count += 1;
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    Ok(loaded_count)
+}
+
+/// Load environment variables from a `.env` file, overwriting existing values.
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the `.env` file
+pub fn load_env_file_override(file_path: &str) -> Result<usize, ConfigError> {
+    let path = std::path::Path::new(file_path);
+    if !path.exists() {
+        return Ok(0);
+    }
+
+    let iter = dotenvy::from_path_iter(path)
+        .map_err(|e| ConfigError::FileError(format!("Failed to read {}: {}", file_path, e)))?;
+
+    let mut loaded_count = 0;
+    for item in iter {
+        match item {
+            Ok((key, value)) => {
+                env::set_var(&key, &value);
+                loaded_count += 1;
+            }
+            Err(_) => continue,
         }
     }
 
@@ -525,6 +700,8 @@ pub struct ConfigBuilder {
     options: Vec<OptionDef>,
     lenv_path: Option<String>,
     lenv_override: bool,
+    env_path: Option<String>,
+    env_override: bool,
     app_name: Option<String>,
     app_about: Option<String>,
     app_version: Option<String>,
@@ -536,6 +713,8 @@ impl ConfigBuilder {
             options: Vec::new(),
             lenv_path: None,
             lenv_override: false,
+            env_path: None,
+            env_override: false,
             app_name: None,
             app_about: None,
             app_version: None,
@@ -571,6 +750,20 @@ impl ConfigBuilder {
     pub fn lenv_override(&mut self, path: &str) -> &mut Self {
         self.lenv_path = Some(path.to_string());
         self.lenv_override = true;
+        self
+    }
+
+    /// Load a .env configuration file (without overriding existing env vars).
+    pub fn env(&mut self, path: &str) -> &mut Self {
+        self.env_path = Some(path.to_string());
+        self.env_override = false;
+        self
+    }
+
+    /// Load a .env configuration file, overriding existing env vars.
+    pub fn env_override(&mut self, path: &str) -> &mut Self {
+        self.env_path = Some(path.to_string());
+        self.env_override = true;
         self
     }
 
@@ -634,14 +827,15 @@ impl ConfigBuilder {
     /// 1. CLI arguments (highest priority)
     /// 2. Environment variables
     /// 3. .lenv file
-    /// 4. Default values (lowest priority)
+    /// 4. .env file
+    /// 5. Default values (lowest priority)
     fn build(&self) -> Config {
         self.build_from(env::args_os().collect())
     }
 
     /// Build the configuration from custom arguments (for testing).
     fn build_from(&self, args: Vec<std::ffi::OsString>) -> Config {
-        // Step 1: Load .lenv file if configured
+        // Step 1: Load .lenv file if configured (higher priority than .env)
         if let Some(ref path) = self.lenv_path {
             if self.lenv_override {
                 let _ = load_lenv_file_override(path);
@@ -650,7 +844,16 @@ impl ConfigBuilder {
             }
         }
 
-        // Step 2: Build clap command dynamically
+        // Step 2: Load .env file if configured (lower priority than .lenv)
+        if let Some(ref path) = self.env_path {
+            if self.env_override {
+                let _ = load_env_file_override(path);
+            } else {
+                let _ = load_env_file(path);
+            }
+        }
+
+        // Step 3: Build clap command dynamically
         let mut cmd =
             clap::Command::new(self.app_name.clone().unwrap_or_else(|| "app".to_string()));
 
@@ -674,6 +877,7 @@ impl ConfigBuilder {
         // Add user-defined options
         for opt in &self.options {
             let kebab_name = to_kebab_case(&opt.name);
+            let env_name = to_upper_case(&opt.name);
 
             let mut arg = clap::Arg::new(kebab_name.clone()).long(kebab_name.clone());
 
@@ -687,23 +891,26 @@ impl ConfigBuilder {
             if opt.is_flag {
                 arg = arg.action(clap::ArgAction::SetTrue);
             } else {
-                // Resolve default: env var (with case-insensitive lookup) > .lenv > default
-                let env_default = getenv(&opt.name, &opt.default);
-                arg = arg.default_value(env_default);
+                // Use clap's env feature so it picks up values from env vars
+                // (which now include .lenv and .env values we loaded above)
+                arg = arg.env(env_name);
+                if !opt.default.is_empty() {
+                    arg = arg.default_value(opt.default.clone());
+                }
             }
 
             cmd = cmd.arg(arg);
         }
 
-        // Step 3: Parse arguments
+        // Step 4: Parse arguments
         let matches = cmd.get_matches_from(args);
 
-        // Step 4: Load --configuration file if provided
+        // Step 5: Load --configuration file if provided
         if let Some(config_path) = matches.get_one::<String>("configuration") {
             let _ = load_lenv_file_override(config_path);
         }
 
-        // Step 5: Collect values into Config
+        // Step 6: Collect values into Config
         let mut values = HashMap::new();
 
         for opt in &self.options {
@@ -725,14 +932,15 @@ impl ConfigBuilder {
 /// Create a unified configuration using a functional builder API.
 ///
 /// This is the Rust equivalent of the JavaScript `makeConfig` function.
-/// It combines .lenv file loading, environment variables, and CLI argument
-/// parsing into a single configuration step.
+/// It combines .lenv file loading, .env file loading, environment variables,
+/// and CLI argument parsing into a single configuration step.
 ///
 /// Priority (highest to lowest):
 /// 1. CLI arguments
 /// 2. Environment variables
 /// 3. .lenv file (via `--configuration` flag or builder `.lenv()`)
-/// 4. Default values
+/// 4. .env file (via builder `.env()`)
+/// 5. Default values
 ///
 /// # Example
 ///
@@ -741,6 +949,7 @@ impl ConfigBuilder {
 ///
 /// let config = make_config(|c| {
 ///     c.lenv(".lenv")
+///      .env(".env")
 ///      .option("port", "Server port", "3000")
 ///      .option_short("api-key", 'k', "API key", "")
 ///      .flag("verbose", "Enable verbose logging")
@@ -842,7 +1051,6 @@ mod tests {
 
         #[test]
         fn test_getenv_with_default() {
-            // Test that default is returned for non-existent var
             let result = getenv("NON_EXISTENT_VAR_12345", "default");
             assert_eq!(result, "default");
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,25 +4,24 @@
 //! easy-to-use configuration system with clear priority ordering.
 //!
 //! Works like a combination of [clap](https://docs.rs/clap) and
-//! [dotenvy](https://docs.rs/dotenvy), but uses `.lenv` files via
-//! [lino-env](https://docs.rs/lino-env) instead of `.env` files.
+//! [dotenvy](https://docs.rs/dotenvy), but also with support for `.lenv` files
+//! via [lino-env](https://docs.rs/lino-env).
 //!
 //! Priority (highest to lowest):
 //! 1. CLI arguments (manually entered options)
-//! 2. Environment variables (from process.env)
-//! 3. Configuration file (.lenv file specified via `--configuration` or `.lenv()`)
-//! 4. `.lenv` file (local environment overrides)
-//! 5. `.env` file (standard dotenv, for compatibility)
-//! 6. Default values
+//! 2. Environment variables (from process env)
+//! 3. `.lenv` file (local environment overrides)
+//! 4. `.env` file (standard dotenv, for compatibility)
+//! 5. Default values
 //!
 //! # Drop-in Replacement for clap
 //!
-//! The `LinoParser` trait extends clap's `Parser` so that `#[arg(env = "PORT")]`
-//! automatically reads from `.lenv` files, `.env` files, and real environment
-//! variables — with no extra boilerplate:
+//! Use `lino_arguments::Parser` instead of `clap::Parser` — everything else
+//! stays the same. Call `Args::parse()` and `.lenv`/`.env` files are loaded
+//! automatically:
 //!
 //! ```rust,ignore
-//! use lino_arguments::{LinoParser, Parser};
+//! use lino_arguments::Parser;
 //!
 //! #[derive(Parser, Debug)]
 //! #[command(name = "my-app")]
@@ -38,8 +37,7 @@
 //! }
 //!
 //! fn main() {
-//!     // Loads .lenv, .env into process env, then parses CLI args via clap
-//!     let args = Args::lino_parse();
+//!     let args = Args::parse();
 //!     println!("port = {}", args.port);
 //! }
 //! ```
@@ -51,6 +49,7 @@
 //!
 //! let config = make_config(|c| {
 //!     c.lenv(".lenv")
+//!      .env(".env")
 //!      .option("port", "Server port", "3000")
 //!      .option("api-key", "API key", "")
 //!      .flag("verbose", "Enable verbose logging")
@@ -74,10 +73,11 @@ use std::collections::HashMap;
 use std::env;
 use thiserror::Error;
 
-// Re-export clap derive macros and traits for struct-based usage.
-// This allows users to use `lino_arguments::Parser` directly without
-// depending on clap as a separate dependency.
-pub use clap::{Args, Parser, Subcommand, ValueEnum};
+// Re-export clap's Parser (derive macro + trait) so that `#[derive(Parser)]`
+// and `Args::parse()` work out of the box. Users import `lino_arguments::Parser`
+// as a drop-in replacement for `clap::Parser`.
+pub use clap::Parser;
+pub use clap::{Args, Subcommand, ValueEnum};
 
 // Re-export the arg attribute macro
 pub use clap::arg;
@@ -112,12 +112,61 @@ pub enum ConfigError {
 // LinoParser Trait — drop-in replacement for clap::Parser
 // ============================================================================
 
-/// Extension trait for clap's `Parser` that automatically loads `.lenv` and
-/// `.env` files into the process environment before parsing CLI arguments.
+// ============================================================================
+// init() — Load .lenv and .env files into the process environment
+// ============================================================================
+
+/// Load `.lenv` and `.env` files into the process environment.
 ///
-/// This enables `#[arg(long, env = "PORT", default_value = "3000")]` to
-/// automatically resolve values from `.lenv` files, `.env` files, real
-/// environment variables, and defaults — with no extra boilerplate.
+/// Call this before `Args::parse()` to get the full priority chain:
+/// CLI args > env vars > `.lenv` > `.env` > `default_value`.
+///
+/// This is the recommended approach for a true drop-in clap replacement:
+///
+/// ```rust,ignore
+/// use lino_arguments::Parser;
+///
+/// #[derive(Parser, Debug)]
+/// struct Args {
+///     #[arg(long, env = "PORT", default_value = "3000")]
+///     port: u16,
+/// }
+///
+/// fn main() {
+///     lino_arguments::init();   // loads .lenv + .env into process env
+///     let args = Args::parse(); // standard clap API — no changes needed
+/// }
+/// ```
+pub fn init() {
+    load_lenv_file(".lenv").ok();
+    load_env_file(".env").ok();
+}
+
+/// Load specified `.lenv` and `.env` files into the process environment.
+///
+/// Like [`init()`], but with custom file paths.
+///
+/// ```rust,ignore
+/// lino_arguments::init_with(Some(".lenv"), Some(".env.local"));
+/// let args = Args::parse();
+/// ```
+pub fn init_with(lenv_path: Option<&str>, env_path: Option<&str>) {
+    if let Some(path) = lenv_path {
+        load_lenv_file(path).ok();
+    }
+    if let Some(path) = env_path {
+        load_env_file(path).ok();
+    }
+}
+
+// ============================================================================
+// LinoParser Trait — convenience extension for clap::Parser
+// ============================================================================
+
+/// Extension trait for clap's `Parser` that combines `.lenv`/`.env` loading
+/// with CLI argument parsing in a single call.
+///
+/// Automatically implemented for any type that derives `clap::Parser`.
 ///
 /// # Priority (highest to lowest)
 ///
@@ -130,7 +179,7 @@ pub enum ConfigError {
 /// # Example
 ///
 /// ```rust,ignore
-/// use lino_arguments::{LinoParser, Parser};
+/// use lino_arguments::{Parser, LinoParser};
 ///
 /// #[derive(Parser, Debug)]
 /// struct Args {
@@ -138,37 +187,24 @@ pub enum ConfigError {
 ///     port: u16,
 /// }
 ///
+/// // Option 1: init() + standard parse() (recommended drop-in)
+/// lino_arguments::init();
+/// let args = Args::parse();
+///
+/// // Option 2: lino_parse() one-liner
 /// let args = Args::lino_parse();
 /// ```
 pub trait LinoParser: Parser {
     /// Parse CLI arguments after loading `.lenv` and `.env` files.
-    ///
-    /// Equivalent to calling:
-    /// ```rust,ignore
-    /// load_lenv_file(".lenv").ok();
-    /// load_env_file(".env").ok();
-    /// Args::parse()
-    /// ```
     fn lino_parse() -> Self {
-        load_lenv_file(".lenv").ok();
-        load_env_file(".env").ok();
-        Self::parse()
+        init();
+        <Self as Parser>::parse()
     }
 
     /// Parse CLI arguments after loading specified `.lenv` and `.env` files.
-    ///
-    /// # Arguments
-    ///
-    /// * `lenv_path` - Path to the `.lenv` file (or `None` to skip)
-    /// * `env_path` - Path to the `.env` file (or `None` to skip)
     fn lino_parse_with(lenv_path: Option<&str>, env_path: Option<&str>) -> Self {
-        if let Some(path) = lenv_path {
-            load_lenv_file(path).ok();
-        }
-        if let Some(path) = env_path {
-            load_env_file(path).ok();
-        }
-        Self::parse()
+        init_with(lenv_path, env_path);
+        <Self as Parser>::parse()
     }
 
     /// Parse from custom arguments after loading `.lenv` and `.env` files.
@@ -178,9 +214,8 @@ pub trait LinoParser: Parser {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        load_lenv_file(".lenv").ok();
-        load_env_file(".env").ok();
-        Self::parse_from(args)
+        init();
+        <Self as Parser>::parse_from(args)
     }
 
     /// Parse from custom arguments after loading specified config files.
@@ -190,17 +225,12 @@ pub trait LinoParser: Parser {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        if let Some(path) = lenv_path {
-            load_lenv_file(path).ok();
-        }
-        if let Some(path) = env_path {
-            load_env_file(path).ok();
-        }
-        Self::parse_from(args)
+        init_with(lenv_path, env_path);
+        <Self as Parser>::parse_from(args)
     }
 }
 
-/// Blanket implementation: any type that implements clap's `Parser`
+/// Blanket implementation: any type that derives `clap::Parser`
 /// automatically gets `LinoParser` methods.
 impl<T: Parser> LinoParser for T {}
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,11 +16,12 @@
 //!
 //! # Drop-in Replacement for clap
 //!
-//! Use `lino_arguments::Parser` instead of `clap::Parser` — everything else
-//! stays the same. Call `Args::parse()` and `.lenv`/`.env` files are loaded
-//! automatically:
+//! Just replace `use clap::Parser` with `use lino_arguments::Parser` —
+//! everything else stays exactly the same. `.lenv` and `.env` files are
+//! loaded automatically at startup before `main()` runs:
 //!
 //! ```rust,ignore
+//! // Only change: import from lino_arguments instead of clap
 //! use lino_arguments::Parser;
 //!
 //! #[derive(Parser, Debug)]
@@ -37,7 +38,7 @@
 //! }
 //!
 //! fn main() {
-//!     let args = Args::parse();
+//!     let args = Args::parse(); // .lenv + .env already loaded
 //!     println!("port = {}", args.port);
 //! }
 //! ```
@@ -74,8 +75,10 @@ use std::env;
 use thiserror::Error;
 
 // Re-export clap's Parser (derive macro + trait) so that `#[derive(Parser)]`
-// and `Args::parse()` work out of the box. Users import `lino_arguments::Parser`
-// as a drop-in replacement for `clap::Parser`.
+// and `Args::parse()` work as a true drop-in replacement for clap.
+// The .lenv/.env files are loaded automatically at startup via the `ctor` crate,
+// so `Args::parse()` sees the environment variables from these files without
+// any extra `init()` call.
 pub use clap::Parser;
 pub use clap::{Args, Subcommand, ValueEnum};
 
@@ -109,8 +112,20 @@ pub enum ConfigError {
 }
 
 // ============================================================================
-// LinoParser Trait — drop-in replacement for clap::Parser
+// Auto-initialization via ctor
 // ============================================================================
+
+/// Automatically load `.lenv` and `.env` files at program startup.
+///
+/// This runs before `main()`, so by the time `Args::parse()` is called,
+/// all values from `.lenv` and `.env` are already in the process environment.
+/// This is what makes the drop-in replacement work: just change the import
+/// from `use clap::Parser` to `use lino_arguments::Parser` and everything
+/// else stays the same.
+#[ctor::ctor]
+fn auto_init() {
+    init();
+}
 
 // ============================================================================
 // init() — Load .lenv and .env files into the process environment
@@ -118,25 +133,12 @@ pub enum ConfigError {
 
 /// Load `.lenv` and `.env` files into the process environment.
 ///
-/// Call this before `Args::parse()` to get the full priority chain:
-/// CLI args > env vars > `.lenv` > `.env` > `default_value`.
+/// Loads `.lenv` first (higher priority), then `.env` (lower priority).
+/// Neither overwrites existing environment variables.
 ///
-/// This is the recommended approach for a true drop-in clap replacement:
-///
-/// ```rust,ignore
-/// use lino_arguments::Parser;
-///
-/// #[derive(Parser, Debug)]
-/// struct Args {
-///     #[arg(long, env = "PORT", default_value = "3000")]
-///     port: u16,
-/// }
-///
-/// fn main() {
-///     lino_arguments::init();   // loads .lenv + .env into process env
-///     let args = Args::parse(); // standard clap API — no changes needed
-/// }
-/// ```
+/// This is called automatically at program startup. You only need to call
+/// it manually if you want to reload files after the program has started,
+/// or if you're using [`init_with()`] with custom paths.
 pub fn init() {
     load_lenv_file(".lenv").ok();
     load_env_file(".env").ok();
@@ -147,7 +149,7 @@ pub fn init() {
 /// Like [`init()`], but with custom file paths.
 ///
 /// ```rust,ignore
-/// lino_arguments::init_with(Some(".lenv"), Some(".env.local"));
+/// lino_arguments::init_with(Some("config/app.lenv"), Some(".env.local"));
 /// let args = Args::parse();
 /// ```
 pub fn init_with(lenv_path: Option<&str>, env_path: Option<&str>) {
@@ -160,23 +162,19 @@ pub fn init_with(lenv_path: Option<&str>, env_path: Option<&str>) {
 }
 
 // ============================================================================
-// LinoParser Trait — convenience extension for clap::Parser
+// LinoParser Trait — convenience extension for custom file paths
 // ============================================================================
 
-/// Extension trait for clap's `Parser` that combines `.lenv`/`.env` loading
-/// with CLI argument parsing in a single call.
+/// Extension trait for `clap::Parser` that provides methods for parsing
+/// with custom `.lenv`/`.env` file paths.
 ///
-/// Automatically implemented for any type that derives `clap::Parser`.
+/// Automatically implemented for any type that derives `Parser`.
 ///
-/// # Priority (highest to lowest)
+/// For standard usage, you don't need this trait at all — just use
+/// `Args::parse()` directly and `.lenv`/`.env` files are loaded
+/// automatically at startup.
 ///
-/// 1. CLI arguments (`--port 8080`)
-/// 2. Environment variables already set in the process
-/// 3. Values from `.lenv` file (loaded into env, won't overwrite existing)
-/// 4. Values from `.env` file (loaded into env, won't overwrite existing)
-/// 5. `default_value` from the `#[arg(...)]` attribute
-///
-/// # Example
+/// Use `LinoParser` methods only when you need custom file paths:
 ///
 /// ```rust,ignore
 /// use lino_arguments::{Parser, LinoParser};
@@ -187,15 +185,17 @@ pub fn init_with(lenv_path: Option<&str>, env_path: Option<&str>) {
 ///     port: u16,
 /// }
 ///
-/// // Option 1: init() + standard parse() (recommended drop-in)
-/// lino_arguments::init();
+/// // Standard usage — just parse(), .lenv/.env already loaded:
 /// let args = Args::parse();
 ///
-/// // Option 2: lino_parse() one-liner
-/// let args = Args::lino_parse();
+/// // Custom file paths:
+/// let args = Args::lino_parse_from_with(
+///     ["app"], Some("custom.lenv"), Some("custom.env")
+/// );
 /// ```
 pub trait LinoParser: Parser {
     /// Parse CLI arguments after loading `.lenv` and `.env` files.
+    /// Equivalent to `Args::parse()` (since auto-init already loads files).
     fn lino_parse() -> Self {
         init();
         <Self as Parser>::parse()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -2,8 +2,7 @@
 //!
 //! This is a simple CLI example showing how to use lino-arguments.
 
-use clap::Parser;
-use lino_arguments::{getenv, getenv_bool, getenv_int, load_lenv_file};
+use lino_arguments::{getenv, getenv_bool, getenv_int, load_lenv_file, Parser};
 
 /// A unified configuration example
 #[derive(Parser, Debug)]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -3,12 +3,12 @@
 //! This is a simple CLI example showing how to use lino-arguments
 //! as a drop-in replacement for clap with .lenv/.env file support.
 
-use lino_arguments::{load_lenv_file, LinoParser, Parser};
+use lino_arguments::{load_lenv_file, Parser};
 
 /// A unified configuration example.
 ///
 /// Uses standard clap `#[arg(env = "...")]` attributes.
-/// `LinoParser::lino_parse()` loads .lenv and .env files into the process
+/// `lino_arguments::init()` loads .lenv and .env files into the process
 /// environment before clap parses, so `env` attributes automatically pick
 /// up values from .lenv/.env files.
 #[derive(Parser, Debug)]
@@ -34,8 +34,9 @@ struct Args {
 }
 
 fn main() {
-    // lino_parse() = load .lenv + .env, then parse CLI args
-    let args = Args::lino_parse();
+    // init() loads .lenv + .env into process env, then parse() works as usual
+    lino_arguments::init();
+    let args = Args::parse();
 
     // Load additional config file if specified via --configuration
     if let Some(ref config_path) = args.configuration {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,16 +1,16 @@
 //! lino-arguments CLI binary
 //!
 //! This is a simple CLI example showing how to use lino-arguments
-//! as a drop-in replacement for clap with .lenv/.env file support.
+//! as a true drop-in replacement for clap with .lenv/.env file support.
+//! Just change the import — everything else is identical to clap.
 
 use lino_arguments::{load_lenv_file, Parser};
 
 /// A unified configuration example.
 ///
 /// Uses standard clap `#[arg(env = "...")]` attributes.
-/// `lino_arguments::init()` loads .lenv and .env files into the process
-/// environment before clap parses, so `env` attributes automatically pick
-/// up values from .lenv/.env files.
+/// lino-arguments automatically loads .lenv and .env files into the process
+/// environment at startup, so `env` attributes pick up values from these files.
 #[derive(Parser, Debug)]
 #[command(name = "lino-arguments")]
 #[command(about = "A unified configuration library example")]
@@ -34,8 +34,7 @@ struct Args {
 }
 
 fn main() {
-    // init() loads .lenv + .env into process env, then parse() works as usual
-    lino_arguments::init();
+    // No init() needed — .lenv and .env are loaded automatically at startup
     let args = Args::parse();
 
     // Load additional config file if specified via --configuration

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,18 +1,24 @@
 //! lino-arguments CLI binary
 //!
-//! This is a simple CLI example showing how to use lino-arguments.
+//! This is a simple CLI example showing how to use lino-arguments
+//! as a drop-in replacement for clap with .lenv/.env file support.
 
-use lino_arguments::{getenv, getenv_bool, getenv_int, load_lenv_file, Parser};
+use lino_arguments::{load_lenv_file, LinoParser, Parser};
 
-/// A unified configuration example
+/// A unified configuration example.
+///
+/// Uses standard clap `#[arg(env = "...")]` attributes.
+/// `LinoParser::lino_parse()` loads .lenv and .env files into the process
+/// environment before clap parses, so `env` attributes automatically pick
+/// up values from .lenv/.env files.
 #[derive(Parser, Debug)]
 #[command(name = "lino-arguments")]
 #[command(about = "A unified configuration library example")]
 #[command(version)]
 struct Args {
     /// Server port
-    #[arg(short, long, env = "PORT")]
-    port: Option<u16>,
+    #[arg(short, long, env = "PORT", default_value = "3000")]
+    port: u16,
 
     /// API key
     #[arg(short = 'k', long, env = "API_KEY")]
@@ -27,57 +33,36 @@ struct Args {
     configuration: Option<String>,
 }
 
-/// Resolved configuration with defaults applied
-struct Config {
-    port: u16,
-    api_key: String,
-    verbose: bool,
-    configuration: Option<String>,
-}
+fn main() {
+    // lino_parse() = load .lenv + .env, then parse CLI args
+    let args = Args::lino_parse();
 
-impl Config {
-    fn from_args(args: Args) -> Self {
-        // Load configuration file if specified
-        // This sets environment variables from the .lenv file
-        // (only for values not already set in the environment)
-        if let Some(ref config_path) = args.configuration {
-            if let Err(e) = load_lenv_file(config_path) {
-                eprintln!(
-                    "Warning: Failed to load config file '{}': {}",
-                    config_path, e
-                );
-            }
-        }
-
-        Config {
-            port: args.port.unwrap_or_else(|| getenv_int("PORT", 3000) as u16),
-            api_key: args.api_key.unwrap_or_else(|| getenv("API_KEY", "")),
-            verbose: args.verbose || getenv_bool("VERBOSE", false),
-            configuration: args.configuration,
+    // Load additional config file if specified via --configuration
+    if let Some(ref config_path) = args.configuration {
+        if let Err(e) = load_lenv_file(config_path) {
+            eprintln!(
+                "Warning: Failed to load config file '{}': {}",
+                config_path, e
+            );
         }
     }
-}
 
-fn main() {
-    let args = Args::parse();
-    let config = Config::from_args(args);
-
-    if config.verbose {
+    if args.verbose {
         println!("Configuration loaded:");
-        println!("  Port: {}", config.port);
+        println!("  Port: {}", args.port);
         println!(
             "  API Key: {}",
-            if config.api_key.is_empty() {
-                "(not set)"
+            if let Some(ref key) = args.api_key {
+                key.as_str()
             } else {
-                &config.api_key
+                "(not set)"
             }
         );
-        println!("  Verbose: {}", config.verbose);
-        if let Some(cfg) = &config.configuration {
+        println!("  Verbose: {}", args.verbose);
+        if let Some(ref cfg) = args.configuration {
             println!("  Config file: {}", cfg);
         }
     }
 
-    println!("Server would start on port {}", config.port);
+    println!("Server would start on port {}", args.port);
 }

--- a/rust/tests/integration_test.rs
+++ b/rust/tests/integration_test.rs
@@ -1,9 +1,9 @@
 //! Integration tests for lino-arguments
 
 use lino_arguments::{
-    getenv, getenv_bool, getenv_int, load_lenv_file, load_lenv_file_override, read_lino_env,
-    to_camel_case, to_kebab_case, to_pascal_case, to_snake_case, to_upper_case, write_lino_env,
-    LinoEnv,
+    getenv, getenv_bool, getenv_int, load_lenv_file, load_lenv_file_override, make_config_from,
+    read_lino_env, to_camel_case, to_kebab_case, to_pascal_case, to_snake_case, to_upper_case,
+    write_lino_env, LinoEnv, Parser,
 };
 use std::collections::HashMap;
 use std::env;
@@ -309,5 +309,213 @@ mod getenv_with_lenv {
 
         // Cleanup
         env::remove_var("LINO_TEST_INTEGRATION_VAR");
+    }
+}
+
+// ============================================================================
+// Clap Re-export Tests
+// ============================================================================
+
+mod clap_reexport {
+    use super::*;
+
+    /// Verify that the Parser derive macro works through lino-arguments re-export
+    #[derive(Parser, Debug)]
+    #[command(name = "test-app")]
+    struct TestArgs {
+        #[arg(short, long, default_value = "3000")]
+        port: String,
+
+        #[arg(short, long)]
+        verbose: bool,
+    }
+
+    #[test]
+    fn test_parser_derive_works() {
+        // Parse with explicit args (simulating CLI)
+        let args = TestArgs::parse_from(["test-app", "--port", "8080", "--verbose"]);
+        assert_eq!(args.port, "8080");
+        assert!(args.verbose);
+    }
+
+    #[test]
+    fn test_parser_defaults_work() {
+        let args = TestArgs::parse_from(["test-app"]);
+        assert_eq!(args.port, "3000");
+        assert!(!args.verbose);
+    }
+}
+
+// ============================================================================
+// Functional make_config API Tests
+// ============================================================================
+
+mod make_config_tests {
+    use super::*;
+
+    #[test]
+    fn test_make_config_basic_options() {
+        let config = make_config_from(["app", "--port", "9090"], |c| {
+            c.option("port", "Server port", "3000")
+        });
+
+        assert_eq!(config.get("port"), "9090");
+    }
+
+    #[test]
+    fn test_make_config_default_values() {
+        let config = make_config_from(["app"], |c| {
+            c.option("port", "Server port", "3000")
+                .option("host", "Server host", "localhost")
+        });
+
+        assert_eq!(config.get("port"), "3000");
+        assert_eq!(config.get("host"), "localhost");
+    }
+
+    #[test]
+    fn test_make_config_flags() {
+        let config = make_config_from(["app", "--verbose"], |c| {
+            c.flag("verbose", "Enable verbose logging")
+        });
+
+        assert!(config.get_bool("verbose"));
+    }
+
+    #[test]
+    fn test_make_config_flag_default_false() {
+        let config = make_config_from(["app"], |c| {
+            c.flag("verbose", "Enable verbose logging")
+        });
+
+        assert!(!config.get_bool("verbose"));
+    }
+
+    #[test]
+    fn test_make_config_short_options() {
+        let config = make_config_from(["app", "-p", "4000"], |c| {
+            c.option_short("port", 'p', "Server port", "3000")
+        });
+
+        assert_eq!(config.get("port"), "4000");
+    }
+
+    #[test]
+    fn test_make_config_short_flags() {
+        let config = make_config_from(["app", "-v"], |c| {
+            c.flag_short("verbose", 'v', "Enable verbose logging")
+        });
+
+        assert!(config.get_bool("verbose"));
+    }
+
+    #[test]
+    fn test_make_config_get_int() {
+        let config = make_config_from(["app", "--port", "8080"], |c| {
+            c.option("port", "Server port", "3000")
+        });
+
+        assert_eq!(config.get_int("port", 3000), 8080);
+    }
+
+    #[test]
+    fn test_make_config_get_int_default() {
+        let config = make_config_from(["app"], |c| {
+            c.option("retries", "Retry count", "")
+        });
+
+        assert_eq!(config.get_int("retries", 5), 5);
+    }
+
+    #[test]
+    fn test_make_config_has() {
+        let config = make_config_from(["app", "--port", "8080"], |c| {
+            c.option("port", "Server port", "3000")
+        });
+
+        assert!(config.has("port"));
+        assert!(!config.has("nonexistent"));
+    }
+
+    #[test]
+    fn test_make_config_kebab_case_to_camel() {
+        let config = make_config_from(["app", "--api-key", "secret123"], |c| {
+            c.option("api-key", "API key", "")
+        });
+
+        // Access via kebab-case should work (converted to camelCase internally)
+        assert_eq!(config.get("api-key"), "secret123");
+        assert_eq!(config.get("apiKey"), "secret123");
+    }
+
+    #[test]
+    fn test_make_config_with_lenv_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_make_config.lenv");
+        let file_path_str = file_path.to_str().unwrap();
+
+        fs::write(&file_path, "PORT: 7070\n").unwrap();
+
+        // Ensure env var doesn't exist
+        env::remove_var("PORT");
+
+        let config = make_config_from(["app"], |c| {
+            c.lenv(file_path_str)
+                .option("port", "Server port", "3000")
+        });
+
+        assert_eq!(config.get("port"), "7070");
+
+        env::remove_var("PORT");
+    }
+
+    #[test]
+    fn test_make_config_cli_overrides_lenv() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_override.lenv");
+        let file_path_str = file_path.to_str().unwrap();
+
+        fs::write(&file_path, "PORT: 7070\n").unwrap();
+
+        // Ensure env var doesn't exist
+        env::remove_var("PORT");
+
+        let config = make_config_from(["app", "--port", "9999"], |c| {
+            c.lenv(file_path_str)
+                .option("port", "Server port", "3000")
+        });
+
+        // CLI should override .lenv value
+        assert_eq!(config.get("port"), "9999");
+
+        env::remove_var("PORT");
+    }
+
+    #[test]
+    fn test_make_config_multiple_options_and_flags() {
+        let config = make_config_from(
+            ["app", "--port", "8080", "--api-key", "secret", "--verbose"],
+            |c| {
+                c.option("port", "Server port", "3000")
+                    .option("api-key", "API key", "")
+                    .flag("verbose", "Enable verbose logging")
+            },
+        );
+
+        assert_eq!(config.get("port"), "8080");
+        assert_eq!(config.get("apiKey"), "secret");
+        assert!(config.get_bool("verbose"));
+    }
+
+    #[test]
+    fn test_make_config_app_metadata() {
+        let config = make_config_from(["my-app", "--port", "8080"], |c| {
+            c.name("my-app")
+                .about("A test application")
+                .version("1.0.0")
+                .option("port", "Server port", "3000")
+        });
+
+        assert_eq!(config.get("port"), "8080");
     }
 }

--- a/rust/tests/integration_test.rs
+++ b/rust/tests/integration_test.rs
@@ -459,148 +459,169 @@ mod clap_reexport {
 mod lino_parser_tests {
     use super::*;
 
-    #[derive(Parser, Debug)]
-    #[command(name = "test-lino-parser")]
-    struct TestArgs {
-        #[arg(long, env = "LINO_TEST_LP_PORT", default_value = "3000")]
-        port: u16,
-
-        #[arg(long, env = "LINO_TEST_LP_HOST", default_value = "localhost")]
-        host: String,
-
-        #[arg(long, env = "LINO_TEST_LP_VERBOSE")]
-        verbose: bool,
-    }
+    // Each test uses a unique struct with unique env var names to avoid
+    // interference when tests run in parallel (sharing process env).
 
     #[test]
     fn test_lino_parse_from_with_lenv_file() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_LENV_PORT_T1", default_value = "3000")]
+            port: u16,
+            #[arg(long, env = "LP_LENV_HOST_T1", default_value = "localhost")]
+            host: String,
+            #[arg(long, env = "LP_LENV_VERBOSE_T1")]
+            verbose: bool,
+        }
+
         let dir = tempdir().unwrap();
         let lenv_path = dir.path().join("test.lenv");
         let lenv_path_str = lenv_path.to_str().unwrap();
 
-        // Write .lenv file with PORT value
-        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
+        fs::write(&lenv_path, "LP_LENV_PORT_T1: 8080\n").unwrap();
+        env::remove_var("LP_LENV_PORT_T1");
 
-        // Ensure env var doesn't exist
-        env::remove_var("LINO_TEST_LP_PORT");
+        let args = Args::lino_parse_from_with(["test"], Some(lenv_path_str), None);
 
-        // Use lino_parse_from_with to load the .lenv file and parse
-        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], Some(lenv_path_str), None);
-
-        // .lenv value should be picked up via env
         assert_eq!(args.port, 8080);
-        assert_eq!(args.host, "localhost"); // default
-        assert!(!args.verbose); // default
+        assert_eq!(args.host, "localhost");
+        assert!(!args.verbose);
 
-        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LP_LENV_PORT_T1");
     }
 
     #[test]
     fn test_lino_parse_from_with_env_file() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_ENV_HOST_T2", default_value = "localhost")]
+            host: String,
+            #[arg(long, env = "LP_ENV_PORT_T2", default_value = "3000")]
+            port: u16,
+        }
+
         let dir = tempdir().unwrap();
         let env_path = dir.path().join(".env");
         let env_path_str = env_path.to_str().unwrap();
 
-        // Write .env file with HOST value
-        fs::write(&env_path, "LINO_TEST_LP_HOST=example.com\n").unwrap();
+        fs::write(&env_path, "LP_ENV_HOST_T2=example.com\n").unwrap();
+        env::remove_var("LP_ENV_HOST_T2");
+        env::remove_var("LP_ENV_PORT_T2");
 
-        env::remove_var("LINO_TEST_LP_HOST");
-
-        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], None, Some(env_path_str));
+        let args = Args::lino_parse_from_with(["test"], None, Some(env_path_str));
 
         assert_eq!(args.host, "example.com");
-        assert_eq!(args.port, 3000); // default
+        assert_eq!(args.port, 3000);
 
-        env::remove_var("LINO_TEST_LP_HOST");
+        env::remove_var("LP_ENV_HOST_T2");
     }
 
     #[test]
     fn test_lino_parse_cli_overrides_lenv() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_CLI_PORT_T3", default_value = "3000")]
+            port: u16,
+        }
+
         let dir = tempdir().unwrap();
         let lenv_path = dir.path().join("test.lenv");
         let lenv_path_str = lenv_path.to_str().unwrap();
 
-        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
-        env::remove_var("LINO_TEST_LP_PORT");
+        fs::write(&lenv_path, "LP_CLI_PORT_T3: 8080\n").unwrap();
+        env::remove_var("LP_CLI_PORT_T3");
 
-        // CLI --port should override .lenv value
-        let args = TestArgs::lino_parse_from_with(
-            ["test-lino-parser", "--port", "9999"],
-            Some(lenv_path_str),
-            None,
-        );
+        let args =
+            Args::lino_parse_from_with(["test", "--port", "9999"], Some(lenv_path_str), None);
 
         assert_eq!(args.port, 9999);
 
-        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LP_CLI_PORT_T3");
     }
 
     #[test]
     fn test_lino_parse_env_var_overrides_lenv() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_ENVOV_PORT_T4", default_value = "3000")]
+            port: u16,
+        }
+
         let dir = tempdir().unwrap();
         let lenv_path = dir.path().join("test.lenv");
         let lenv_path_str = lenv_path.to_str().unwrap();
 
-        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
+        fs::write(&lenv_path, "LP_ENVOV_PORT_T4: 8080\n").unwrap();
 
         // Set env var BEFORE loading .lenv — env var should take priority
-        env::set_var("LINO_TEST_LP_PORT", "7070");
+        env::set_var("LP_ENVOV_PORT_T4", "7070");
 
-        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], Some(lenv_path_str), None);
+        let args = Args::lino_parse_from_with(["test"], Some(lenv_path_str), None);
 
-        // env var (7070) should win over .lenv (8080) because load_lenv_file
-        // does NOT overwrite existing env vars
         assert_eq!(args.port, 7070);
 
-        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LP_ENVOV_PORT_T4");
     }
 
     #[test]
     fn test_lino_parse_lenv_overrides_env_file() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_LENVOV_PORT_T5", default_value = "3000")]
+            port: u16,
+        }
+
         let dir = tempdir().unwrap();
         let lenv_path = dir.path().join("test.lenv");
         let lenv_path_str = lenv_path.to_str().unwrap();
         let env_path = dir.path().join(".env");
         let env_path_str = env_path.to_str().unwrap();
 
-        // .lenv has port 8080, .env has port 5050
-        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
-        fs::write(&env_path, "LINO_TEST_LP_PORT=5050\n").unwrap();
+        fs::write(&lenv_path, "LP_LENVOV_PORT_T5: 8080\n").unwrap();
+        fs::write(&env_path, "LP_LENVOV_PORT_T5=5050\n").unwrap();
 
-        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LP_LENVOV_PORT_T5");
 
-        // .lenv is loaded first, so it sets the env var; .env won't overwrite
-        let args = TestArgs::lino_parse_from_with(
-            ["test-lino-parser"],
-            Some(lenv_path_str),
-            Some(env_path_str),
-        );
+        let args = Args::lino_parse_from_with(["test"], Some(lenv_path_str), Some(env_path_str));
 
         assert_eq!(args.port, 8080); // .lenv wins over .env
 
-        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LP_LENVOV_PORT_T5");
     }
 
     #[test]
     fn test_lino_parse_full_priority_chain() {
-        // Test the full priority: CLI > env var > .lenv > .env > default
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_FPC_PORT_T6", default_value = "3000")]
+            port: u16,
+            #[arg(long, env = "LP_FPC_HOST_T6", default_value = "localhost")]
+            host: String,
+            #[arg(long, env = "LP_FPC_VERBOSE_T6")]
+            verbose: bool,
+        }
+
         let dir = tempdir().unwrap();
         let lenv_path = dir.path().join("test.lenv");
         let lenv_path_str = lenv_path.to_str().unwrap();
         let env_path = dir.path().join(".env");
         let env_path_str = env_path.to_str().unwrap();
 
-        // Setup: .lenv has host, .env has verbose flag value
-        fs::write(&lenv_path, "LINO_TEST_LP_HOST: from-lenv\n").unwrap();
-        fs::write(&env_path, "LINO_TEST_LP_VERBOSE=true\n").unwrap();
+        fs::write(&lenv_path, "LP_FPC_HOST_T6: from-lenv\n").unwrap();
+        fs::write(&env_path, "LP_FPC_VERBOSE_T6=true\n").unwrap();
 
-        env::remove_var("LINO_TEST_LP_PORT");
-        env::remove_var("LINO_TEST_LP_HOST");
-        env::remove_var("LINO_TEST_LP_VERBOSE");
+        env::remove_var("LP_FPC_PORT_T6");
+        env::remove_var("LP_FPC_HOST_T6");
+        env::remove_var("LP_FPC_VERBOSE_T6");
 
-        // CLI overrides port, .lenv provides host, .env provides verbose
-        let args = TestArgs::lino_parse_from_with(
-            ["test-lino-parser", "--port", "4000"],
+        let args = Args::lino_parse_from_with(
+            ["test", "--port", "4000"],
             Some(lenv_path_str),
             Some(env_path_str),
         );
@@ -609,17 +630,28 @@ mod lino_parser_tests {
         assert_eq!(args.host, "from-lenv"); // from .lenv
         assert!(args.verbose); // from .env
 
-        env::remove_var("LINO_TEST_LP_HOST");
-        env::remove_var("LINO_TEST_LP_VERBOSE");
+        env::remove_var("LP_FPC_HOST_T6");
+        env::remove_var("LP_FPC_VERBOSE_T6");
     }
 
     #[test]
     fn test_lino_parse_defaults_when_no_files() {
-        env::remove_var("LINO_TEST_LP_PORT");
-        env::remove_var("LINO_TEST_LP_HOST");
-        env::remove_var("LINO_TEST_LP_VERBOSE");
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "LP_DEF_PORT_T7", default_value = "3000")]
+            port: u16,
+            #[arg(long, env = "LP_DEF_HOST_T7", default_value = "localhost")]
+            host: String,
+            #[arg(long, env = "LP_DEF_VERBOSE_T7")]
+            verbose: bool,
+        }
 
-        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], None, None);
+        env::remove_var("LP_DEF_PORT_T7");
+        env::remove_var("LP_DEF_HOST_T7");
+        env::remove_var("LP_DEF_VERBOSE_T7");
+
+        let args = Args::lino_parse_from_with(["test"], None, None);
 
         assert_eq!(args.port, 3000);
         assert_eq!(args.host, "localhost");
@@ -731,18 +763,18 @@ mod make_config_tests {
         let file_path = dir.path().join("test_make_config.lenv");
         let file_path_str = file_path.to_str().unwrap();
 
-        fs::write(&file_path, "PORT: 7070\n").unwrap();
+        fs::write(&file_path, "MC_LENV_PORT: 7070\n").unwrap();
 
-        // Ensure env var doesn't exist
-        env::remove_var("PORT");
+        env::remove_var("MC_LENV_PORT");
 
         let config = make_config_from(["app"], |c| {
-            c.lenv(file_path_str).option("port", "Server port", "3000")
+            c.lenv(file_path_str)
+                .option("mc-lenv-port", "Server port", "3000")
         });
 
-        assert_eq!(config.get("port"), "7070");
+        assert_eq!(config.get("mcLenvPort"), "7070");
 
-        env::remove_var("PORT");
+        env::remove_var("MC_LENV_PORT");
     }
 
     #[test]
@@ -751,17 +783,18 @@ mod make_config_tests {
         let file_path = dir.path().join(".env");
         let file_path_str = file_path.to_str().unwrap();
 
-        fs::write(&file_path, "PORT=6060\n").unwrap();
+        fs::write(&file_path, "MC_ENV_PORT=6060\n").unwrap();
 
-        env::remove_var("PORT");
+        env::remove_var("MC_ENV_PORT");
 
         let config = make_config_from(["app"], |c| {
-            c.env(file_path_str).option("port", "Server port", "3000")
+            c.env(file_path_str)
+                .option("mc-env-port", "Server port", "3000")
         });
 
-        assert_eq!(config.get("port"), "6060");
+        assert_eq!(config.get("mcEnvPort"), "6060");
 
-        env::remove_var("PORT");
+        env::remove_var("MC_ENV_PORT");
     }
 
     #[test]
@@ -772,21 +805,21 @@ mod make_config_tests {
         let env_path = dir.path().join(".env");
         let env_path_str = env_path.to_str().unwrap();
 
-        fs::write(&lenv_path, "MAKE_CFG_PORT: 8080\n").unwrap();
-        fs::write(&env_path, "MAKE_CFG_PORT=5050\n").unwrap();
+        fs::write(&lenv_path, "MC_LENVOV_PORT: 8080\n").unwrap();
+        fs::write(&env_path, "MC_LENVOV_PORT=5050\n").unwrap();
 
-        env::remove_var("MAKE_CFG_PORT");
+        env::remove_var("MC_LENVOV_PORT");
 
         let config = make_config_from(["app"], |c| {
             c.lenv(lenv_path_str)
                 .env(env_path_str)
-                .option("make-cfg-port", "Port", "3000")
+                .option("mc-lenvov-port", "Port", "3000")
         });
 
         // .lenv should win over .env
-        assert_eq!(config.get("makeCfgPort"), "8080");
+        assert_eq!(config.get("mcLenvovPort"), "8080");
 
-        env::remove_var("MAKE_CFG_PORT");
+        env::remove_var("MC_LENVOV_PORT");
     }
 
     #[test]
@@ -795,19 +828,19 @@ mod make_config_tests {
         let file_path = dir.path().join("test_override.lenv");
         let file_path_str = file_path.to_str().unwrap();
 
-        fs::write(&file_path, "PORT: 7070\n").unwrap();
+        fs::write(&file_path, "MC_CLIOV_PORT: 7070\n").unwrap();
 
-        // Ensure env var doesn't exist
-        env::remove_var("PORT");
+        env::remove_var("MC_CLIOV_PORT");
 
-        let config = make_config_from(["app", "--port", "9999"], |c| {
-            c.lenv(file_path_str).option("port", "Server port", "3000")
+        let config = make_config_from(["app", "--mc-cliov-port", "9999"], |c| {
+            c.lenv(file_path_str)
+                .option("mc-cliov-port", "Server port", "3000")
         });
 
         // CLI should override .lenv value
-        assert_eq!(config.get("port"), "9999");
+        assert_eq!(config.get("mcCliovPort"), "9999");
 
-        env::remove_var("PORT");
+        env::remove_var("MC_CLIOV_PORT");
     }
 
     #[test]

--- a/rust/tests/integration_test.rs
+++ b/rust/tests/integration_test.rs
@@ -384,9 +384,7 @@ mod make_config_tests {
 
     #[test]
     fn test_make_config_flag_default_false() {
-        let config = make_config_from(["app"], |c| {
-            c.flag("verbose", "Enable verbose logging")
-        });
+        let config = make_config_from(["app"], |c| c.flag("verbose", "Enable verbose logging"));
 
         assert!(!config.get_bool("verbose"));
     }
@@ -420,9 +418,7 @@ mod make_config_tests {
 
     #[test]
     fn test_make_config_get_int_default() {
-        let config = make_config_from(["app"], |c| {
-            c.option("retries", "Retry count", "")
-        });
+        let config = make_config_from(["app"], |c| c.option("retries", "Retry count", ""));
 
         assert_eq!(config.get_int("retries", 5), 5);
     }
@@ -460,8 +456,7 @@ mod make_config_tests {
         env::remove_var("PORT");
 
         let config = make_config_from(["app"], |c| {
-            c.lenv(file_path_str)
-                .option("port", "Server port", "3000")
+            c.lenv(file_path_str).option("port", "Server port", "3000")
         });
 
         assert_eq!(config.get("port"), "7070");
@@ -481,8 +476,7 @@ mod make_config_tests {
         env::remove_var("PORT");
 
         let config = make_config_from(["app", "--port", "9999"], |c| {
-            c.lenv(file_path_str)
-                .option("port", "Server port", "3000")
+            c.lenv(file_path_str).option("port", "Server port", "3000")
         });
 
         // CLI should override .lenv value

--- a/rust/tests/integration_test.rs
+++ b/rust/tests/integration_test.rs
@@ -1,9 +1,9 @@
 //! Integration tests for lino-arguments
 
 use lino_arguments::{
-    getenv, getenv_bool, getenv_int, load_lenv_file, load_lenv_file_override, make_config_from,
-    read_lino_env, to_camel_case, to_kebab_case, to_pascal_case, to_snake_case, to_upper_case,
-    write_lino_env, LinoEnv, Parser,
+    getenv, getenv_bool, getenv_int, load_env_file, load_env_file_override, load_lenv_file,
+    load_lenv_file_override, make_config_from, read_lino_env, to_camel_case, to_kebab_case,
+    to_pascal_case, to_snake_case, to_upper_case, write_lino_env, LinoEnv, LinoParser, Parser,
 };
 use std::collections::HashMap;
 use std::env;
@@ -282,6 +282,112 @@ mod lenv_file_tests {
 }
 
 // ============================================================================
+// .env File Loading Tests
+// ============================================================================
+
+mod env_file_tests {
+    use super::*;
+
+    #[test]
+    fn test_load_env_file_sets_env_vars() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join(".env");
+        let file_path_str = file_path.to_str().unwrap();
+
+        // Write a standard .env file
+        fs::write(
+            &file_path,
+            "LINO_TEST_ENV_PORT=9090\nLINO_TEST_ENV_HOST=localhost\n",
+        )
+        .unwrap();
+
+        // Ensure env vars don't exist before loading
+        env::remove_var("LINO_TEST_ENV_PORT");
+        env::remove_var("LINO_TEST_ENV_HOST");
+
+        // Load the file
+        let loaded = load_env_file(file_path_str).unwrap();
+        assert_eq!(loaded, 2);
+
+        // Check env vars are set
+        assert_eq!(env::var("LINO_TEST_ENV_PORT").unwrap(), "9090");
+        assert_eq!(env::var("LINO_TEST_ENV_HOST").unwrap(), "localhost");
+
+        // Cleanup
+        env::remove_var("LINO_TEST_ENV_PORT");
+        env::remove_var("LINO_TEST_ENV_HOST");
+    }
+
+    #[test]
+    fn test_load_env_file_does_not_overwrite_existing() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join(".env");
+        let file_path_str = file_path.to_str().unwrap();
+
+        fs::write(&file_path, "LINO_TEST_ENV_EXISTING=from_file\n").unwrap();
+
+        // Set the env var before loading
+        env::set_var("LINO_TEST_ENV_EXISTING", "from_env");
+
+        let loaded = load_env_file(file_path_str).unwrap();
+        assert_eq!(loaded, 0);
+
+        assert_eq!(env::var("LINO_TEST_ENV_EXISTING").unwrap(), "from_env");
+
+        env::remove_var("LINO_TEST_ENV_EXISTING");
+    }
+
+    #[test]
+    fn test_load_env_file_override_overwrites() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join(".env");
+        let file_path_str = file_path.to_str().unwrap();
+
+        fs::write(&file_path, "LINO_TEST_ENV_OVERRIDE=from_file\n").unwrap();
+
+        env::set_var("LINO_TEST_ENV_OVERRIDE", "from_env");
+
+        let loaded = load_env_file_override(file_path_str).unwrap();
+        assert_eq!(loaded, 1);
+
+        assert_eq!(env::var("LINO_TEST_ENV_OVERRIDE").unwrap(), "from_file");
+
+        env::remove_var("LINO_TEST_ENV_OVERRIDE");
+    }
+
+    #[test]
+    fn test_load_env_file_nonexistent_returns_ok() {
+        let result = load_env_file("/nonexistent/path/to/file.env");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_load_env_file_quoted_values() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join(".env");
+        let file_path_str = file_path.to_str().unwrap();
+
+        fs::write(
+            &file_path,
+            "LINO_TEST_ENV_QUOTED=\"hello world\"\nLINO_TEST_ENV_SINGLE='single quotes'\n",
+        )
+        .unwrap();
+
+        env::remove_var("LINO_TEST_ENV_QUOTED");
+        env::remove_var("LINO_TEST_ENV_SINGLE");
+
+        load_env_file(file_path_str).unwrap();
+
+        assert_eq!(env::var("LINO_TEST_ENV_QUOTED").unwrap(), "hello world");
+        assert_eq!(env::var("LINO_TEST_ENV_SINGLE").unwrap(), "single quotes");
+
+        env::remove_var("LINO_TEST_ENV_QUOTED");
+        env::remove_var("LINO_TEST_ENV_SINGLE");
+    }
+}
+
+// ============================================================================
 // Integration Tests - getenv with lenv file
 // ============================================================================
 
@@ -342,6 +448,181 @@ mod clap_reexport {
     fn test_parser_defaults_work() {
         let args = TestArgs::parse_from(["test-app"]);
         assert_eq!(args.port, "3000");
+        assert!(!args.verbose);
+    }
+}
+
+// ============================================================================
+// LinoParser Trait Tests
+// ============================================================================
+
+mod lino_parser_tests {
+    use super::*;
+
+    #[derive(Parser, Debug)]
+    #[command(name = "test-lino-parser")]
+    struct TestArgs {
+        #[arg(long, env = "LINO_TEST_LP_PORT", default_value = "3000")]
+        port: u16,
+
+        #[arg(long, env = "LINO_TEST_LP_HOST", default_value = "localhost")]
+        host: String,
+
+        #[arg(long, env = "LINO_TEST_LP_VERBOSE")]
+        verbose: bool,
+    }
+
+    #[test]
+    fn test_lino_parse_from_with_lenv_file() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        // Write .lenv file with PORT value
+        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
+
+        // Ensure env var doesn't exist
+        env::remove_var("LINO_TEST_LP_PORT");
+
+        // Use lino_parse_from_with to load the .lenv file and parse
+        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], Some(lenv_path_str), None);
+
+        // .lenv value should be picked up via env
+        assert_eq!(args.port, 8080);
+        assert_eq!(args.host, "localhost"); // default
+        assert!(!args.verbose); // default
+
+        env::remove_var("LINO_TEST_LP_PORT");
+    }
+
+    #[test]
+    fn test_lino_parse_from_with_env_file() {
+        let dir = tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        // Write .env file with HOST value
+        fs::write(&env_path, "LINO_TEST_LP_HOST=example.com\n").unwrap();
+
+        env::remove_var("LINO_TEST_LP_HOST");
+
+        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], None, Some(env_path_str));
+
+        assert_eq!(args.host, "example.com");
+        assert_eq!(args.port, 3000); // default
+
+        env::remove_var("LINO_TEST_LP_HOST");
+    }
+
+    #[test]
+    fn test_lino_parse_cli_overrides_lenv() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
+        env::remove_var("LINO_TEST_LP_PORT");
+
+        // CLI --port should override .lenv value
+        let args = TestArgs::lino_parse_from_with(
+            ["test-lino-parser", "--port", "9999"],
+            Some(lenv_path_str),
+            None,
+        );
+
+        assert_eq!(args.port, 9999);
+
+        env::remove_var("LINO_TEST_LP_PORT");
+    }
+
+    #[test]
+    fn test_lino_parse_env_var_overrides_lenv() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
+
+        // Set env var BEFORE loading .lenv — env var should take priority
+        env::set_var("LINO_TEST_LP_PORT", "7070");
+
+        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], Some(lenv_path_str), None);
+
+        // env var (7070) should win over .lenv (8080) because load_lenv_file
+        // does NOT overwrite existing env vars
+        assert_eq!(args.port, 7070);
+
+        env::remove_var("LINO_TEST_LP_PORT");
+    }
+
+    #[test]
+    fn test_lino_parse_lenv_overrides_env_file() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        // .lenv has port 8080, .env has port 5050
+        fs::write(&lenv_path, "LINO_TEST_LP_PORT: 8080\n").unwrap();
+        fs::write(&env_path, "LINO_TEST_LP_PORT=5050\n").unwrap();
+
+        env::remove_var("LINO_TEST_LP_PORT");
+
+        // .lenv is loaded first, so it sets the env var; .env won't overwrite
+        let args = TestArgs::lino_parse_from_with(
+            ["test-lino-parser"],
+            Some(lenv_path_str),
+            Some(env_path_str),
+        );
+
+        assert_eq!(args.port, 8080); // .lenv wins over .env
+
+        env::remove_var("LINO_TEST_LP_PORT");
+    }
+
+    #[test]
+    fn test_lino_parse_full_priority_chain() {
+        // Test the full priority: CLI > env var > .lenv > .env > default
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        // Setup: .lenv has host, .env has verbose flag value
+        fs::write(&lenv_path, "LINO_TEST_LP_HOST: from-lenv\n").unwrap();
+        fs::write(&env_path, "LINO_TEST_LP_VERBOSE=true\n").unwrap();
+
+        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LINO_TEST_LP_HOST");
+        env::remove_var("LINO_TEST_LP_VERBOSE");
+
+        // CLI overrides port, .lenv provides host, .env provides verbose
+        let args = TestArgs::lino_parse_from_with(
+            ["test-lino-parser", "--port", "4000"],
+            Some(lenv_path_str),
+            Some(env_path_str),
+        );
+
+        assert_eq!(args.port, 4000); // from CLI
+        assert_eq!(args.host, "from-lenv"); // from .lenv
+        assert!(args.verbose); // from .env
+
+        env::remove_var("LINO_TEST_LP_HOST");
+        env::remove_var("LINO_TEST_LP_VERBOSE");
+    }
+
+    #[test]
+    fn test_lino_parse_defaults_when_no_files() {
+        env::remove_var("LINO_TEST_LP_PORT");
+        env::remove_var("LINO_TEST_LP_HOST");
+        env::remove_var("LINO_TEST_LP_VERBOSE");
+
+        let args = TestArgs::lino_parse_from_with(["test-lino-parser"], None, None);
+
+        assert_eq!(args.port, 3000);
+        assert_eq!(args.host, "localhost");
         assert!(!args.verbose);
     }
 }
@@ -462,6 +743,50 @@ mod make_config_tests {
         assert_eq!(config.get("port"), "7070");
 
         env::remove_var("PORT");
+    }
+
+    #[test]
+    fn test_make_config_with_env_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join(".env");
+        let file_path_str = file_path.to_str().unwrap();
+
+        fs::write(&file_path, "PORT=6060\n").unwrap();
+
+        env::remove_var("PORT");
+
+        let config = make_config_from(["app"], |c| {
+            c.env(file_path_str).option("port", "Server port", "3000")
+        });
+
+        assert_eq!(config.get("port"), "6060");
+
+        env::remove_var("PORT");
+    }
+
+    #[test]
+    fn test_make_config_lenv_overrides_env_file() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "MAKE_CFG_PORT: 8080\n").unwrap();
+        fs::write(&env_path, "MAKE_CFG_PORT=5050\n").unwrap();
+
+        env::remove_var("MAKE_CFG_PORT");
+
+        let config = make_config_from(["app"], |c| {
+            c.lenv(lenv_path_str)
+                .env(env_path_str)
+                .option("make-cfg-port", "Port", "3000")
+        });
+
+        // .lenv should win over .env
+        assert_eq!(config.get("makeCfgPort"), "8080");
+
+        env::remove_var("MAKE_CFG_PORT");
     }
 
     #[test]

--- a/rust/tests/integration_test.rs
+++ b/rust/tests/integration_test.rs
@@ -1,9 +1,10 @@
 //! Integration tests for lino-arguments
 
 use lino_arguments::{
-    getenv, getenv_bool, getenv_int, load_env_file, load_env_file_override, load_lenv_file,
-    load_lenv_file_override, make_config_from, read_lino_env, to_camel_case, to_kebab_case,
-    to_pascal_case, to_snake_case, to_upper_case, write_lino_env, LinoEnv, LinoParser, Parser,
+    getenv, getenv_bool, getenv_int, init_with, load_env_file, load_env_file_override,
+    load_lenv_file, load_lenv_file_override, make_config_from, read_lino_env, to_camel_case,
+    to_kebab_case, to_pascal_case, to_snake_case, to_upper_case, write_lino_env, LinoEnv,
+    LinoParser, Parser,
 };
 use std::collections::HashMap;
 use std::env;
@@ -869,5 +870,248 @@ mod make_config_tests {
         });
 
         assert_eq!(config.get("port"), "8080");
+    }
+}
+
+// ============================================================================
+// init() and init_with() Tests
+// ============================================================================
+
+mod init_tests {
+    use super::*;
+
+    #[test]
+    fn test_init_with_loads_lenv_file() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "INIT_LENV_PORT_T1: 7777\n").unwrap();
+        env::remove_var("INIT_LENV_PORT_T1");
+
+        init_with(Some(lenv_path_str), None);
+
+        assert_eq!(env::var("INIT_LENV_PORT_T1").unwrap(), "7777");
+
+        env::remove_var("INIT_LENV_PORT_T1");
+    }
+
+    #[test]
+    fn test_init_with_loads_env_file() {
+        let dir = tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        fs::write(&env_path, "INIT_ENV_HOST_T2=example.com\n").unwrap();
+        env::remove_var("INIT_ENV_HOST_T2");
+
+        init_with(None, Some(env_path_str));
+
+        assert_eq!(env::var("INIT_ENV_HOST_T2").unwrap(), "example.com");
+
+        env::remove_var("INIT_ENV_HOST_T2");
+    }
+
+    #[test]
+    fn test_init_with_loads_both_files() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "INIT_BOTH_A_T3: from_lenv\n").unwrap();
+        fs::write(&env_path, "INIT_BOTH_B_T3=from_env\n").unwrap();
+
+        env::remove_var("INIT_BOTH_A_T3");
+        env::remove_var("INIT_BOTH_B_T3");
+
+        init_with(Some(lenv_path_str), Some(env_path_str));
+
+        assert_eq!(env::var("INIT_BOTH_A_T3").unwrap(), "from_lenv");
+        assert_eq!(env::var("INIT_BOTH_B_T3").unwrap(), "from_env");
+
+        env::remove_var("INIT_BOTH_A_T3");
+        env::remove_var("INIT_BOTH_B_T3");
+    }
+
+    #[test]
+    fn test_init_with_lenv_takes_priority_over_env() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        // Same key in both files — .lenv should win
+        fs::write(&lenv_path, "INIT_PRIO_T4: from_lenv\n").unwrap();
+        fs::write(&env_path, "INIT_PRIO_T4=from_env\n").unwrap();
+
+        env::remove_var("INIT_PRIO_T4");
+
+        init_with(Some(lenv_path_str), Some(env_path_str));
+
+        // .lenv is loaded first, so it sets the var; .env won't overwrite
+        assert_eq!(env::var("INIT_PRIO_T4").unwrap(), "from_lenv");
+
+        env::remove_var("INIT_PRIO_T4");
+    }
+
+    #[test]
+    fn test_init_with_existing_env_var_takes_priority() {
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "INIT_EXISTING_T5: from_lenv\n").unwrap();
+
+        // Set env var BEFORE init — it should take priority
+        env::set_var("INIT_EXISTING_T5", "from_process");
+
+        init_with(Some(lenv_path_str), None);
+
+        assert_eq!(env::var("INIT_EXISTING_T5").unwrap(), "from_process");
+
+        env::remove_var("INIT_EXISTING_T5");
+    }
+}
+
+// ============================================================================
+// Drop-in parse() Tests (init + standard clap parse)
+// ============================================================================
+
+mod dropin_parse_tests {
+    use super::*;
+
+    #[test]
+    fn test_dropin_parse_from_with_lenv() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "DI_LENV_PORT_T1", default_value = "3000")]
+            port: u16,
+        }
+
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "DI_LENV_PORT_T1: 8888\n").unwrap();
+        env::remove_var("DI_LENV_PORT_T1");
+
+        // Drop-in pattern: init_with + parse_from
+        init_with(Some(lenv_path_str), None);
+        let args = Args::parse_from(["test"]);
+
+        assert_eq!(args.port, 8888);
+
+        env::remove_var("DI_LENV_PORT_T1");
+    }
+
+    #[test]
+    fn test_dropin_parse_from_with_env_file() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "DI_ENV_HOST_T2", default_value = "localhost")]
+            host: String,
+        }
+
+        let dir = tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        fs::write(&env_path, "DI_ENV_HOST_T2=example.com\n").unwrap();
+        env::remove_var("DI_ENV_HOST_T2");
+
+        init_with(None, Some(env_path_str));
+        let args = Args::parse_from(["test"]);
+
+        assert_eq!(args.host, "example.com");
+
+        env::remove_var("DI_ENV_HOST_T2");
+    }
+
+    #[test]
+    fn test_dropin_cli_overrides_env_files() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "DI_CLI_PORT_T3", default_value = "3000")]
+            port: u16,
+        }
+
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "DI_CLI_PORT_T3: 8080\n").unwrap();
+        env::remove_var("DI_CLI_PORT_T3");
+
+        init_with(Some(lenv_path_str), None);
+        let args = Args::parse_from(["test", "--port", "9999"]);
+
+        assert_eq!(args.port, 9999); // CLI wins
+
+        env::remove_var("DI_CLI_PORT_T3");
+    }
+
+    #[test]
+    fn test_dropin_full_priority_chain() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "DI_FPC_PORT_T4", default_value = "3000")]
+            port: u16,
+            #[arg(long, env = "DI_FPC_HOST_T4", default_value = "localhost")]
+            host: String,
+            #[arg(long, env = "DI_FPC_VERBOSE_T4")]
+            verbose: bool,
+            #[arg(long, env = "DI_FPC_WORKERS_T4", default_value = "4")]
+            workers: u16,
+        }
+
+        let dir = tempdir().unwrap();
+        let lenv_path = dir.path().join("test.lenv");
+        let lenv_path_str = lenv_path.to_str().unwrap();
+        let env_path = dir.path().join(".env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        fs::write(&lenv_path, "DI_FPC_HOST_T4: from-lenv\n").unwrap();
+        fs::write(&env_path, "DI_FPC_VERBOSE_T4=true\n").unwrap();
+
+        env::remove_var("DI_FPC_PORT_T4");
+        env::remove_var("DI_FPC_HOST_T4");
+        env::remove_var("DI_FPC_VERBOSE_T4");
+        env::remove_var("DI_FPC_WORKERS_T4");
+
+        init_with(Some(lenv_path_str), Some(env_path_str));
+        let args = Args::parse_from(["test", "--port", "4000"]);
+
+        assert_eq!(args.port, 4000); // from CLI
+        assert_eq!(args.host, "from-lenv"); // from .lenv
+        assert!(args.verbose); // from .env
+        assert_eq!(args.workers, 4); // from default_value
+
+        env::remove_var("DI_FPC_HOST_T4");
+        env::remove_var("DI_FPC_VERBOSE_T4");
+    }
+
+    #[test]
+    fn test_dropin_defaults_when_no_files() {
+        #[derive(Parser, Debug)]
+        #[command(name = "test")]
+        struct Args {
+            #[arg(long, env = "DI_DEF_PORT_T5", default_value = "3000")]
+            port: u16,
+        }
+
+        env::remove_var("DI_DEF_PORT_T5");
+
+        // init_with with no files — should still work
+        init_with(None, None);
+        let args = Args::parse_from(["test"]);
+
+        assert_eq!(args.port, 3000);
     }
 }


### PR DESCRIPTION
## Summary

- **True drop-in clap replacement**: just change `use clap::Parser` to `use lino_arguments::Parser` — zero other code changes needed
- **Automatic .lenv/.env loading** at program startup via `ctor` — no `init()` call required
- **Full priority chain**: CLI args > env vars > `.lenv` file > `.env` file > `default_value`
- **`LinoParser` trait** kept for custom file paths (`lino_parse_from_with()`)
- **Functional `make_config` builder API** with `.lenv()`, `.env()`, `.option()`, `.flag()` methods
- **Re-export clap derive macros** (`Parser`, `Args`, `Subcommand`, `ValueEnum`)

Fixes #23

## Drop-in Usage

```rust
// Only change: import from lino_arguments instead of clap
use lino_arguments::Parser;

#[derive(Parser, Debug)]
#[command(name = "my-app")]
struct Args {
    #[arg(long, env = "PORT", default_value = "3000")]
    port: u16,

    #[arg(long, env = "API_KEY")]
    api_key: Option<String>,

    #[arg(long, env = "VERBOSE")]
    verbose: bool,
}

fn main() {
    let args = Args::parse(); // .lenv + .env already loaded automatically
    println!("port = {}", args.port);
}
```

With `.lenv` file: `PORT: 8080` or `.env` file: `PORT=8080`

## How it works

The `ctor` crate runs `init()` before `main()`, loading `.lenv` and `.env` files into the process environment. By the time `Args::parse()` runs, clap's `env = "PORT"` attribute sees the values from these files. No custom trait wrapping needed — it's clap's standard `Parser` trait.

## Custom file paths

For non-standard file paths, use `LinoParser`:

```rust
use lino_arguments::{Parser, LinoParser};

let args = Args::lino_parse_from_with(
    ["app"], Some("custom.lenv"), Some("custom.env")
);
```

## Test plan

- [x] All 66 integration tests pass
- [x] Drop-in pattern: `Args::parse()` with auto .lenv/.env loading (no `init()` needed)
- [x] `LinoParser` trait: custom file paths via `lino_parse_with()`, `lino_parse_from_with()`
- [x] Full priority chain: CLI > env var > .lenv > .env > default_value
- [x] .env file loading via dotenvy (with quoted values support)
- [x] .lenv file loading (existing functionality preserved)
- [x] Functional API with `.env()` support
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` with `-Dwarnings` passes
- [x] Both examples compile and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)