### PR TITLE
fix(ci): prevent duplicate version publishing with language-specific releases

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Version packages and commit to main
         if: steps.check_changesets.outputs.has_changesets == 'true'
         id: version
-        run: node ../scripts/version-and-commit.mjs --mode changeset
+        run: node ../scripts/version-and-commit.mjs --mode changeset --tag-prefix "js_" --release-label "JavaScript"
 
       - name: Publish to npm
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
@@ -300,13 +300,13 @@ jobs:
         if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node ../scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+        run: node ../scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --tag-prefix "js_" --release-label "JavaScript"
 
       - name: Format GitHub release notes
         if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node ../scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+        run: node ../scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}" --tag-prefix "js_"
 
   # Manual Instant Release
   instant-release:
@@ -336,7 +336,7 @@ jobs:
 
       - name: Version packages and commit to main
         id: version
-        run: node ../scripts/version-and-commit.mjs --mode instant --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+        run: node ../scripts/version-and-commit.mjs --mode instant --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}" --tag-prefix "js_" --release-label "JavaScript"
 
       - name: Publish to npm
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
@@ -347,13 +347,13 @@ jobs:
         if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node ../scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+        run: node ../scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --tag-prefix "js_" --release-label "JavaScript"
 
       - name: Format GitHub release notes
         if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node ../scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+        run: node ../scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}" --tag-prefix "js_"
 
   # Manual Changeset PR
   changeset-pr:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -295,6 +295,7 @@ jobs:
         env:
           HAS_FRAGMENTS: ${{ steps.bump_type.outputs.has_fragments }}
           RUST_ROOT: rust
+          TAG_PREFIX: rust_
         run: node scripts/check-release-needed.mjs
 
       - name: Collect changelog and bump version
@@ -305,7 +306,9 @@ jobs:
           RUST_ROOT: rust
         run: |
           node scripts/version-and-commit.mjs \
-            --bump-type "${{ steps.bump_type.outputs.bump_type }}"
+            --bump-type "${{ steps.bump_type.outputs.bump_type }}" \
+            --tag-prefix "rust_" \
+            --release-label "Rust"
 
       - name: Get current version
         id: current_version
@@ -333,14 +336,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .
-        run: node scripts/create-github-release.mjs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}"
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}" --tag-prefix "rust_" --release-label "Rust"
 
       - name: Format GitHub release notes
         if: steps.check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .
-        run: node scripts/format-rust-release.mjs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}"
+        run: node scripts/format-rust-release.mjs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}" --tag-prefix "rust_"
 
   # === MANUAL INSTANT RELEASE ===
   # Manual release via workflow_dispatch - only after CI passes
@@ -388,7 +391,7 @@ jobs:
           BUMP_TYPE: ${{ github.event.inputs.bump_type }}
           DESCRIPTION: ${{ github.event.inputs.description }}
           RUST_ROOT: rust
-        run: node scripts/version-and-commit.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+        run: node scripts/version-and-commit.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}" --tag-prefix "rust_" --release-label "Rust"
 
       - name: Build release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
@@ -408,14 +411,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .
-        run: node scripts/create-github-release.mjs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}" --tag-prefix "rust_" --release-label "Rust"
 
       - name: Format GitHub release notes
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .
-        run: node scripts/format-rust-release.mjs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
+        run: node scripts/format-rust-release.mjs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}" --tag-prefix "rust_"
 
   # === MANUAL CHANGELOG PR ===
   changelog-pr:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T20:13:30.905Z for PR creation at branch issue-27-88fb89a5de9c for issue https://github.com/link-foundation/lino-arguments/issues/27

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T20:13:30.905Z for PR creation at branch issue-27-88fb89a5de9c for issue https://github.com/link-foundation/lino-arguments/issues/27

--- a/docs/case-studies/issue-27/case-study.md
+++ b/docs/case-studies/issue-27/case-study.md
@@ -1,0 +1,94 @@
+# Case Study: Issue #27 — Fix CI/CD So We Never Publish the Same Version Twice
+
+## Summary
+
+The Rust CI/CD auto-release pipeline failed because it attempted to publish `lino-arguments@0.2.0` to crates.io when that version was already published. Multiple root causes were identified and fixed.
+
+## Timeline of Events
+
+| Time (UTC) | Event |
+|---|---|
+| 2026-04-04 | Rust v0.2.0 successfully published to crates.io and GitHub Release created |
+| 2026-04-10 14:44 | Push to main triggers Rust CI/CD (commit `6308d6e`) |
+| 2026-04-10 14:45 | Detect Changes: `rs-changed=false`, `workflow-changed=true`, `rust-workflow-changed=true` |
+| 2026-04-10 14:45 | Lint, Test, Build jobs pass successfully |
+| 2026-04-10 14:46:29 | Auto Release: `check-release-needed.mjs` determines `should_release=true` (found changelog fragments) |
+| 2026-04-10 14:46:39 | `publish-crate.mjs` attempts `cargo publish` for v0.2.0 |
+| 2026-04-10 14:46:39 | **FAILURE**: `error: crate lino-arguments@0.2.0 already exists on crates.io index` |
+| 2026-04-10 14:46:39 | Script reports "Failed to publish for unknown reason" — exit code 1 |
+
+## Root Causes
+
+### Root Cause 1: `publish-crate.mjs` couldn't detect "already exists" errors
+
+**Problem**: The `exec()` function used `stdio: 'inherit'`, which sends stderr directly to the terminal. When `cargo publish` fails, the error details are in stderr — but with `inherit` mode, `error.message` in the catch block only contains the generic `Command failed:` prefix, not the actual error text.
+
+**Evidence** (from CI log line 3402-3403):
+```
+error: crate lino-arguments@0.2.0 already exists on crates.io index
+Failed to publish for unknown reason
+```
+
+The script had detection code for `'already exists'` in the catch block, but it could never match because the actual error text was piped to the terminal, not captured.
+
+**Fix**: 
+1. Changed `stdio: 'inherit'` to `stdio: 'pipe'` to capture stderr/stdout
+2. Added pre-publish check against the crates.io API (`curl -s https://crates.io/api/v1/crates/{name}/{version}`) before attempting `cargo publish`
+3. Combined `error.stderr + error.stdout + error.message` for reliable pattern matching
+
+### Root Cause 2: `check-release-needed.mjs` only checked git tags, not the registry
+
+**Problem**: The script checked if a git tag `v{version}` exists to determine if a release was needed. However, git tags and crates.io publication are separate concerns — a tag can exist without a successful publish (failed CI), or a publish can succeed without a tag (manual publish).
+
+**Fix**: Added crates.io API check (`https://crates.io/api/v1/crates/{name}/{version}`) alongside git tag verification. The script now handles four possible states:
+- Tag exists + published → skip release
+- Tag exists + not published → publish without version bump
+- No tag + published → skip release (don't re-publish)
+- No tag + not published → publish with version bump
+
+### Root Cause 3: Shared tag prefix between JS and Rust releases
+
+**Problem**: Both JavaScript and Rust releases used the `v` prefix (e.g., `v0.2.0`). This means if JS and Rust versions ever align, they would create conflicting tags and releases.
+
+**Fix**: Introduced language-specific prefixes:
+- Rust: `rust_0.2.0` tag, `[Rust] 0.2.0` display name
+- JavaScript: `js_0.3.0` tag, `[JavaScript] 0.3.0` display name
+
+### Root Cause 4: Hardcoded package name in `publish-to-npm.mjs`
+
+**Problem**: The npm version check used `npm view "test-anywhere@${version}"` instead of the actual package name from `package.json`. This was likely a copy-paste artifact from a template.
+
+**Fix**: Read `name` field from `./package.json` dynamically.
+
+## Requirements Checklist
+
+| # | Requirement | Status |
+|---|---|---|
+| 1 | Never publish the same version twice | Fixed (pre-publish registry check + graceful "already exists" handling) |
+| 2 | Separate changelogs for JS and Rust | Already in place (`js/CHANGELOG.md`, `rust/CHANGELOG.md`) |
+| 3 | Separate versions with separate bumps | Already in place (JS: 0.3.0, Rust: 0.2.0) |
+| 4 | Separate releases to crates/npm | Already in place (separate workflows) |
+| 5 | Separate GitHub Releases | Fixed (language-specific tag prefixes and display names) |
+| 6 | Release prefixes `js_X.Y.Z`, `rust_X.Y.Z` | Fixed |
+| 7 | Display names `[Rust] X.Y.Z`, `[JavaScript] X.Y.Z` | Fixed |
+| 8 | Badges on each release with direct links | Already in place (shields.io badges added by format scripts) |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/publish-crate.mjs` | Pre-check crates.io API; capture stderr for error detection |
+| `scripts/check-release-needed.mjs` | Check crates.io registry + configurable tag prefix |
+| `scripts/version-and-commit.mjs` | Support `--tag-prefix` and `--release-label` |
+| `scripts/create-github-release.mjs` | Support `--release-label` for display names |
+| `scripts/format-rust-release.mjs` | Configurable tag prefix (default: `rust_`) |
+| `scripts/format-github-release.mjs` | Configurable tag prefix |
+| `scripts/publish-to-npm.mjs` | Read package name from package.json |
+| `.github/workflows/rust.yml` | Pass `rust_` prefix and `Rust` label |
+| `.github/workflows/js.yml` | Pass `js_` prefix and `JavaScript` label |
+
+## References
+
+- Failed CI run: https://github.com/link-foundation/lino-arguments/actions/runs/24248668790
+- Rust template best practices: https://github.com/link-foundation/rust-ai-driven-development-pipeline-template
+- JS template best practices: https://github.com/link-foundation/js-ai-driven-development-pipeline-template

--- a/docs/case-studies/issue-27/issue-data.json
+++ b/docs/case-studies/issue-27/issue-data.json
@@ -1,0 +1,49 @@
+{
+  "issue": {
+    "number": 27,
+    "title": "Fix CI/CD so we never publish the same version twice",
+    "url": "https://github.com/link-foundation/lino-arguments/issues/27",
+    "labels": ["bug"]
+  },
+  "failed_ci_run": {
+    "id": 24248668790,
+    "url": "https://github.com/link-foundation/lino-arguments/actions/runs/24248668790/job/70801987692",
+    "workflow": "Rust CI/CD",
+    "trigger": "push to main",
+    "commit": "6308d6e841743920b170dd5fd714ffc9915be4d1",
+    "failed_job": "Auto Release",
+    "error": "crate lino-arguments@0.2.0 already exists on crates.io index",
+    "exit_code": 1
+  },
+  "root_causes": [
+    {
+      "id": "RC1",
+      "summary": "publish-crate.mjs used stdio:'inherit' preventing error detection",
+      "details": "execSync with stdio:'inherit' sends stderr to terminal not error.message, so 'already exists' check never matched"
+    },
+    {
+      "id": "RC2",
+      "summary": "check-release-needed.mjs only checked git tags not crates.io",
+      "details": "Git tags and registry publication are independent; checking only tags is unreliable"
+    },
+    {
+      "id": "RC3",
+      "summary": "Shared 'v' tag prefix for both JS and Rust releases",
+      "details": "Both languages used v{version} tags, creating collision risk"
+    },
+    {
+      "id": "RC4",
+      "summary": "Hardcoded 'test-anywhere' package name in publish-to-npm.mjs",
+      "details": "Copy-paste from template; npm version check used wrong package name"
+    }
+  ],
+  "versions_at_time_of_issue": {
+    "javascript": "0.3.0",
+    "rust": "0.2.0"
+  },
+  "existing_tags": ["v0.1.1", "v0.2.0", "v0.2.5", "v0.2.7", "v0.2.8", "v0.3.0"],
+  "fix_pr": {
+    "number": 28,
+    "url": "https://github.com/link-foundation/lino-arguments/pull/28"
+  }
+}

--- a/rust/changelog.d/fix-duplicate-publish.md
+++ b/rust/changelog.d/fix-duplicate-publish.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+- CI/CD: Prevent duplicate version publishing by checking crates.io registry before attempting publish
+- CI/CD: Properly capture cargo publish stderr to detect "already exists" errors
+- CI/CD: Use language-specific tag prefixes (`rust_X.Y.Z`) to avoid tag collisions with JavaScript releases

--- a/scripts/check-release-needed.mjs
+++ b/scripts/check-release-needed.mjs
@@ -24,6 +24,7 @@
 
 import { readFileSync, appendFileSync } from 'fs';
 import { execSync } from 'child_process';
+import https from 'https';
 import {
   getRustRoot,
   getCargoTomlPath,
@@ -38,6 +39,7 @@ const getArg = (name, defaultValue) => {
 };
 
 const hasFragments = getArg('has-fragments', process.env.HAS_FRAGMENTS || 'false');
+const tagPrefix = getArg('tag-prefix', process.env.TAG_PREFIX || 'v');
 
 // Get Rust package root (auto-detect or use explicit config)
 const rustRootConfig = parseRustRootConfig();
@@ -78,34 +80,86 @@ function getCurrentVersion() {
 /**
  * Check if a git tag exists for this version
  * @param {string} version
+ * @param {string} prefix - Tag prefix (default: "v")
  * @returns {boolean}
  */
-function checkTagExists(version) {
+function checkTagExists(version, prefix = 'v') {
   try {
-    execSync(`git rev-parse v${version}`, { stdio: 'ignore' });
+    execSync(`git rev-parse ${prefix}${version}`, { stdio: 'ignore' });
     return true;
   } catch {
     return false;
   }
 }
 
-function main() {
+/**
+ * Get package name from Cargo.toml
+ * @returns {string}
+ */
+function getPackageName() {
+  const cargoToml = readFileSync(CARGO_TOML, 'utf-8');
+  const match = cargoToml.match(/^name\s*=\s*"([^"]+)"/m);
+  return match ? match[1] : '';
+}
+
+/**
+ * Check if a version already exists on crates.io
+ * @param {string} crateName
+ * @param {string} version
+ * @returns {Promise<boolean>}
+ */
+function checkCratesIoVersion(crateName, version) {
+  return new Promise((resolve) => {
+    try {
+      const response = execSync(
+        `curl -s -o /dev/null -w "%{http_code}" https://crates.io/api/v1/crates/${crateName}/${version}`,
+        { encoding: 'utf-8' }
+      ).trim();
+      resolve(response === '200');
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+async function main() {
   try {
     const fragmentsExist = hasFragments === 'true';
 
     if (!fragmentsExist) {
-      // No fragments - check if current version tag exists
+      // No fragments - check if current version is already published
       const currentVersion = getCurrentVersion();
-      const tagExists = checkTagExists(currentVersion);
+      const packageName = getPackageName();
 
-      if (tagExists) {
+      // Check both: git tag existence AND crates.io publication
+      const tagExists = checkTagExists(currentVersion, tagPrefix);
+      const publishedOnCratesIo = packageName ? await checkCratesIoVersion(packageName, currentVersion) : false;
+
+      console.log(`Version: ${currentVersion}`);
+      console.log(`Tag exists: ${tagExists}`);
+      console.log(`Published on crates.io: ${publishedOnCratesIo}`);
+
+      if (tagExists && publishedOnCratesIo) {
         console.log(
-          `No changelog fragments and v${currentVersion} already released`
+          `No changelog fragments and ${currentVersion} already released and published`
+        );
+        setOutput('should_release', 'false');
+      } else if (tagExists && !publishedOnCratesIo) {
+        // Tag exists but not published — need to publish without bumping
+        console.log(
+          `Tag exists but ${currentVersion} not published on crates.io — will publish`
+        );
+        setOutput('should_release', 'true');
+        setOutput('skip_bump', 'true');
+      } else if (!tagExists && publishedOnCratesIo) {
+        // Published but no tag — skip (don't try to re-publish)
+        console.log(
+          `${currentVersion} already published on crates.io (tag missing) — skipping`
         );
         setOutput('should_release', 'false');
       } else {
         console.log(
-          `No changelog fragments but v${currentVersion} not yet released`
+          `No changelog fragments but ${currentVersion} not yet released`
         );
         setOutput('should_release', 'true');
         setOutput('skip_bump', 'true');

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -36,6 +36,7 @@ const version = getArg('release-version', process.env.VERSION || '');
 const repository = getArg('repository', process.env.REPOSITORY || '');
 const tagPrefix = getArg('tag-prefix', process.env.TAG_PREFIX || 'v');
 const cratesIoUrl = getArg('crates-io-url', process.env.CRATES_IO_URL || '');
+const releaseLabel = getArg('release-label', process.env.RELEASE_LABEL || '');
 
 // Get Rust package root (auto-detect or use explicit config)
 const rustRootConfig = parseRustRootConfig();
@@ -92,9 +93,12 @@ try {
 
   // Create release using GitHub API with JSON input
   // This avoids shell escaping issues
+  const releaseName = releaseLabel
+    ? `[${releaseLabel}] ${version}`
+    : `${tagPrefix}${version}`;
   const payload = JSON.stringify({
     tag_name: tag,
-    name: `${tagPrefix}${version}`,
+    name: releaseName,
     body: releaseNotes,
   });
 

--- a/scripts/format-github-release.mjs
+++ b/scripts/format-github-release.mjs
@@ -41,10 +41,15 @@ const config = makeConfig({
         type: 'string',
         default: getenv('COMMIT_SHA', ''),
         describe: 'Commit SHA for PR detection',
+      })
+      .option('tag-prefix', {
+        type: 'string',
+        default: getenv('TAG_PREFIX', 'js_'),
+        describe: 'Tag prefix for release (e.g., js_, rust_)',
       }),
 });
 
-const { releaseVersion: version, repository, commitSha } = config;
+const { releaseVersion: version, repository, commitSha, tagPrefix } = config;
 
 if (!version || !repository || !commitSha) {
   console.error('Error: Missing required arguments');
@@ -54,7 +59,8 @@ if (!version || !repository || !commitSha) {
   process.exit(1);
 }
 
-const tag = `v${version}`;
+const effectivePrefix = tagPrefix || 'js_';
+const tag = `${effectivePrefix}${version}`;
 
 try {
   // Get the release ID for this version

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -112,7 +112,7 @@ try {
   }
 
   // Build formatted release notes
-  const versionWithoutV = version.replace(/^v/, '');
+  const versionWithoutV = version.replace(/^(v|js_|rust_)/, '');
   const npmBadge = `[![npm version](https://img.shields.io/badge/npm-${versionWithoutV}-blue.svg)](https://www.npmjs.com/package/${packageName}/v/${versionWithoutV})`;
 
   let formattedBody = `## What's Changed\n\n${cleanDescription}`;

--- a/scripts/format-rust-release.mjs
+++ b/scripts/format-rust-release.mjs
@@ -32,6 +32,7 @@ const getArg = (name, defaultValue = '') => {
 
 const version = getArg('release-version', process.env.VERSION || '');
 const repository = getArg('repository', process.env.REPOSITORY || '');
+const tagPrefix = getArg('tag-prefix', process.env.TAG_PREFIX || 'rust_');
 // Default crate name derived from repo name (last segment)
 const defaultCrateName = repository.split('/').pop() || '';
 const crateName = getArg('crate-name', process.env.CRATE_NAME || defaultCrateName);
@@ -44,8 +45,8 @@ if (!version || !repository) {
   process.exit(1);
 }
 
-const versionWithoutV = version.replace(/^v/, '');
-const tag = `v${versionWithoutV}`;
+const versionWithoutV = version.replace(/^v/, '').replace(/^rust_/, '');
+const tag = `${tagPrefix}${versionWithoutV}`;
 
 // ---------------------------------------------------------------------------
 // Shields.io badges for Rust

--- a/scripts/publish-crate.mjs
+++ b/scripts/publish-crate.mjs
@@ -64,13 +64,13 @@ function setOutput(key, value) {
 }
 
 /**
- * Execute a shell command
+ * Execute a shell command, capturing output
  * @param {string} command - The command to execute
  * @param {Object} options - Execution options
  * @returns {string} - The command output
  */
 function exec(command, options = {}) {
-  return execSync(command, { encoding: 'utf-8', stdio: 'inherit', ...options });
+  return execSync(command, { encoding: 'utf-8', stdio: 'pipe', ...options });
 }
 
 /**
@@ -107,6 +107,25 @@ function main() {
       );
     }
 
+    // First, check if this version is already published on crates.io
+    try {
+      const cratesIoResponse = execSync(
+        `curl -s https://crates.io/api/v1/crates/${name}/${version}`,
+        { encoding: 'utf-8' }
+      );
+      const cratesIoData = JSON.parse(cratesIoResponse);
+      if (cratesIoData.version && cratesIoData.version.num === version) {
+        console.log(
+          `Version ${version} already exists on crates.io - skipping publish`
+        );
+        setOutput('publish_result', 'already_exists');
+        return;
+      }
+    } catch {
+      // Version not found on crates.io or API error - proceed with publish
+      console.log('Version not found on crates.io, proceeding with publish...');
+    }
+
     try {
       // Build the cargo publish command
       let command = 'cargo publish --allow-dirty';
@@ -119,24 +138,26 @@ function main() {
         command = `cd ${rustRoot} && ${command}`;
       }
 
-      exec(command);
+      const output = exec(command);
+      console.log(output);
 
       console.log(`Successfully published ${name}@${version} to crates.io`);
       setOutput('publish_result', 'success');
     } catch (error) {
-      const errorMessage = error.message || '';
+      // With stdio: 'pipe', the error output is captured in stderr/stdout
+      const errorOutput = (error.stderr || '') + (error.stdout || '') + (error.message || '');
 
       if (
-        errorMessage.includes('already uploaded') ||
-        errorMessage.includes('already exists')
+        errorOutput.includes('already uploaded') ||
+        errorOutput.includes('already exists')
       ) {
         console.log(
           `Version ${version} already exists on crates.io - this is OK`
         );
         setOutput('publish_result', 'already_exists');
       } else {
-        console.error('Failed to publish for unknown reason');
-        console.error(errorMessage);
+        console.error('Failed to publish to crates.io');
+        console.error(errorOutput);
         setOutput('publish_result', 'failed');
         process.exit(1);
       }

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -63,17 +63,18 @@ async function main() {
       await $`git pull origin main`;
     }
 
-    // Get current version
+    // Get current version and package name
     const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
     const currentVersion = packageJson.version;
-    console.log(`Current version to publish: ${currentVersion}`);
+    const PACKAGE_NAME = packageJson.name;
+    console.log(`Current version to publish: ${PACKAGE_NAME}@${currentVersion}`);
 
     // Check if this version is already published on npm
     console.log(
       `Checking if version ${currentVersion} is already published...`
     );
     const checkResult =
-      await $`npm view "test-anywhere@${currentVersion}" version`.run({
+      await $`npm view "${PACKAGE_NAME}@${currentVersion}" version`.run({
         capture: true,
       });
 
@@ -99,7 +100,7 @@ async function main() {
         await $`npm run changeset:publish`;
         setOutput('published', 'true');
         setOutput('published_version', currentVersion);
-        console.log(`\u2705 Published test-anywhere@${currentVersion} to npm`);
+        console.log(`\u2705 Published ${PACKAGE_NAME}@${currentVersion} to npm`);
         return;
       } catch {
         if (i < MAX_RETRIES) {

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -41,6 +41,8 @@ const getArg = (name, defaultValue) => {
 
 const bumpType = getArg('bump-type', process.env.BUMP_TYPE || '');
 const description = getArg('description', process.env.DESCRIPTION || '');
+const tagPrefix = getArg('tag-prefix', process.env.TAG_PREFIX || 'v');
+const releaseLabel = getArg('release-label', process.env.RELEASE_LABEL || '');
 
 // Get Rust package root (auto-detect or use explicit config)
 const rustRootConfig = parseRustRootConfig();
@@ -144,7 +146,7 @@ function updateCargoToml(newVersion) {
  */
 function checkTagExists(version) {
   try {
-    exec(`git rev-parse v${version}`, { stdio: 'ignore' });
+    exec(`git rev-parse ${tagPrefix}${version}`, { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -234,7 +236,7 @@ function main() {
 
     // Check if this version was already released
     if (checkTagExists(newVersion)) {
-      console.log(`Tag v${newVersion} already exists`);
+      console.log(`Tag ${tagPrefix}${newVersion} already exists`);
       setOutput('already_released', 'true');
       setOutput('new_version', newVersion);
       return;
@@ -266,18 +268,21 @@ function main() {
     }
 
     // Commit changes
+    const labelStr = releaseLabel ? `(${releaseLabel}) ` : '';
     const commitMsg = description
-      ? `chore: release v${newVersion}\n\n${description}`
-      : `chore: release v${newVersion}`;
+      ? `chore: release ${labelStr}${tagPrefix}${newVersion}\n\n${description}`
+      : `chore: release ${labelStr}${tagPrefix}${newVersion}`;
     exec(`git commit -m "${commitMsg.replace(/"/g, '\\"')}"`);
     console.log(`Committed version ${newVersion}`);
 
-    // Create tag
+    // Create tag with language-specific prefix
+    const tagName = `${tagPrefix}${newVersion}`;
+    const displayName = releaseLabel ? `[${releaseLabel}] ${newVersion}` : `${tagPrefix}${newVersion}`;
     const tagMsg = description
-      ? `Release v${newVersion}\n\n${description}`
-      : `Release v${newVersion}`;
-    exec(`git tag -a v${newVersion} -m "${tagMsg.replace(/"/g, '\\"')}"`);
-    console.log(`Created tag v${newVersion}`);
+      ? `Release ${displayName}\n\n${description}`
+      : `Release ${displayName}`;
+    exec(`git tag -a ${tagName} -m "${tagMsg.replace(/"/g, '\\"')}"`);
+    console.log(`Created tag ${tagName}`);
 
     // Push changes and tag
     exec('git push');

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -43,6 +43,7 @@ const bumpType = getArg('bump-type', process.env.BUMP_TYPE || '');
 const description = getArg('description', process.env.DESCRIPTION || '');
 const tagPrefix = getArg('tag-prefix', process.env.TAG_PREFIX || 'v');
 const releaseLabel = getArg('release-label', process.env.RELEASE_LABEL || '');
+const mode = getArg('mode', process.env.VERSION_MODE || 'rust');
 
 // Get Rust package root (auto-detect or use explicit config)
 const rustRootConfig = parseRustRootConfig();
@@ -53,7 +54,8 @@ const CARGO_TOML = getCargoTomlPath({ rustRoot });
 const CHANGELOG_DIR = getChangelogDir({ rustRoot });
 const CHANGELOG_FILE = getChangelogPath({ rustRoot });
 
-if (!bumpType || !['major', 'minor', 'patch'].includes(bumpType)) {
+// In changeset mode, bump type is determined by changesets, not required as input
+if (mode !== 'changeset' && mode !== 'instant' && (!bumpType || !['major', 'minor', 'patch'].includes(bumpType))) {
   console.error(
     'Usage: node scripts/version-and-commit.mjs --bump-type <major|minor|patch> [--description <desc>] [--rust-root <path>]'
   );
@@ -225,7 +227,85 @@ function collectChangelog(version) {
   console.log(`Collected ${files.length} changelog fragment(s)`);
 }
 
-function main() {
+/**
+ * Get version from package.json (for changeset mode)
+ * @returns {string}
+ */
+function getPackageJsonVersion() {
+  const pkgPath = existsSync('package.json') ? 'package.json' : 'js/package.json';
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  return pkg.version;
+}
+
+/**
+ * Run changeset-based version bump and commit (JavaScript mode)
+ */
+function mainChangeset() {
+  try {
+    // Configure git
+    exec('git config user.name "github-actions[bot]"');
+    exec('git config user.email "github-actions[bot]@users.noreply.github.com"');
+
+    // Run changeset version to apply version bumps
+    const cwd = existsSync('package.json') ? '.' : 'js';
+    exec(`npm run changeset:version`, { cwd, stdio: 'inherit' });
+
+    // Get the new version after changeset version
+    const newVersion = getPackageJsonVersion();
+
+    // Check if this version was already released
+    if (checkTagExists(newVersion)) {
+      console.log(`Tag ${tagPrefix}${newVersion} already exists`);
+      setOutput('already_released', 'true');
+      setOutput('new_version', newVersion);
+      setOutput('version_committed', 'false');
+      return;
+    }
+
+    // Stage all changes made by changeset version
+    exec('git add -A');
+
+    // Check if there are changes to commit
+    try {
+      exec('git diff --cached --quiet', { stdio: 'ignore' });
+      console.log('No changes to commit');
+      setOutput('version_committed', 'false');
+      setOutput('new_version', newVersion);
+      return;
+    } catch {
+      // There are changes to commit
+    }
+
+    // Commit changes
+    const labelStr = releaseLabel ? `(${releaseLabel}) ` : '';
+    const commitMsg = `chore: release ${labelStr}${tagPrefix}${newVersion}`;
+    exec(`git commit -m "${commitMsg.replace(/"/g, '\\"')}"`);
+    console.log(`Committed version ${newVersion}`);
+
+    // Create tag with language-specific prefix
+    const tagName = `${tagPrefix}${newVersion}`;
+    const displayName = releaseLabel ? `[${releaseLabel}] ${newVersion}` : `${tagPrefix}${newVersion}`;
+    const tagMsg = `Release ${displayName}`;
+    exec(`git tag -a ${tagName} -m "${tagMsg.replace(/"/g, '\\"')}"`);
+    console.log(`Created tag ${tagName}`);
+
+    // Push changes and tag
+    exec('git push');
+    exec('git push --tags');
+    console.log('Pushed changes and tags');
+
+    setOutput('version_committed', 'true');
+    setOutput('new_version', newVersion);
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Run Cargo.toml-based version bump and commit (Rust mode)
+ */
+function mainRust() {
   try {
     // Configure git
     exec('git config user.name "github-actions[bot]"');
@@ -297,4 +377,83 @@ function main() {
   }
 }
 
-main();
+/**
+ * Run instant JS version bump (npm version) and commit
+ */
+function mainInstantJs() {
+  try {
+    // Configure git
+    exec('git config user.name "github-actions[bot]"');
+    exec('git config user.email "github-actions[bot]@users.noreply.github.com"');
+
+    if (!bumpType || !['major', 'minor', 'patch'].includes(bumpType)) {
+      console.error('Error: --bump-type is required for instant mode');
+      process.exit(1);
+    }
+
+    // Bump package.json version using npm version (no git tag, we handle tagging ourselves)
+    const cwd = existsSync('package.json') ? '.' : 'js';
+    exec(`npm version ${bumpType} --no-git-tag-version`, { cwd, stdio: 'inherit' });
+
+    const newVersion = getPackageJsonVersion();
+
+    // Check if this version was already released
+    if (checkTagExists(newVersion)) {
+      console.log(`Tag ${tagPrefix}${newVersion} already exists`);
+      setOutput('already_released', 'true');
+      setOutput('new_version', newVersion);
+      setOutput('version_committed', 'false');
+      return;
+    }
+
+    // Stage changes
+    exec('git add -A');
+
+    // Check if there are changes to commit
+    try {
+      exec('git diff --cached --quiet', { stdio: 'ignore' });
+      console.log('No changes to commit');
+      setOutput('version_committed', 'false');
+      setOutput('new_version', newVersion);
+      return;
+    } catch {
+      // There are changes to commit
+    }
+
+    // Commit changes
+    const labelStr = releaseLabel ? `(${releaseLabel}) ` : '';
+    const commitMsg = description
+      ? `chore: release ${labelStr}${tagPrefix}${newVersion}\n\n${description}`
+      : `chore: release ${labelStr}${tagPrefix}${newVersion}`;
+    exec(`git commit -m "${commitMsg.replace(/"/g, '\\"')}"`);
+    console.log(`Committed version ${newVersion}`);
+
+    // Create tag
+    const tagName = `${tagPrefix}${newVersion}`;
+    const displayName = releaseLabel ? `[${releaseLabel}] ${newVersion}` : `${tagPrefix}${newVersion}`;
+    const tagMsg = description
+      ? `Release ${displayName}\n\n${description}`
+      : `Release ${displayName}`;
+    exec(`git tag -a ${tagName} -m "${tagMsg.replace(/"/g, '\\"')}"`);
+    console.log(`Created tag ${tagName}`);
+
+    // Push changes and tag
+    exec('git push');
+    exec('git push --tags');
+    console.log('Pushed changes and tags');
+
+    setOutput('version_committed', 'true');
+    setOutput('new_version', newVersion);
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+if (mode === 'changeset') {
+  mainChangeset();
+} else if (mode === 'instant') {
+  mainInstantJs();
+} else {
+  mainRust();
+}


### PR DESCRIPTION
## Summary

Fixes #27 — CI/CD failed because `publish-crate.mjs` attempted to publish `lino-arguments@0.2.0` to crates.io when it was already published, and the error detection code couldn't catch it.

### Root Causes Found and Fixed

1. **`publish-crate.mjs` couldn't detect "already exists" errors** — `execSync` with `stdio:'inherit'` sends stderr to the terminal, not to `error.message` in the catch block. The detection code `errorMessage.includes('already exists')` could never match.

2. **`check-release-needed.mjs` only checked git tags, not crates.io** — Git tags and crates.io publication are independent. A tag can exist without a successful publish.

3. **Shared `v` tag prefix for JS and Rust releases** — Both languages used `v{version}` tags, creating collision risk. Now uses `rust_X.Y.Z` and `js_X.Y.Z`.

4. **Hardcoded `test-anywhere` in `publish-to-npm.mjs`** — npm version check used wrong package name (copy-paste from template).

5. **`version-and-commit.mjs` didn't support JS changeset/instant modes** — The script was Rust-only, now supports `--mode changeset` and `--mode instant` for JavaScript releases.

### Changes

| File | Change |
|---|---|
| `scripts/publish-crate.mjs` | Pre-check crates.io API; capture stderr for error detection |
| `scripts/check-release-needed.mjs` | Check crates.io registry + configurable tag prefix |
| `scripts/version-and-commit.mjs` | Support `--tag-prefix`, `--release-label`, `--mode changeset/instant` |
| `scripts/create-github-release.mjs` | Support `--release-label` for display names |
| `scripts/format-rust-release.mjs` | Configurable tag prefix (default: `rust_`) |
| `scripts/format-github-release.mjs` | Configurable tag prefix |
| `scripts/format-release-notes.mjs` | Strip `js_`/`rust_` prefixes |
| `scripts/publish-to-npm.mjs` | Read package name from `package.json` |
| `.github/workflows/rust.yml` | Pass `rust_` prefix and `Rust` label |
| `.github/workflows/js.yml` | Pass `js_` prefix and `JavaScript` label |
| `docs/case-studies/issue-27/` | Case study with timeline, root cause analysis, and fix documentation |
| `rust/changelog.d/fix-duplicate-publish.md` | Changelog fragment for the Rust release |

### Release Format

- **Tags**: `rust_0.2.1`, `js_0.3.1` (language-specific, no collisions)
- **GitHub Releases**: `[Rust] 0.2.1`, `[JavaScript] 0.3.1` (clear visual labels)
- **Badges**: Each release gets shields.io badges linking to published packages

## Test plan

- [x] All scripts pass Node.js syntax check (`node -c`)
- [x] Verified `publish-crate.mjs` pre-checks crates.io before attempting publish
- [x] Verified `check-release-needed.mjs` queries crates.io registry
- [x] Verified error detection captures stderr properly with `stdio: 'pipe'`
- [ ] Verify Rust CI workflow passes on this PR
- [ ] Verify JS CI workflow passes on this PR
- [ ] After merge: verify auto-release skips already-published versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)