### PR TITLE
fix(ci): JS CI/CD publishing broken — add npm publish check for unpublished versions

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -291,10 +291,52 @@ jobs:
         id: version
         run: node ../scripts/version-and-commit.mjs --mode changeset --tag-prefix "js_" --release-label "JavaScript"
 
+      - name: Check if current version needs publishing
+        id: check_publish
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          echo "Current version: ${PACKAGE_NAME}@${CURRENT_VERSION}"
+
+          # Check if this version is already on npm
+          if npm view "${PACKAGE_NAME}@${CURRENT_VERSION}" version 2>/dev/null; then
+            echo "Version ${CURRENT_VERSION} is already published on npm"
+            echo "needs_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version ${CURRENT_VERSION} is NOT published on npm"
+            echo "needs_publish=true" >> $GITHUB_OUTPUT
+          fi
+          echo "current_version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Publish to npm
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true' || steps.check_publish.outputs.needs_publish == 'true'
         id: publish
         run: node ../scripts/publish-to-npm.mjs --should-pull
+
+      - name: Ensure release tag exists
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.publish.outputs.published_version }}"
+          TAG="js_${VERSION}"
+          # Check if the js_ prefixed tag already exists
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists"
+          else
+            echo "Tag ${TAG} does not exist, creating it..."
+            # Try to use the v-prefixed tag commit if it exists (migration from old tag scheme)
+            if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+              COMMIT=$(git rev-parse "v${VERSION}")
+              echo "Using commit from v${VERSION} tag: ${COMMIT}"
+            else
+              COMMIT=$(git rev-parse HEAD)
+              echo "Using HEAD commit: ${COMMIT}"
+            fi
+            git tag -a "${TAG}" "${COMMIT}" -m "Release [JavaScript] ${VERSION}"
+            git push origin "${TAG}"
+            echo "Created and pushed tag ${TAG}"
+          fi
 
       - name: Create GitHub Release
         if: steps.publish.outputs.published == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T20:59:24.265Z for PR creation at branch issue-29-e8aec0bb3b3b for issue https://github.com/link-foundation/lino-arguments/issues/29

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T20:59:24.265Z for PR creation at branch issue-29-e8aec0bb3b3b for issue https://github.com/link-foundation/lino-arguments/issues/29

--- a/docs/case-studies/issue-29/case-study.md
+++ b/docs/case-studies/issue-29/case-study.md
@@ -1,0 +1,129 @@
+# Case Study: Issue #29 — CI/CD for JavaScript Publishing is Broken
+
+## Summary
+
+The JavaScript CI/CD pipeline has not published to npm since version 0.2.5 (Dec 2025), despite version 0.3.0 being committed to `package.json` and tagged in git on Dec 31, 2025. The npm registry shows `lino-arguments@0.2.5` as latest, while the repository has `0.3.0`. Meanwhile, Rust releases (e.g., `rust_0.3.0`) publish successfully, highlighting that the JS pipeline has a structural defect.
+
+## Timeline of Events
+
+| Time (UTC) | Event |
+|---|---|
+| 2025-12-09 | JS v0.2.5 published to npm (last successful npm publish) |
+| 2025-12-31 10:40 | PR #18 merged to main with JS changes + changeset file `add-rust-version.md` |
+| 2025-12-31 10:42 | JS CI/CD Release job runs: `changeset version` consumes the changeset, bumps `package.json` to 0.3.0, commits, creates tag `v0.3.0` |
+| 2025-12-31 ~10:42 | **FAILURE POINT**: npm publish step either failed or was skipped (logs expired, HTTP 410) |
+| 2025-12-31 onward | npm registry still shows 0.2.5 as latest |
+| 2026-01-13 21:25 | Push to main triggers JS CI/CD — Release job finds 0 changesets, skips version+publish |
+| 2026-04-04 | PR #24 merged — Rust-only changes, no JS code changes |
+| 2026-04-10 14:44 | PR #26 merged — CI/CD workflow changes, no JS code changes |
+| 2026-04-10 20:47 | PR #28 merged — CI/CD changes; JS CI/CD runs, Release job finds 0 changesets, skips version+publish |
+| 2026-04-10 20:49 | Rust `rust_0.3.0` released successfully to crates.io and GitHub |
+| 2026-04-10 | Issue #29 opened: "CI/CD for JavaScript publishing is broken" |
+
+## Requirements from the Issue
+
+1. **JS package must be published to npm** — npm shows 0.2.5, repository has 0.3.0
+2. **CI logs and data must be downloaded** to `./docs/case-studies/issue-29/`
+3. **Deep case study analysis** with timeline, root causes, and solutions
+4. **Root cause identification** for each problem
+5. **Proposed solutions** with references to existing tools/libraries
+
+## Root Causes
+
+### Root Cause 1: Release job has no fallback when changesets are absent but version is unpublished
+
+**Problem**: The JS `release` job in `.github/workflows/js.yml` has this flow:
+
+```
+1. Check for changesets → has_changesets
+2. IF has_changesets: Run version-and-commit.mjs → version_committed, already_released
+3. IF version_committed OR already_released: Run publish-to-npm.mjs
+```
+
+When there are no changeset files (step 1 = false), step 2 is skipped entirely, so `version_committed` and `already_released` are never set. Step 3's condition evaluates to false, and **publish is skipped** — even though `package.json` has an unpublished version.
+
+**Evidence** (from CI run 24263446026, line 5986):
+```
+Found 0 changeset file(s)
+```
+The "Version packages" and "Publish to npm" steps were never executed.
+
+**Evidence** (from CI run 20973144893, line 5968):
+```
+Found 0 changeset file(s)
+```
+Same pattern — 0 changesets, publish skipped.
+
+**Contrast with Rust pipeline**: The Rust workflow in `rust.yml` has an independent `check-release-needed.mjs` step (lines 292-299) that verifies whether the current version needs releasing regardless of changelog fragment state. The JS workflow lacks this equivalent safeguard.
+
+### Root Cause 2: Original v0.3.0 publish likely failed silently
+
+**Problem**: The Dec 31, 2025 CI run (ID 20617328160) that created the v0.3.0 commit and tag is the one that should have published to npm. However, the CI logs for this run have expired (HTTP 410), so we cannot definitively determine what went wrong.
+
+**Evidence**:
+- `npm view lino-arguments versions` returns `["0.2.1", "0.2.5"]` — v0.3.0 is absent
+- Git tag `v0.3.0` exists pointing to commit `a2790c6` (the changeset version commit)
+- The changeset file `add-rust-version.md` was consumed (removed by `changeset version`)
+- `package.json` shows version `0.3.0`
+
+**Most likely cause**: The publish step either encountered a transient npm/OIDC error, or the step condition prevented it from running (similar to Root Cause 1, if the pipeline had an earlier version of this bug).
+
+### Root Cause 3: Tag prefix migration gap
+
+**Problem**: Issue #27 (PR #28) introduced language-specific tag prefixes: `rust_` for Rust, `js_` for JavaScript. The JS workflow now uses `--tag-prefix "js_"` in the release steps. However, no `js_*` tags exist — all existing JS releases used the `v` prefix (v0.1.1, v0.2.0, v0.2.5, v0.2.7, v0.2.8, v0.3.0).
+
+This means:
+- `checkTagExists('0.3.0')` with prefix `js_` looks for `js_0.3.0` — not found
+- The `create-github-release.mjs` step tries to create a release for tag `js_0.3.0` — tag doesn't exist
+- No migration path from `v`-prefix to `js_`-prefix tags was implemented
+
+## Solutions
+
+### Solution 1: Add npm publish check independent of changesets (implemented)
+
+Added a new step `Check if current version needs publishing` to the `release` job that runs after the version step. This step:
+
+1. Reads the current version from `package.json`
+2. Checks if that version exists on npm via `npm view`
+3. Sets `needs_publish=true` if the version is missing from npm
+
+The publish step condition is updated to also trigger when `needs_publish == 'true'`:
+```yaml
+if: steps.version.outputs.version_committed == 'true' ||
+    steps.version.outputs.already_released == 'true' ||
+    steps.check_publish.outputs.needs_publish == 'true'
+```
+
+### Solution 2: Add tag migration step (implemented)
+
+Added an `Ensure release tag exists` step that runs before `Create GitHub Release`. This step:
+
+1. Checks if the `js_`-prefixed tag exists
+2. If not, looks for an equivalent `v`-prefixed tag and creates the `js_` tag pointing to the same commit
+3. Falls back to HEAD if no `v`-prefixed tag exists
+
+This provides a one-time migration path from the old `v` prefix to the new `js_` prefix.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `.github/workflows/js.yml` | Added `Check if current version needs publishing` step, `Ensure release tag exists` step, updated publish condition |
+
+## Verification
+
+After merging this fix to main:
+
+1. The JS CI/CD pipeline will detect that `lino-arguments@0.3.0` is not on npm
+2. The publish step will run and publish v0.3.0 to npm
+3. The `js_0.3.0` tag will be created from the existing `v0.3.0` tag
+4. A `[JavaScript] 0.3.0` GitHub release will be created
+5. Future releases with changesets will continue to work as before
+
+## References
+
+- Issue: https://github.com/link-foundation/lino-arguments/issues/29
+- PR: https://github.com/link-foundation/lino-arguments/pull/30
+- npm package: https://www.npmjs.com/package/lino-arguments
+- Rust pipeline (working reference): `.github/workflows/rust.yml` lines 252-346
+- `@changesets/cli` docs: https://github.com/changesets/changesets

--- a/docs/case-studies/issue-29/issue-data.json
+++ b/docs/case-studies/issue-29/issue-data.json
@@ -1,0 +1,61 @@
+{
+  "issue_number": 29,
+  "title": "CI/CD for JavaScript publishing is broken",
+  "url": "https://github.com/link-foundation/lino-arguments/issues/29",
+  "author": "konard",
+  "created_at": "2026-04-10",
+  "labels": ["bug"],
+  "related_releases": {
+    "rust_0.3.0": {
+      "tag": "rust_0.3.0",
+      "date": "2026-04-10T20:49:09Z",
+      "published_to_registry": true
+    },
+    "v0.3.0_js": {
+      "tag": "v0.3.0",
+      "date": "2025-12-31T10:42:10Z",
+      "published_to_registry": false,
+      "npm_latest_version": "0.2.5"
+    }
+  },
+  "ci_runs_analyzed": [
+    {
+      "run_id": 24263446026,
+      "event": "push",
+      "branch": "main",
+      "date": "2026-04-10T20:47:01Z",
+      "conclusion": "success",
+      "log_file": "js-cicd-run-24263446026.log",
+      "finding": "Release job found 0 changeset files, skipped version and publish steps"
+    },
+    {
+      "run_id": 20973144893,
+      "event": "push",
+      "branch": "main",
+      "date": "2026-01-13T21:25:26Z",
+      "conclusion": "success",
+      "log_file": "js-cicd-run-20973144893.log",
+      "finding": "Release job found 0 changeset files, skipped version and publish steps"
+    },
+    {
+      "run_id": 20617328160,
+      "event": "push",
+      "branch": "main",
+      "date": "2025-12-31T10:40:47Z",
+      "conclusion": "success",
+      "log_file": null,
+      "finding": "Logs expired (HTTP 410). This was the run that versioned 0.3.0 but likely failed to publish to npm."
+    }
+  ],
+  "npm_state": {
+    "package": "lino-arguments",
+    "published_versions": ["0.2.1", "0.2.5"],
+    "latest_tag": "0.2.5",
+    "expected_latest": "0.3.0"
+  },
+  "git_tags": {
+    "js_prefix": [],
+    "v_prefix": ["v0.1.1", "v0.2.0", "v0.2.5", "v0.2.7", "v0.2.8", "v0.3.0"],
+    "rust_prefix": ["rust_0.3.0"]
+  }
+}

--- a/docs/case-studies/issue-29/js-cicd-run-20973144893.txt
+++ b/docs/case-studies/issue-29/js-cicd-run-20973144893.txt
@@ -1,0 +1,5984 @@
+Detect Changes	UNKNOWN STEP	﻿2026-01-13T21:25:30.6512652Z Current runner version: '2.330.0'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6536922Z ##[group]Runner Image Provisioner
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6537713Z Hosted Compute Agent
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6538392Z Version: 20251211.462
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6539002Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6539686Z Build Date: 2025-12-11T16:28:49Z
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6540434Z Worker ID: {48541980-4015-4dbc-b3b2-e02a4950a096}
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6541109Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6541632Z ##[group]Operating System
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6542226Z Ubuntu
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6542713Z 24.04.3
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6543129Z LTS
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6543637Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6544138Z ##[group]Runner Image
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6544675Z Image: ubuntu-24.04
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6545323Z Version: 20260105.202.1
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6546651Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6548148Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6549768Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6552393Z ##[group]GITHUB_TOKEN Permissions
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6555675Z Actions: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6556253Z ArtifactMetadata: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6556745Z Attestations: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6557405Z Checks: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6557887Z Contents: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6558336Z Deployments: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6558995Z Discussions: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6559457Z Issues: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6559918Z Metadata: read
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6560456Z Models: read
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6560934Z Packages: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6561401Z Pages: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6562021Z PullRequests: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6562634Z RepositoryProjects: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6563168Z SecurityEvents: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6563801Z Statuses: write
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6564257Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6566473Z Secret source: Actions
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6567505Z Prepare workflow directory
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6957028Z Prepare all required actions
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:30.6996463Z Getting action download info
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.1712613Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.2945846Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5173980Z Complete job name: Detect Changes
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5861781Z ##[group]Run actions/checkout@v4
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5862648Z with:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5863030Z   fetch-depth: 0
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5863477Z   repository: link-foundation/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5864193Z   token: ***
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5864573Z   ssh-strict: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5864954Z   ssh-user: git
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5865503Z   persist-credentials: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5865945Z   clean: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5866339Z   sparse-checkout-cone-mode: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5866798Z   fetch-tags: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5867275Z   show-progress: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5867687Z   lfs: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5868050Z   submodules: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5868458Z   set-safe-directory: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.5869162Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.6952651Z Syncing repository: link-foundation/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.6954478Z ##[group]Getting Git version info
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.6955283Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.6956550Z [command]/usr/bin/git version
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7046273Z git version 2.52.0
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7074580Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7100771Z Temporarily overriding HOME='/home/runner/work/_temp/29d64ce6-0e19-4681-a6d8-e1b3a3de0e4b' before making global git config changes
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7103103Z Adding repository directory to the temporary git global config as a safe directory
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7107751Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7152031Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7157010Z ##[group]Initializing the repository
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7162897Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7290314Z hint: Using 'master' as the name for the initial branch. This default branch name
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7291626Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7293187Z hint: to use in all of your new repositories, which will suppress this warning,
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7294387Z hint: call:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7295017Z hint:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7295941Z hint: 	git config --global init.defaultBranch <name>
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7296912Z hint:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7297497Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7298422Z hint: 'development'. The just-created branch can be renamed via this command:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7299172Z hint:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7299548Z hint: 	git branch -m <name>
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7299993Z hint:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7300581Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7301672Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7313181Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7364266Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7365003Z ##[group]Disabling automatic garbage collection
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7366093Z [command]/usr/bin/git config --local gc.auto 0
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7398092Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7398749Z ##[group]Setting up auth
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7409001Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7445190Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7825124Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.7856376Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.8079720Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.8112869Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.8342640Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.8378638Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.8379882Z ##[group]Fetching the repository
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:31.8388876Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4979804Z From https://github.com/link-foundation/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4987236Z  * [new branch]      changeset-release/manual-19391025857 -> origin/changeset-release/manual-19391025857
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4990591Z  * [new branch]      claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj -> origin/claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4992652Z  * [new branch]      claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq -> origin/claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4994023Z  * [new branch]      issue-1-171e0c1cad4c  -> origin/issue-1-171e0c1cad4c
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4994875Z  * [new branch]      issue-10-89893ff89d82 -> origin/issue-10-89893ff89d82
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4996221Z  * [new branch]      issue-10-d4419a0e77c2 -> origin/issue-10-d4419a0e77c2
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4997093Z  * [new branch]      issue-13-167bb501b116 -> origin/issue-13-167bb501b116
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4998431Z  * [new branch]      issue-14-555e0cfd6e57 -> origin/issue-14-555e0cfd6e57
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.4999501Z  * [new branch]      issue-17-aac47b45095f -> origin/issue-17-aac47b45095f
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5000581Z  * [new branch]      issue-19-c4402d419d95 -> origin/issue-19-c4402d419d95
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5001680Z  * [new branch]      issue-20-535e73c3f5df -> origin/issue-20-535e73c3f5df
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5002765Z  * [new branch]      issue-6-88ce301275b5  -> origin/issue-6-88ce301275b5
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5003812Z  * [new branch]      issue-6-ed79da598197  -> origin/issue-6-ed79da598197
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5004920Z  * [new branch]      issue-6-ef625c0a060f  -> origin/issue-6-ef625c0a060f
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5006188Z  * [new branch]      main                  -> origin/main
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5006936Z  * [new tag]         v0.2.5                -> v0.2.5
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5007626Z  * [new tag]         v0.2.7                -> v0.2.7
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5008334Z  * [new tag]         v0.2.8                -> v0.2.8
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5009024Z  * [new tag]         v0.3.0                -> v0.3.0
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5058421Z [command]/usr/bin/git branch --list --remote origin/main
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5088730Z   origin/main
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5102014Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5120060Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5128111Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5129353Z ##[group]Determining the checkout info
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5130769Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5132934Z [command]/usr/bin/git sparse-checkout disable
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5179952Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5208705Z ##[group]Checking out the ref
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5213553Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5371159Z Switched to a new branch 'main'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5372426Z branch 'main' set up to track 'origin/main'.
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5380427Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5418589Z [command]/usr/bin/git log -1 --format=%H
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5441656Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5731092Z ##[group]Run actions/setup-node@v4
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5731931Z with:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5732410Z   node-version: 20.x
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5733012Z   always-auth: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5733599Z   check-latest: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5734470Z   token: ***
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.5734979Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.7780990Z Found in cache @ /opt/hostedtoolcache/node/20.19.6/x64
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:32.7788070Z ##[group]Environment details
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9319134Z node: v20.19.6
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9319796Z npm: 10.8.2
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9320159Z yarn: 1.22.22
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9321474Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9454046Z ##[group]Run node scripts/detect-code-changes.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9454495Z [36;1mnode scripts/detect-code-changes.mjs[0m
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9498687Z shell: /usr/bin/bash -e {0}
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9498937Z env:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9499118Z   GITHUB_EVENT_NAME: push
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9499332Z   GITHUB_BASE_SHA: 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9499523Z   GITHUB_HEAD_SHA: 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9499699Z ##[endgroup]
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9865846Z Detecting file changes for CI/CD...
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9866198Z 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9866417Z Comparing HEAD^ to HEAD
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9909532Z Changed files:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9909984Z   .github/workflows/js.yml
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9910426Z   .github/workflows/rust.yml
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9910999Z   rust/changelog.d/20250111-cicd-best-practices.md
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9911664Z   scripts/check-changelog-fragment.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9912213Z   scripts/check-release-needed.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9912892Z   scripts/check-version-modification.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9913449Z   scripts/collect-changelog.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9913998Z   scripts/create-changelog-fragment.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9914990Z   scripts/create-github-release.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9915722Z   scripts/detect-code-changes.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9916194Z   scripts/get-bump-type.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9916622Z   scripts/get-version.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9917024Z   scripts/git-config.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9917478Z   scripts/publish-crate.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9917897Z   scripts/rust-paths.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9918398Z   scripts/version-and-commit.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9918717Z 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9921900Z rs-changed=false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9923646Z toml-changed=false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9924598Z js-changed=false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9925662Z package-changed=false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9926730Z mjs-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9927599Z docs-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9928396Z workflow-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9929247Z rust-workflow-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9930078Z js-workflow-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9931965Z 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9932247Z Files considered as code changes:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9932740Z   .github/workflows/js.yml
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9933140Z   .github/workflows/rust.yml
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9933606Z   scripts/check-changelog-fragment.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9934149Z   scripts/check-release-needed.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9934663Z   scripts/check-version-modification.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9935168Z   scripts/collect-changelog.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9935905Z   scripts/create-changelog-fragment.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9936433Z   scripts/create-github-release.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9936911Z   scripts/detect-code-changes.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9937341Z   scripts/get-bump-type.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9937729Z   scripts/get-version.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9938102Z   scripts/git-config.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9938485Z   scripts/publish-crate.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9938871Z   scripts/rust-paths.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9939341Z   scripts/version-and-commit.mjs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9939623Z 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9939806Z any-code-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9940620Z rust-code-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9942417Z js-code-changed=true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9943321Z rust-package-changed=false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9944246Z js-package-changed=false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9944504Z 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9944715Z Language-specific detection:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9945117Z   Rust-related changes: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9945685Z   JS-related changes: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9946175Z   Rust package code changes: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9946567Z   JS package code changes: false
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9946918Z   Shared scripts changed: true
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9947088Z 
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:34.9947203Z Change detection completed.
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.0149843Z Post job cleanup.
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.1850645Z Post job cleanup.
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2789043Z [command]/usr/bin/git version
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2824943Z git version 2.52.0
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2870525Z Temporarily overriding HOME='/home/runner/work/_temp/b538b7d4-7d38-428c-a308-842d48325c2a' before making global git config changes
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2872214Z Adding repository directory to the temporary git global config as a safe directory
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2877517Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2917067Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.2949232Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3180100Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3201061Z http.https://github.com/.extraheader
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3214359Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3248130Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3481641Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3515277Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3866508Z Evaluate and set job outputs
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3874200Z Set output 'js-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3877071Z Set output 'package-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3877706Z Set output 'mjs-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3877996Z Set output 'docs-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3878287Z Set output 'js-workflow-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3878578Z Set output 'js-code-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3878865Z Set output 'js-package-changed'
+Detect Changes	UNKNOWN STEP	2026-01-13T21:25:35.3879522Z Cleaning up orphan processes
+Lint and Format Check	UNKNOWN STEP	﻿2026-01-13T21:25:41.8437105Z Current runner version: '2.330.0'
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8463973Z ##[group]Runner Image Provisioner
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8464886Z Hosted Compute Agent
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8465452Z Version: 20251211.462
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8466021Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8466792Z Build Date: 2025-12-11T16:28:49Z
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8467466Z Worker ID: {94b2415f-089f-4f1a-a963-4f92c8aeaf38}
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8468132Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8468669Z ##[group]Operating System
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8469250Z Ubuntu
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8469690Z 24.04.3
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8470192Z LTS
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8470698Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8471161Z ##[group]Runner Image
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8472119Z Image: ubuntu-24.04
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8472671Z Version: 20260105.202.1
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8473691Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8475290Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8476328Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8479111Z ##[group]GITHUB_TOKEN Permissions
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8481481Z Actions: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8482584Z ArtifactMetadata: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8483284Z Attestations: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8483807Z Checks: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8484285Z Contents: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8484858Z Deployments: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8485381Z Discussions: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8485880Z Issues: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8486425Z Metadata: read
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8486912Z Models: read
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8487367Z Packages: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8487932Z Pages: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8488391Z PullRequests: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8489066Z RepositoryProjects: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8489659Z SecurityEvents: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8490206Z Statuses: write
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8490696Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8492991Z Secret source: Actions
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8494181Z Prepare workflow directory
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8883480Z Prepare all required actions
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:41.8919879Z Getting action download info
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.2381430Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.3452902Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.5383607Z Complete job name: Lint and Format Check
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6085556Z ##[group]Run actions/checkout@v4
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6086387Z with:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6086838Z   repository: link-foundation/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6087532Z   token: ***
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6087919Z   ssh-strict: true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6088314Z   ssh-user: git
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6088705Z   persist-credentials: true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6089150Z   clean: true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6089547Z   sparse-checkout-cone-mode: true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6090016Z   fetch-depth: 1
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6090394Z   fetch-tags: false
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6090806Z   show-progress: true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6091198Z   lfs: false
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6091559Z   submodules: false
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6092126Z   set-safe-directory: true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.6092847Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7151411Z Syncing repository: link-foundation/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7153337Z ##[group]Getting Git version info
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7154352Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7155360Z [command]/usr/bin/git version
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7238131Z git version 2.52.0
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7264510Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7285152Z Temporarily overriding HOME='/home/runner/work/_temp/c50bd646-c70a-4e0e-9767-7a110116b72b' before making global git config changes
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7286536Z Adding repository directory to the temporary git global config as a safe directory
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7290234Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7330025Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7334000Z ##[group]Initializing the repository
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7337962Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7471887Z hint: Using 'master' as the name for the initial branch. This default branch name
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7473297Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7474959Z hint: to use in all of your new repositories, which will suppress this warning,
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7476363Z hint: call:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7477052Z hint:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7477910Z hint: 	git config --global init.defaultBranch <name>
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7478785Z hint:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7479401Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7480394Z hint: 'development'. The just-created branch can be renamed via this command:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7481192Z hint:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7481591Z hint: 	git branch -m <name>
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7482286Z hint:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7483256Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7484387Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7488721Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7523850Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7524571Z ##[group]Disabling automatic garbage collection
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7527936Z [command]/usr/bin/git config --local gc.auto 0
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7555690Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7556419Z ##[group]Setting up auth
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7562409Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7592643Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7950066Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.7981147Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.8208637Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.8244584Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.8471585Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.8510750Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.8512149Z ##[group]Fetching the repository
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:42.8522981Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1016780Z From https://github.com/link-foundation/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1017844Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1049123Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1050259Z ##[group]Determining the checkout info
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1051972Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1057289Z [command]/usr/bin/git sparse-checkout disable
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1098958Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1124726Z ##[group]Checking out the ref
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1129077Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1304552Z Switched to a new branch 'main'
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1307435Z branch 'main' set up to track 'origin/main'.
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1386287Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1389455Z [command]/usr/bin/git log -1 --format=%H
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1390773Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1622906Z ##[group]Run actions/setup-node@v4
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1623504Z with:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1623898Z   node-version: 20.x
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1624348Z   always-auth: false
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1624796Z   check-latest: false
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1625413Z   token: ***
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.1625818Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.3374299Z Found in cache @ /opt/hostedtoolcache/node/20.19.6/x64
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.3380711Z ##[group]Environment details
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7005126Z node: v20.19.6
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7006202Z npm: 10.8.2
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7007046Z yarn: 1.22.22
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7008946Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7144927Z ##[group]Run npm install
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7146111Z [36;1mnpm install[0m
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7192213Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:43.7193333Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.5616164Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.5625271Z > lino-arguments@0.3.0 prepare
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.5626779Z > husky || true
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.5627104Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6078274Z .git can't be found
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6079065Z added 234 packages, and audited 235 packages in 3s
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6079676Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6080016Z 59 packages are looking for funding
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6080524Z   run `npm fund` for details
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6100626Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6101105Z 1 moderate severity vulnerability
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6101545Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6102046Z To address all issues, run:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6102605Z   npm audit fix
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6102929Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6103255Z Run `npm audit` for details.
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6305898Z ##[group]Run npm run lint
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6306198Z [36;1mnpm run lint[0m
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6340667Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.6340926Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.7413096Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.7413720Z > lino-arguments@0.3.0 lint
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.7414165Z > eslint .
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:46.7414333Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.7207810Z ##[group]Run npm run format:check
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.7208123Z [36;1mnpm run format:check[0m
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.7241479Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.7241937Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.8341977Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.8342444Z > lino-arguments@0.3.0 format:check
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.8343019Z > prettier --check .
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.8343266Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:47.9137580Z Checking formatting...
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.5513035Z All matched files use Prettier code style!
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.5858311Z ##[group]Run npm run check:file-size
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.5858635Z [36;1mnpm run check:file-size[0m
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.5892203Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.5892450Z ##[endgroup]
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.6958640Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.6959236Z > lino-arguments@0.3.0 check:file-size
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.6959759Z > node ../scripts/check-file-size.mjs
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.6960012Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.7262496Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.7263301Z Checking JavaScript files for maximum 1500 lines...
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.7263822Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.7324682Z ✓ All files are within the line limit
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.7325057Z 
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.7481047Z Post job cleanup.
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:48.9177840Z Post job cleanup.
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0121339Z [command]/usr/bin/git version
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0158477Z git version 2.52.0
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0204885Z Temporarily overriding HOME='/home/runner/work/_temp/bc1dec46-1eef-4463-b228-2b81b0bf97a6' before making global git config changes
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0205886Z Adding repository directory to the temporary git global config as a safe directory
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0218118Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0251191Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0282741Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0512981Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0535283Z http.https://github.com/.extraheader
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0548286Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0580073Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0804003Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.0835667Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and Format Check	UNKNOWN STEP	2026-01-13T21:25:49.1176492Z Cleaning up orphan processes
+Test (bun on ubuntu-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:41.6444955Z Current runner version: '2.330.0'
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6467779Z ##[group]Runner Image Provisioner
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6468678Z Hosted Compute Agent
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6469213Z Version: 20251211.462
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6469799Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6470520Z Build Date: 2025-12-11T16:28:49Z
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6471163Z Worker ID: {24310dc0-5e75-4544-8f51-9f3510d11ecd}
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6471853Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6472622Z ##[group]Operating System
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6473297Z Ubuntu
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6473735Z 24.04.3
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6474150Z LTS
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6475054Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6475546Z ##[group]Runner Image
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6476060Z Image: ubuntu-24.04
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6476589Z Version: 20260105.202.1
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6477582Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6479178Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6480153Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6483015Z ##[group]GITHUB_TOKEN Permissions
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6485286Z Actions: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6485838Z ArtifactMetadata: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6486465Z Attestations: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6486941Z Checks: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6487419Z Contents: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6487919Z Deployments: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6488552Z Discussions: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6489005Z Issues: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6489506Z Metadata: read
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6489964Z Models: read
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6490472Z Packages: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6490911Z Pages: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6491494Z PullRequests: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6492343Z RepositoryProjects: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6492882Z SecurityEvents: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6493483Z Statuses: write
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6493935Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6495929Z Secret source: Actions
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6496729Z Prepare workflow directory
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.7029687Z Prepare all required actions
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.7083935Z Getting action download info
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.1107979Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.2624930Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.3542979Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.7351736Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.2297636Z Complete job name: Test (bun on ubuntu-latest)
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3145222Z ##[group]Run actions/checkout@v4
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3146614Z with:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3147896Z   repository: link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3149216Z   token: ***
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3149945Z   ssh-strict: true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3150712Z   ssh-user: git
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3151482Z   persist-credentials: true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3152498Z   clean: true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3153262Z   sparse-checkout-cone-mode: true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3154190Z   fetch-depth: 1
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3154933Z   fetch-tags: false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3155687Z   show-progress: true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3156445Z   lfs: false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3157158Z   submodules: false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3157913Z   set-safe-directory: true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3159207Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4243320Z Syncing repository: link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4245863Z ##[group]Getting Git version info
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4247312Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4249236Z [command]/usr/bin/git version
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4319911Z git version 2.52.0
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4346803Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4367141Z Temporarily overriding HOME='/home/runner/work/_temp/b627a750-968f-4a11-bfc2-a414dc1a2e9d' before making global git config changes
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4370078Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4373674Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4413262Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4416984Z ##[group]Initializing the repository
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4422209Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4519200Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4521678Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4524512Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4527030Z hint: call:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4528311Z hint:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4529842Z hint: 	git config --global init.defaultBranch <name>
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4531800Z hint:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4533985Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4537199Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4539591Z hint:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4540743Z hint: 	git branch -m <name>
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4541968Z hint:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4543363Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4545399Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4550546Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4571092Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4573683Z ##[group]Disabling automatic garbage collection
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4575881Z [command]/usr/bin/git config --local gc.auto 0
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4604928Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4607140Z ##[group]Setting up auth
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4612569Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4645049Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4964392Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.4996157Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5212803Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5242994Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5461714Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5495271Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5497575Z ##[group]Fetching the repository
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5506894Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9206316Z From https://github.com/link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9209156Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9238807Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9240506Z ##[group]Determining the checkout info
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9242212Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9245675Z [command]/usr/bin/git sparse-checkout disable
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9285215Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9310067Z ##[group]Checking out the ref
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9313319Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9488416Z Switched to a new branch 'main'
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9491050Z branch 'main' set up to track 'origin/main'.
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9498835Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9530724Z [command]/usr/bin/git log -1 --format=%H
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9552576Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9960402Z ##[group]Run actions/setup-node@v4
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9961349Z with:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9962143Z   node-version: 20.x
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9962913Z   always-auth: false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9963676Z   check-latest: false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9964703Z   token: ***
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9965383Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.1849644Z Found in cache @ /opt/hostedtoolcache/node/20.19.6/x64
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.1855423Z ##[group]Environment details
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1517074Z node: v20.19.6
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1517612Z npm: 10.8.2
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1517965Z yarn: 1.22.22
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1519917Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1660302Z ##[group]Run oven-sh/setup-bun@v2
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1660629Z with:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1660849Z   bun-version: latest
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1661090Z   no-cache: false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1661316Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3766319Z Downloading a new version of Bun: https://bun.sh/download/latest/linux/x64?avx2=true&profile=false
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.9649980Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/ba962ed8-b6b7-4db5-bd7f-089a41457e94.zip
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7095815Z [command]/home/runner/.bun/bin/bun --revision
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7132476Z 1.3.6+d530ed993
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7259205Z ##[group]Run npm install
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7259542Z [36;1mnpm install[0m
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7303640Z shell: /usr/bin/bash -e {0}
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7303933Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.3717818Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.3718730Z > lino-arguments@0.3.0 prepare
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4164246Z > husky || true
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4164540Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4164762Z .git can't be found
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4165304Z added 234 packages, and audited 235 packages in 4s
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4165922Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4166106Z 59 packages are looking for funding
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4166459Z   run `npm fund` for details
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4189998Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4190612Z 1 moderate severity vulnerability
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4193664Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4194008Z To address all issues, run:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4194567Z   npm audit fix
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4194833Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4195116Z Run `npm audit` for details.
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4394978Z ##[group]Run bun test
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4395358Z [36;1mbun test[0m
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4428379Z shell: /usr/bin/bash -e {0}
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4428630Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4495934Z bun test v1.3.6 (d530ed99)
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4536233Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4537134Z ##[group]tests/index.test.js:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4923369Z (pass) Case Conversion Utilities > toUpperCase > should convert camelCase to UPPER_CASE
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4924642Z (pass) Case Conversion Utilities > toUpperCase > should convert kebab-case to UPPER_CASE
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4925657Z (pass) Case Conversion Utilities > toUpperCase > should convert snake_case to UPPER_CASE [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4926907Z (pass) Case Conversion Utilities > toUpperCase > should convert PascalCase to UPPER_CASE
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4927988Z (pass) Case Conversion Utilities > toUpperCase > should handle already UPPER_CASE
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4928877Z (pass) Case Conversion Utilities > toCamelCase > should convert kebab-case to camelCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4929749Z (pass) Case Conversion Utilities > toCamelCase > should convert UPPER_CASE to camelCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4930999Z (pass) Case Conversion Utilities > toCamelCase > should convert snake_case to camelCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4932436Z (pass) Case Conversion Utilities > toCamelCase > should convert PascalCase to camelCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4933582Z (pass) Case Conversion Utilities > toCamelCase > should handle already camelCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4935127Z (pass) Case Conversion Utilities > toKebabCase > should convert camelCase to kebab-case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4936274Z (pass) Case Conversion Utilities > toKebabCase > should convert UPPER_CASE to kebab-case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4937964Z (pass) Case Conversion Utilities > toKebabCase > should convert PascalCase to kebab-case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4939054Z (pass) Case Conversion Utilities > toKebabCase > should handle already kebab-case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4940284Z (pass) Case Conversion Utilities > toSnakeCase > should convert camelCase to snake_case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4941554Z (pass) Case Conversion Utilities > toSnakeCase > should convert kebab-case to snake_case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4942985Z (pass) Case Conversion Utilities > toSnakeCase > should convert UPPER_CASE to snake_case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4944125Z (pass) Case Conversion Utilities > toSnakeCase > should handle already snake_case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4944851Z (pass) Case Conversion Utilities > toPascalCase > should convert camelCase to PascalCase [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4945559Z (pass) Case Conversion Utilities > toPascalCase > should convert kebab-case to PascalCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4946228Z (pass) Case Conversion Utilities > toPascalCase > should convert snake_case to PascalCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4946867Z (pass) Case Conversion Utilities > toPascalCase > should handle already PascalCase
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4947360Z (pass) getenv > should find variable in UPPER_CASE
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4947778Z (pass) getenv > should find variable in camelCase [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4948181Z (pass) getenv > should find variable in kebab-case
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4948579Z (pass) getenv > should return default value when not found
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4949064Z (pass) getenv > should return empty string as default when not specified
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4949649Z (pass) getenv > should try original key first
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5037684Z (pass) makeConfig > Hero Example (defaults) > should work with minimal configuration [9.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5057743Z (pass) makeConfig > Hero Example (defaults) > should use CLI arguments with highest priority [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5076443Z (pass) makeConfig > Hero Example (defaults) > should convert kebab-case to camelCase in result [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5079457Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5094039Z (pass) makeConfig > Environment Loading Priority > should load .lenv file by default [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5097846Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5106018Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5114993Z (pass) makeConfig > Environment Loading Priority > should handle --configuration flag [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5116778Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5127532Z (pass) makeConfig > Environment Loading Priority > should prioritize CLI over environment [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5136455Z (pass) makeConfig > Environment Loading Priority > should handle missing .lenv file gracefully [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5138421Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5149076Z (pass) makeConfig > Case Conversion in Environment Loading > should convert all keys to UPPER_CASE in process.env [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5165950Z (pass) makeConfig > Case Conversion in Environment Loading > should find env vars in any case format via getenv [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5177759Z (pass) makeConfig > Configuration Options > should support disabling lenv [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5189744Z (pass) makeConfig > Configuration Options > should support enabling env/dotenvx (deprecated) [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5200077Z (pass) makeConfig > Configuration Options > should support disabling getenv [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5208082Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5216184Z (pass) makeConfig > Configuration Options > should support configuration alias -c [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5218537Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5230345Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5235678Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5243046Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5247668Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5256972Z (pass) makeConfig > Complete Priority Chain > should demonstrate full priority: CLI > getenv > --configuration > .lenv [4.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5278472Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --version option by calling .version(false) [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5292784Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --help option [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5302930Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with --version in strict mode [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5311112Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should handle --version with boolean type [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5321234Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow users to explicitly enable help [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5337133Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with multiple custom options including version [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5346338Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling built-in --version [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5356436Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling both --version and --help [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5365852Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow version with alias [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5376848Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow help with alias [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5386943Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should work with both built-in version/help and custom options [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5409261Z (pass) parseLinoArguments (legacy) > should parse simple links notation format [2.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5414339Z (pass) parseLinoArguments (legacy) > should parse arguments without parentheses [1.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5415921Z (pass) parseLinoArguments (legacy) > should handle empty input
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5416788Z (pass) parseLinoArguments (legacy) > should handle null input
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5421326Z (pass) parseLinoArguments (legacy) > should filter out comments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5421793Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5422535Z ##[endgroup]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5422730Z 
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5422878Z  58 pass
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5423174Z  0 fail
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5423576Z Ran 58 tests across 1 file. [92.00ms]
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5538889Z Post job cleanup.
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.7429160Z Post job cleanup.
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9109105Z Post job cleanup.
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0036559Z [command]/usr/bin/git version
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0073300Z git version 2.52.0
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0115993Z Temporarily overriding HOME='/home/runner/work/_temp/6c8e9eaa-3c63-4898-ace7-e9ce434440fb' before making global git config changes
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0117052Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0128216Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0162350Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0194294Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0425127Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0445688Z http.https://github.com/.extraheader
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0457732Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0487227Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0708027Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0739509Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:52.1062978Z Cleaning up orphan processes
+Test (node on ubuntu-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:41.9628527Z Current runner version: '2.330.0'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9653230Z ##[group]Runner Image Provisioner
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9654181Z Hosted Compute Agent
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9654711Z Version: 20251211.462
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9655364Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9656050Z Build Date: 2025-12-11T16:28:49Z
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9656656Z Worker ID: {e73ccc5e-da74-4116-97f6-9ed37ece1510}
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9657541Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9658074Z ##[group]Operating System
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9658630Z Ubuntu
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9659171Z 24.04.3
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9659587Z LTS
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9660029Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9660843Z ##[group]Runner Image
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9661388Z Image: ubuntu-24.04
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9661843Z Version: 20260105.202.1
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9662871Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9664420Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9665516Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9668546Z ##[group]GITHUB_TOKEN Permissions
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9671013Z Actions: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9671551Z ArtifactMetadata: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9672104Z Attestations: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9672560Z Checks: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9673131Z Contents: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9673585Z Deployments: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9674108Z Discussions: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9674667Z Issues: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9675113Z Metadata: read
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9675576Z Models: read
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9676075Z Packages: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9676563Z Pages: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9677042Z PullRequests: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9677916Z RepositoryProjects: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9678490Z SecurityEvents: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9678979Z Statuses: write
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9679517Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9682088Z Secret source: Actions
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9683035Z Prepare workflow directory
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.0098959Z Prepare all required actions
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.0135310Z Getting action download info
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.4880441Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.5876422Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6799179Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3440086Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.2228313Z Complete job name: Test (node on ubuntu-latest)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3108875Z ##[group]Run actions/checkout@v4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3110152Z with:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3110965Z   repository: link-foundation/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3112304Z   token: ***
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3113046Z   ssh-strict: true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3113829Z   ssh-user: git
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3114597Z   persist-credentials: true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3115452Z   clean: true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3116228Z   sparse-checkout-cone-mode: true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3117173Z   fetch-depth: 1
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3118084Z   fetch-tags: false
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3118852Z   show-progress: true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3119632Z   lfs: false
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3120345Z   submodules: false
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3121127Z   set-safe-directory: true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.3122251Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4214939Z Syncing repository: link-foundation/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4217703Z ##[group]Getting Git version info
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4219212Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4221189Z [command]/usr/bin/git version
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4266919Z git version 2.52.0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4293377Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4313810Z Temporarily overriding HOME='/home/runner/work/_temp/da0479b6-def1-4d4e-ab96-0299ff523402' before making global git config changes
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4316812Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4319813Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4354959Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4358380Z ##[group]Initializing the repository
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4362591Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4446748Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4449020Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4451445Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4452845Z hint: call:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4453525Z hint:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4454406Z hint: 	git config --global init.defaultBranch <name>
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4456093Z hint:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4457183Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4459065Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4460807Z hint:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4461560Z hint: 	git branch -m <name>
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4462412Z hint:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4463544Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4465599Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4468954Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4495753Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4497083Z ##[group]Disabling automatic garbage collection
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4499682Z [command]/usr/bin/git config --local gc.auto 0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4530197Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4532379Z ##[group]Setting up auth
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4537743Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4570727Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4870166Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.4901763Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.5121995Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.5153411Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.5375050Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.5408379Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.5409922Z ##[group]Fetching the repository
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.5417660Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1348936Z From https://github.com/link-foundation/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1349999Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1380579Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1381305Z ##[group]Determining the checkout info
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1383332Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1388143Z [command]/usr/bin/git sparse-checkout disable
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1426458Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1451169Z ##[group]Checking out the ref
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1455000Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1630926Z Switched to a new branch 'main'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1633703Z branch 'main' set up to track 'origin/main'.
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1640110Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1672820Z [command]/usr/bin/git log -1 --format=%H
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1694286Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1996502Z ##[group]Run actions/setup-node@v4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1996887Z with:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1997153Z   node-version: 20.x
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1997774Z   always-auth: false
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1998064Z   check-latest: false
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1998506Z   token: ***
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1998766Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3758880Z Found in cache @ /opt/hostedtoolcache/node/20.19.6/x64
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3764928Z ##[group]Environment details
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2189060Z node: v20.19.6
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2189666Z npm: 10.8.2
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2189906Z yarn: 1.22.22
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2190676Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2295382Z ##[group]Run npm install
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2295702Z [36;1mnpm install[0m
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2337891Z shell: /usr/bin/bash -e {0}
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2338148Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.7937821Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.7944363Z > lino-arguments@0.3.0 prepare
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.7944799Z > husky || true
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.7944953Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8372174Z .git can't be found
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8372916Z added 234 packages, and audited 235 packages in 4s
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8373399Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8373735Z 59 packages are looking for funding
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8374219Z   run `npm fund` for details
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8394446Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8394893Z 1 moderate severity vulnerability
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8395246Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8395548Z To address all issues, run:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8396007Z   npm audit fix
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8396249Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8396481Z Run `npm audit` for details.
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8589392Z ##[group]Run npm test
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8589674Z [36;1mnpm test[0m
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8621616Z shell: /usr/bin/bash -e {0}
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.8621859Z ##[endgroup]
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.9794705Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.9795375Z > lino-arguments@0.3.0 test
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.9795801Z > node --test tests/
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.9795964Z 
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.0174037Z TAP version 13
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1166821Z # 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1179183Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1202844Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1213453Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1248774Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1341370Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1356856Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1370819Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1377639Z # 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1394989Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1401510Z # 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1661542Z # Subtest: Case Conversion Utilities
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1663632Z     # Subtest: toUpperCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1666393Z         # Subtest: should convert camelCase to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1681156Z         ok 1 - should convert camelCase to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1682539Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1683110Z           duration_ms: 1.195082
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1684509Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1685055Z         # Subtest: should convert kebab-case to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1694232Z         ok 2 - should convert kebab-case to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1695184Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1695799Z           duration_ms: 0.225331
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1698357Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1698936Z         # Subtest: should convert snake_case to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1700562Z         ok 3 - should convert snake_case to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1701149Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1701562Z           duration_ms: 0.16617
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1701999Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1703393Z         # Subtest: should convert PascalCase to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1705046Z         ok 4 - should convert PascalCase to UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1706540Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1707458Z           duration_ms: 0.163615
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1707951Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1715788Z         # Subtest: should handle already UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1718148Z         ok 5 - should handle already UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1719010Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1719711Z           duration_ms: 0.147876
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1720389Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1727463Z         1..5
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1740617Z     ok 1 - toUpperCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1742432Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1743100Z       duration_ms: 2.677609
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1744283Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1745162Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1745883Z     # Subtest: toCamelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1746510Z         # Subtest: should convert kebab-case to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1747451Z         ok 1 - should convert kebab-case to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1748026Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1748891Z           duration_ms: 0.329625
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1749389Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1749904Z         # Subtest: should convert UPPER_CASE to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1750593Z         ok 2 - should convert UPPER_CASE to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1751153Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1751549Z           duration_ms: 0.156893
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1751952Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1752480Z         # Subtest: should convert snake_case to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1753185Z         ok 3 - should convert snake_case to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1753704Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1754101Z           duration_ms: 0.234668
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1754501Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1755042Z         # Subtest: should convert PascalCase to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1762843Z         ok 4 - should convert PascalCase to camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1763430Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1763840Z           duration_ms: 0.238104
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1764481Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1765104Z         # Subtest: should handle already camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1765752Z         ok 5 - should handle already camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1766270Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1766667Z           duration_ms: 0.181639
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1767086Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1767735Z         1..5
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1768120Z     ok 2 - toCamelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1768512Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1768860Z       duration_ms: 1.532051
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1769269Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1769609Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1797068Z     # Subtest: toKebabCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1828369Z         # Subtest: should convert camelCase to kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1867210Z         ok 1 - should convert camelCase to kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1868429Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1869128Z           duration_ms: 0.353049
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1869539Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1870051Z         # Subtest: should convert UPPER_CASE to kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1871068Z         ok 2 - should convert UPPER_CASE to kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1871602Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1871946Z           duration_ms: 0.285523
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1872308Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1872744Z         # Subtest: should convert PascalCase to kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1873363Z         ok 3 - should convert PascalCase to kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1873826Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1874175Z           duration_ms: 0.163074
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1874544Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1874949Z         # Subtest: should handle already kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1875558Z         ok 4 - should handle already kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1876058Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1876427Z           duration_ms: 0.145111
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1876820Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1877126Z         1..4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1897917Z     ok 3 - toKebabCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1898330Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1898682Z       duration_ms: 1.235617
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1899106Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1899526Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1899910Z     # Subtest: toSnakeCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1900478Z         # Subtest: should convert camelCase to snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1901154Z         ok 1 - should convert camelCase to snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1901704Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1902097Z           duration_ms: 0.272058
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1902481Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1902977Z         # Subtest: should convert kebab-case to snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1903642Z         ok 2 - should convert kebab-case to snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1904149Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1904527Z           duration_ms: 0.144751
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1904926Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1905415Z         # Subtest: should convert UPPER_CASE to snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1906205Z         ok 3 - should convert UPPER_CASE to snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1907081Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1907767Z           duration_ms: 0.125384
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1908171Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1908649Z         # Subtest: should handle already snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1909282Z         ok 4 - should handle already snake_case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1909760Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1910138Z           duration_ms: 0.265676
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1910536Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1910844Z         1..4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1911226Z     ok 4 - toSnakeCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1911582Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1911913Z       duration_ms: 1.029392
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1912317Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1912639Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1912970Z     # Subtest: toPascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1913524Z         # Subtest: should convert camelCase to PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1914214Z         ok 1 - should convert camelCase to PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1914729Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1915120Z           duration_ms: 0.240719
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1915583Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1916130Z         # Subtest: should convert kebab-case to PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1916823Z         ok 2 - should convert kebab-case to PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1917533Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1917942Z           duration_ms: 0.173735
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1918346Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1918844Z         # Subtest: should convert snake_case to PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1919518Z         ok 3 - should convert snake_case to PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1920042Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1920416Z           duration_ms: 0.134511
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1920814Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1921310Z         # Subtest: should handle already PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1921940Z         ok 4 - should handle already PascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1922436Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1922819Z           duration_ms: 0.789204
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1923214Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1923550Z         1..4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1924244Z     ok 5 - toPascalCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1961010Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1961372Z       duration_ms: 1.516722
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1961783Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1962104Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1962378Z     1..5
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1962787Z ok 1 - Case Conversion Utilities
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1963202Z   ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1963519Z   duration_ms: 9.055297
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1963877Z   type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1964192Z   ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1964499Z # Subtest: getenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1964958Z     # Subtest: should find variable in UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1965554Z     ok 1 - should find variable in UPPER_CASE
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1966007Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1966319Z       duration_ms: 0.448777
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1966683Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1967079Z     # Subtest: should find variable in camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1967856Z     ok 2 - should find variable in camelCase
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1968311Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1968628Z       duration_ms: 0.18711
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1968975Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1969364Z     # Subtest: should find variable in kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1969930Z     ok 3 - should find variable in kebab-case
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1970365Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1970672Z       duration_ms: 0.195805
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1971032Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1971485Z     # Subtest: should return default value when not found
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1972127Z     ok 4 - should return default value when not found
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1972599Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1972894Z       duration_ms: 0.149449
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1973248Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1973775Z     # Subtest: should return empty string as default when not specified
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1974581Z     ok 5 - should return empty string as default when not specified
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1975142Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1975439Z       duration_ms: 0.177481
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1976043Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1976458Z     # Subtest: should try original key first
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1976972Z     ok 6 - should try original key first
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1977607Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1977957Z       duration_ms: 0.191678
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1978318Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1978583Z     1..6
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1978863Z ok 2 - getenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1979144Z   ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1979436Z   duration_ms: 1.576985
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1979782Z   type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1980067Z   ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1985507Z # Subtest: makeConfig
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1991992Z     # Subtest: Hero Example (defaults)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1995047Z         # Subtest: should work with minimal configuration
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.1998234Z         ok 1 - should work with minimal configuration
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2000414Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2002230Z           duration_ms: 8.340242
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2004139Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2006106Z         # Subtest: should use CLI arguments with highest priority
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2008527Z         ok 2 - should use CLI arguments with highest priority
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2010541Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2012989Z           duration_ms: 2.471404
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2014987Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2016945Z         # Subtest: should convert kebab-case to camelCase in result
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2019302Z         ok 3 - should convert kebab-case to camelCase in result
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2021166Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2022942Z           duration_ms: 2.643375
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2024764Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2028751Z         1..3
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2029182Z     ok 1 - Hero Example (defaults)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2029638Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2029979Z       duration_ms: 13.614398
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2030396Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2030746Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2031188Z     # Subtest: Environment Loading Priority
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2031828Z         # Subtest: should load .lenv file by default
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2032776Z         ok 1 - should load .lenv file by default
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2033280Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2033675Z           duration_ms: 2.690464
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2034088Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2034564Z         # Subtest: should handle --configuration flag
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2035213Z         ok 2 - should handle --configuration flag
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2035673Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2036027Z           duration_ms: 3.736647
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2036364Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2036812Z         # Subtest: should prioritize CLI over environment
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2040413Z         ok 3 - should prioritize CLI over environment
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2041208Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2041646Z           duration_ms: 1.947456
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2042059Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2045849Z         # Subtest: should handle missing .lenv file gracefully
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2048976Z         ok 4 - should handle missing .lenv file gracefully
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2049826Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2050151Z           duration_ms: 1.426604
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2050491Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2052620Z         1..4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2056331Z     ok 2 - Environment Loading Priority
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2056766Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2057071Z       duration_ms: 10.000932
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2057641Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2057945Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2082405Z     # Subtest: Case Conversion in Environment Loading
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2083212Z         # Subtest: should convert all keys to UPPER_CASE in process.env
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2083999Z         ok 1 - should convert all keys to UPPER_CASE in process.env
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2084640Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2085008Z           duration_ms: 1.580521
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2085393Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2086186Z         # Subtest: should find env vars in any case format via getenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2086985Z         ok 2 - should find env vars in any case format via getenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2087789Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2109025Z           duration_ms: 2.20136
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2114361Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2114763Z         1..2
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2115292Z     ok 3 - Case Conversion in Environment Loading
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2115829Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2116221Z       duration_ms: 3.889542
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2116624Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2116976Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2117613Z     # Subtest: Configuration Options
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2118178Z         # Subtest: should support disabling lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2118767Z         ok 1 - should support disabling lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2119246Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2119644Z           duration_ms: 1.513165
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2120064Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2120633Z         # Subtest: should support enabling env/dotenvx (deprecated)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2121492Z         ok 2 - should support enabling env/dotenvx (deprecated)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2122124Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2122524Z           duration_ms: 2.176714
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2122924Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2123365Z         # Subtest: should support disabling getenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2123990Z         ok 3 - should support disabling getenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2124504Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2124893Z           duration_ms: 1.06048
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2125312Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2125799Z         # Subtest: should support configuration alias -c
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2126466Z         ok 4 - should support configuration alias -c
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2126962Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2127556Z           duration_ms: 1.746911
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2127974Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2128296Z         1..4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2128692Z     ok 4 - Configuration Options
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2129117Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2129474Z       duration_ms: 6.656527
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2130219Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2130568Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2130963Z     # Subtest: Complete Priority Chain
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2131855Z         # Subtest: should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2132996Z         ok 1 - should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2133760Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2134182Z           duration_ms: 6.160081
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2134608Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2135041Z         1..1
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2135487Z     ok 5 - Complete Priority Chain
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2135938Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2136285Z       duration_ms: 6.248476
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2136674Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2137003Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2137681Z     # Subtest: Built-in Flag Conflicts (Issue \#14)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2138581Z         # Subtest: should allow user-defined --version option by calling .version(false)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2139657Z         ok 1 - should allow user-defined --version option by calling .version(false)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2140372Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2140765Z           duration_ms: 1.55334
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2141215Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2141762Z         # Subtest: should allow user-defined --help option
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2142473Z         ok 2 - should allow user-defined --help option
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2142992Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2143319Z           duration_ms: 1.715552
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2143661Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2144102Z         # Subtest: should work with --version in strict mode
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2144701Z         ok 3 - should work with --version in strict mode
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2145163Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2145483Z           duration_ms: 1.703971
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2145829Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2146554Z         # Subtest: should handle --version with boolean type
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2147235Z         ok 4 - should handle --version with boolean type
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2147940Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2148277Z           duration_ms: 1.056733
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2148632Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2149070Z         # Subtest: should allow users to explicitly enable help
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2149715Z         ok 5 - should allow users to explicitly enable help
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2150186Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2150510Z           duration_ms: 1.15183
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2150860Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2151412Z         # Subtest: should work with multiple custom options including version
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2152206Z         ok 6 - should work with multiple custom options including version
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2152751Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2153072Z           duration_ms: 1.688502
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2153417Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2153689Z         1..6
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2154065Z     ok 6 - Built-in Flag Conflicts (Issue \#14)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2154502Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2154783Z       duration_ms: 9.101513
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2155136Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2155433Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2155891Z     # Subtest: Explicitly Enabling Built-in Version and Help
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2156615Z         # Subtest: should allow explicitly enabling built-in --version
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2157521Z         ok 1 - should allow explicitly enabling built-in --version
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2158050Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2158388Z           duration_ms: 1.295759
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2158733Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2159291Z         # Subtest: should allow explicitly enabling both --version and --help
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2160116Z         ok 2 - should allow explicitly enabling both --version and --help
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2160661Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2160992Z           duration_ms: 1.299616
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2161352Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2161740Z         # Subtest: should allow version with alias
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2162484Z         ok 3 - should allow version with alias
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2162920Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2163244Z           duration_ms: 1.251306
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2163592Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2169399Z         # Subtest: should allow help with alias
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2169970Z         ok 4 - should allow help with alias
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2170401Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2170761Z           duration_ms: 1.234033
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2171135Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2171698Z         # Subtest: should work with both built-in version/help and custom options
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2172530Z         ok 5 - should work with both built-in version/help and custom options
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2173126Z           ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2174264Z           duration_ms: 1.835156
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2174683Z           ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2174986Z         1..5
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2175513Z     ok 7 - Explicitly Enabling Built-in Version and Help
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2176068Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2176425Z       duration_ms: 7.105988
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2176775Z       type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2177054Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2177622Z     1..7
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2177985Z ok 3 - makeConfig
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2178274Z   ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2178526Z   duration_ms: 56.963212
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2178864Z   type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2179146Z   ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2188721Z # Subtest: parseLinoArguments (legacy)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2189366Z     # Subtest: should parse simple links notation format
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2190037Z     ok 1 - should parse simple links notation format
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2190547Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2190873Z       duration_ms: 1.859201
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2191244Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2191707Z     # Subtest: should parse arguments without parentheses
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2192390Z     ok 2 - should parse arguments without parentheses
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2193111Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2198483Z       duration_ms: 0.367406
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2198863Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2199241Z     # Subtest: should handle empty input
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2199750Z     ok 3 - should handle empty input
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2200154Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2200471Z       duration_ms: 0.195074
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2200832Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2201204Z     # Subtest: should handle null input
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2201695Z     ok 4 - should handle null input
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2202104Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2202402Z       duration_ms: 0.116718
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2202758Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2203113Z     # Subtest: should filter out comments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2203624Z     ok 5 - should filter out comments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2208120Z       ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2210440Z       duration_ms: 0.552913
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2210865Z       ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2212417Z     1..5
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2212992Z ok 4 - parseLinoArguments (legacy)
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2213545Z   ---
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2214034Z   duration_ms: 3.25096
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2215246Z   type: 'suite'
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2215561Z   ...
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2268763Z 1..4
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2269361Z # tests 58
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2270364Z # suites 16
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2270945Z # pass 58
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2271554Z # fail 0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2272125Z # cancelled 0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2272620Z # skipped 0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2273676Z # todo 0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2274824Z # duration_ms 220.156419
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.2512534Z Post job cleanup.
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4192450Z Post job cleanup.
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5142891Z [command]/usr/bin/git version
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5181227Z git version 2.52.0
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5225679Z Temporarily overriding HOME='/home/runner/work/_temp/e8bc1a10-65b2-41f1-806a-04b569ecd650' before making global git config changes
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5226564Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5238959Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5275119Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5309086Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5548069Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5570726Z http.https://github.com/.extraheader
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5583112Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5613996Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5836458Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5868396Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:51.6198529Z Cleaning up orphan processes
+Test (node on windows-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:41.5660852Z Current runner version: '2.330.0'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5688314Z ##[group]Runner Image Provisioner
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5689093Z Hosted Compute Agent
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5689578Z Version: 20251211.462
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5690142Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5690761Z Build Date: 2025-12-11T16:28:49Z
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5691395Z Worker ID: {640bdd1e-ef9d-44d6-9d9a-b6b23f3af734}
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5692031Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5692479Z ##[group]Operating System
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5693053Z Microsoft Windows Server 2025
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5693544Z 10.0.26100
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5694263Z Datacenter
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5694697Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5695160Z ##[group]Runner Image
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5695616Z Image: windows-2025
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5696123Z Version: 20260105.172.1
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5697330Z Included Software: https://github.com/actions/runner-images/blob/win25/20260105.172/images/windows/Windows2025-Readme.md
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5698774Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20260105.172
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5699623Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5702179Z ##[group]GITHUB_TOKEN Permissions
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5704457Z Actions: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5704991Z ArtifactMetadata: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5705528Z Attestations: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5706052Z Checks: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5706516Z Contents: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5706988Z Deployments: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5707703Z Discussions: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5708173Z Issues: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5708632Z Metadata: read
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5709042Z Models: read
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5709481Z Packages: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5709934Z Pages: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5710423Z PullRequests: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5710986Z RepositoryProjects: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5711522Z SecurityEvents: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5712037Z Statuses: write
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5712468Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5714842Z Secret source: Actions
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.5716245Z Prepare workflow directory
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6173023Z Prepare all required actions
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.6210371Z Getting action download info
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.8627709Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:41.9884633Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.1512926Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.4482590Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.8045287Z Complete job name: Test (node on windows-latest)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9333841Z ##[group]Run actions/checkout@v4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9334771Z with:
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9335168Z   repository: link-foundation/lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9335813Z   token: ***
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9336177Z   ssh-strict: true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9336517Z   ssh-user: git
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9336869Z   persist-credentials: true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9337261Z   clean: true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9337663Z   sparse-checkout-cone-mode: true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9338086Z   fetch-depth: 1
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9338414Z   fetch-tags: false
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9338762Z   show-progress: true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9339102Z   lfs: false
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9339412Z   submodules: false
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9339756Z   set-safe-directory: true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9340350Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.1010400Z Syncing repository: link-foundation/lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.1012279Z ##[group]Getting Git version info
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.1012960Z Working directory is 'D:\a\lino-arguments\lino-arguments'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.2110997Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5829277Z git version 2.52.0.windows.1
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5889301Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5916220Z Temporarily overriding HOME='D:\a\_temp\d59a79e9-ff7b-49d1-8fa4-9a8aa8b40374' before making global git config changes
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5919098Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.5930639Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.6548164Z Deleting the contents of 'D:\a\lino-arguments\lino-arguments'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.6555541Z ##[group]Initializing the repository
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.6566324Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-arguments\lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.7472294Z Initialized empty Git repository in D:/a/lino-arguments/lino-arguments/.git/
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.7521667Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8032905Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8033656Z ##[group]Disabling automatic garbage collection
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8042526Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8328957Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8329624Z ##[group]Setting up auth
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8343000Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:43.8639596Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:45.2270189Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:45.2558187Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7657377Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7956985Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3032655Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3336153Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3336637Z ##[group]Fetching the repository
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3350043Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3851513Z From https://github.com/link-foundation/lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3852598Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4199855Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4200692Z ##[group]Determining the checkout info
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4203457Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4214229Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4645754Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4950800Z ##[group]Checking out the ref
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.4963600Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.5955853Z branch 'main' set up to track 'origin/main'.
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.5965282Z Switched to a new branch 'main'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.6004902Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.6412855Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.6690945Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7110689Z ##[group]Run actions/setup-node@v4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7110984Z with:
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7112109Z   node-version: 20.x
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7112298Z   always-auth: false
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7112484Z   check-latest: false
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7112791Z   token: ***
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.7113177Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.9703774Z Found in cache @ C:\hostedtoolcache\windows\node\20.19.6\x64
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.9715965Z ##[group]Environment details
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.8827190Z node: v20.19.6
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.8827524Z npm: 10.8.2
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.8827763Z yarn: 1.22.22
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.8829386Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9108169Z ##[group]Run npm install
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9108486Z [36;1mnpm install[0m
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9727019Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9727412Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7659515Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7665852Z > lino-arguments@0.3.0 prepare
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7666213Z > husky || true
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7666331Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8549374Z .git can't be found
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8549913Z added 234 packages, and audited 235 packages in 6s
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8550546Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8551018Z 59 packages are looking for funding
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8551396Z   run `npm fund` for details
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8573665Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8574415Z 1 moderate severity vulnerability
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8575143Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8575368Z To address all issues, run:
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8575787Z   npm audit fix
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8575974Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8576138Z Run `npm audit` for details.
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4837220Z ##[group]Run npm test
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4837494Z [36;1mnpm test[0m
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4906577Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4906900Z ##[endgroup]
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0912568Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0913025Z > lino-arguments@0.3.0 test
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0913348Z > node --test tests/
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0913486Z 
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2102956Z TAP version 13
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3737901Z # 📝 Loaded 2 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3759038Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3782694Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3806416Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3860571Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4002826Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4030815Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4052744Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4063690Z # 📝 Loaded 2 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4077576Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4089295Z # 📝 Loaded 2 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4400390Z # Subtest: Case Conversion Utilities
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4402135Z     # Subtest: toUpperCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4412183Z         # Subtest: should convert camelCase to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4446300Z         ok 1 - should convert camelCase to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4447187Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4447768Z           duration_ms: 1.4593
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4448342Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4448991Z         # Subtest: should convert kebab-case to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4449848Z         ok 2 - should convert kebab-case to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4450557Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4451048Z           duration_ms: 0.2877
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4452047Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4460533Z         # Subtest: should convert snake_case to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4461861Z         ok 3 - should convert snake_case to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4462681Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4463335Z           duration_ms: 0.1854
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4470426Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4471139Z         # Subtest: should convert PascalCase to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4472054Z         ok 4 - should convert PascalCase to UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4472898Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4473214Z           duration_ms: 0.1824
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4473566Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4473961Z         # Subtest: should handle already UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4474532Z         ok 5 - should handle already UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4474961Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4475845Z           duration_ms: 0.17
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4479859Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4480173Z         1..5
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4480495Z     ok 1 - toUpperCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4480810Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4481092Z       duration_ms: 3.1722
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4481565Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4481854Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4482191Z     # Subtest: toCamelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4516720Z         # Subtest: should convert kebab-case to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4517644Z         ok 1 - should convert kebab-case to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4518354Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4723098Z           duration_ms: 0.4419
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4723698Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4724417Z         # Subtest: should convert UPPER_CASE to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4728789Z         ok 2 - should convert UPPER_CASE to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4729511Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4730007Z           duration_ms: 0.1728
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4730500Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4731045Z         # Subtest: should convert snake_case to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4731924Z         ok 3 - should convert snake_case to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4759428Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4772603Z           duration_ms: 0.8586
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4773218Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4773855Z         # Subtest: should convert PascalCase to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4795549Z         ok 4 - should convert PascalCase to camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4796886Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4797965Z           duration_ms: 0.241
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4801212Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4801627Z         # Subtest: should handle already camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4802204Z         ok 5 - should handle already camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4802617Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4803168Z           duration_ms: 0.1976
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4803478Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4803705Z         1..5
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4803941Z     ok 2 - toCamelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4804214Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4804466Z       duration_ms: 2.4054
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4804750Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4804989Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4805219Z     # Subtest: toKebabCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4815284Z         # Subtest: should convert camelCase to kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4817298Z         ok 1 - should convert camelCase to kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4817736Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4818122Z           duration_ms: 0.3701
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4818427Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4818830Z         # Subtest: should convert UPPER_CASE to kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4819400Z         ok 2 - should convert UPPER_CASE to kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4819824Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4823254Z           duration_ms: 0.2723
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4823679Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4824085Z         # Subtest: should convert PascalCase to kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4824680Z         ok 3 - should convert PascalCase to kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4825478Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4825776Z           duration_ms: 0.1752
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4826115Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4826485Z         # Subtest: should handle already kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4827138Z         ok 4 - should handle already kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4827570Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4827845Z           duration_ms: 0.1516
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4828162Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4837257Z         1..4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4837589Z     ok 3 - toKebabCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4837918Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4838183Z       duration_ms: 1.2574
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4838516Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4838782Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4839040Z     # Subtest: toSnakeCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4839511Z         # Subtest: should convert camelCase to snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4840095Z         ok 1 - should convert camelCase to snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4840549Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4840836Z           duration_ms: 0.2925
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4841171Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4841574Z         # Subtest: should convert kebab-case to snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4842269Z         ok 2 - should convert kebab-case to snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4842718Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4842992Z           duration_ms: 0.1562
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4843309Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4843724Z         # Subtest: should convert UPPER_CASE to snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4845406Z         ok 3 - should convert UPPER_CASE to snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4845934Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4846221Z           duration_ms: 0.1771
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4846547Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4846914Z         # Subtest: should handle already snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4847825Z         ok 4 - should handle already snake_case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4848250Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4848803Z           duration_ms: 0.2888
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4849162Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4849712Z         1..4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4850021Z     ok 4 - toSnakeCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4850319Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4850579Z       duration_ms: 1.125
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4850894Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4851678Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4851955Z     # Subtest: toPascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4852429Z         # Subtest: should convert camelCase to PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4853863Z         ok 1 - should convert camelCase to PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4854334Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4854612Z           duration_ms: 0.2915
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4854937Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4855649Z         # Subtest: should convert kebab-case to PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4856255Z         ok 2 - should convert kebab-case to PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4856708Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4856980Z           duration_ms: 0.189
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4857301Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4857996Z         # Subtest: should convert snake_case to PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4858879Z         ok 3 - should convert snake_case to PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4859335Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4859598Z           duration_ms: 0.1557
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4859927Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4874485Z         # Subtest: should handle already PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4875039Z         ok 4 - should handle already PascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4875451Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4875725Z           duration_ms: 0.132
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4876050Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4876294Z         1..4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4876535Z     ok 5 - toPascalCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4876828Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4877397Z       duration_ms: 0.9417
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4877703Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4878183Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4878398Z     1..5
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4878713Z ok 1 - Case Conversion Utilities
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4879224Z   ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4880776Z   duration_ms: 10.1451
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4881349Z   type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4881606Z   ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4881857Z # Subtest: getenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4882439Z     # Subtest: should find variable in UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4883169Z     ok 1 - should find variable in UPPER_CASE
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4883619Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4883875Z       duration_ms: 0.6925
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4884159Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4884680Z     # Subtest: should find variable in camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4885207Z     ok 2 - should find variable in camelCase
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4885810Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4886065Z       duration_ms: 0.2455
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4886517Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4886848Z     # Subtest: should find variable in kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4887346Z     ok 3 - should find variable in kebab-case
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4887916Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4888151Z       duration_ms: 0.2851
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4888420Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4888998Z     # Subtest: should return default value when not found
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4889760Z     ok 4 - should return default value when not found
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4890189Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4890633Z       duration_ms: 0.2009
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4890930Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4891407Z     # Subtest: should return empty string as default when not specified
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4892155Z     ok 5 - should return empty string as default when not specified
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4892877Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4893144Z       duration_ms: 0.1853
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4893435Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4894226Z     # Subtest: should try original key first
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4894885Z     ok 6 - should try original key first
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4895253Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4895493Z       duration_ms: 0.2291
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4895804Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4896022Z     1..6
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4896242Z ok 2 - getenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4896489Z   ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4896725Z   duration_ms: 2.0953
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4897000Z   type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4897239Z   ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4897481Z # Subtest: makeConfig
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4897824Z     # Subtest: Hero Example (defaults)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4898336Z         # Subtest: should work with minimal configuration
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4898908Z         ok 1 - should work with minimal configuration
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4899344Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4899647Z           duration_ms: 11.8585
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4899953Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4900377Z         # Subtest: should use CLI arguments with highest priority
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4901018Z         ok 2 - should use CLI arguments with highest priority
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4901478Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4901738Z           duration_ms: 3.2126
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4902043Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4902761Z         # Subtest: should convert kebab-case to camelCase in result
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4903435Z         ok 3 - should convert kebab-case to camelCase in result
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4903884Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4904148Z           duration_ms: 2.3946
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4904448Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4904690Z         1..3
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4904987Z     ok 1 - Hero Example (defaults)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4905323Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4905569Z       duration_ms: 17.6896
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4905861Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4908183Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4908546Z     # Subtest: Environment Loading Priority
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4909070Z         # Subtest: should load .lenv file by default
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4909576Z         ok 1 - should load .lenv file by default
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4909960Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4910208Z           duration_ms: 3.9083
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4910531Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4910891Z         # Subtest: should handle --configuration flag
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4912122Z         ok 2 - should handle --configuration flag
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4912551Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4912813Z           duration_ms: 4.9702
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4913131Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4918865Z         # Subtest: should prioritize CLI over environment
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4919529Z         ok 3 - should prioritize CLI over environment
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4919965Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4920225Z           duration_ms: 2.6113
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4920552Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4920962Z         # Subtest: should handle missing .lenv file gracefully
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4921554Z         ok 4 - should handle missing .lenv file gracefully
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4921988Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4922246Z           duration_ms: 2.6652
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4922538Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4922764Z         1..4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4923073Z     ok 2 - Environment Loading Priority
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4923473Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4923739Z       duration_ms: 14.3544
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4924050Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4924313Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4924673Z     # Subtest: Case Conversion in Environment Loading
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4925344Z         # Subtest: should convert all keys to UPPER_CASE in process.env
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4926868Z         ok 1 - should convert all keys to UPPER_CASE in process.env
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4927722Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4928021Z           duration_ms: 2.6346
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4928611Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4929089Z         # Subtest: should find env vars in any case format via getenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4929774Z         ok 2 - should find env vars in any case format via getenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4930237Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4930495Z           duration_ms: 2.2681
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4930802Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4931025Z         1..2
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4931374Z     ok 3 - Case Conversion in Environment Loading
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4931809Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4932050Z       duration_ms: 5.0209
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4932360Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4932612Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4932911Z     # Subtest: Configuration Options
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4933384Z         # Subtest: should support disabling lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4934263Z         ok 1 - should support disabling lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4934687Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4934966Z           duration_ms: 2.38
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4935280Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4935729Z         # Subtest: should support enabling env/dotenvx (deprecated)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4936431Z         ok 2 - should support enabling env/dotenvx (deprecated)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4936895Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4937162Z           duration_ms: 3.6403
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4937470Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4937811Z         # Subtest: should support disabling getenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4938321Z         ok 3 - should support disabling getenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4938705Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4938962Z           duration_ms: 2.1504
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4939268Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4939642Z         # Subtest: should support configuration alias -c
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4940214Z         ok 4 - should support configuration alias -c
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4940640Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4940887Z           duration_ms: 2.7693
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4941192Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4941426Z         1..4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4941723Z     ok 4 - Configuration Options
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4942059Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4942307Z       duration_ms: 11.1393
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4942634Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4942895Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4943200Z     # Subtest: Complete Priority Chain
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4943957Z         # Subtest: should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4945173Z         ok 1 - should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4945846Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4946106Z           duration_ms: 9.1799
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4946419Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4946651Z         1..1
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4946961Z     ok 5 - Complete Priority Chain
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4947308Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4947557Z       duration_ms: 9.3246
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4948194Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4948446Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4948795Z     # Subtest: Built-in Flag Conflicts (Issue \#14)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4949510Z         # Subtest: should allow user-defined --version option by calling .version(false)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4950428Z         ok 1 - should allow user-defined --version option by calling .version(false)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4951027Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4951292Z           duration_ms: 2.1603
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4952114Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4952624Z         # Subtest: should allow user-defined --help option
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4953198Z         ok 2 - should allow user-defined --help option
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4953618Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4953876Z           duration_ms: 1.8835
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4954190Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4954580Z         # Subtest: should work with --version in strict mode
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4955147Z         ok 3 - should work with --version in strict mode
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4955574Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4956622Z           duration_ms: 1.8127
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4957001Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4957404Z         # Subtest: should handle --version with boolean type
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4957980Z         ok 4 - should handle --version with boolean type
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4958390Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4958672Z           duration_ms: 1.5515
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4958986Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4959400Z         # Subtest: should allow users to explicitly enable help
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4960032Z         ok 5 - should allow users to explicitly enable help
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4960469Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4960716Z           duration_ms: 1.4537
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4961000Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4961453Z         # Subtest: should work with multiple custom options including version
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4962223Z         ok 6 - should work with multiple custom options including version
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4962731Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4962994Z           duration_ms: 2.0655
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4963298Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4963532Z         1..6
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4963871Z     ok 6 - Built-in Flag Conflicts (Issue \#14)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4964267Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4964513Z       duration_ms: 11.1715
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4964813Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4965065Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4965470Z     # Subtest: Explicitly Enabling Built-in Version and Help
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4966155Z         # Subtest: should allow explicitly enabling built-in --version
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4966845Z         ok 1 - should allow explicitly enabling built-in --version
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4967322Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4967571Z           duration_ms: 1.6183
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4967879Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4968364Z         # Subtest: should allow explicitly enabling both --version and --help
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4969152Z         ok 2 - should allow explicitly enabling both --version and --help
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4969672Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4969921Z           duration_ms: 2.3229
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4970227Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4970560Z         # Subtest: should allow version with alias
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4971046Z         ok 3 - should allow version with alias
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4971433Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4971689Z           duration_ms: 1.6232
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4972351Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4972941Z         # Subtest: should allow help with alias
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4973373Z         ok 4 - should allow help with alias
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4973736Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4973982Z           duration_ms: 1.5409
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4974288Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4974817Z         # Subtest: should work with both built-in version/help and custom options
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4975618Z         ok 5 - should work with both built-in version/help and custom options
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4976146Z           ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4976430Z           duration_ms: 1.6395
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4976753Z           ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4976996Z         1..5
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4977396Z     ok 7 - Explicitly Enabling Built-in Version and Help
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.4991997Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5017978Z       duration_ms: 8.9335
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5018348Z       type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5018623Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5018849Z     1..7
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5019216Z ok 3 - makeConfig
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5019480Z   ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5019725Z   duration_ms: 78.4546
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5020005Z   type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5020247Z   ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5020584Z # Subtest: parseLinoArguments (legacy)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5021123Z     # Subtest: should parse simple links notation format
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5021698Z     ok 1 - should parse simple links notation format
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5022124Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5022371Z       duration_ms: 2.6292
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5022891Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5023269Z     # Subtest: should parse arguments without parentheses
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5023832Z     ok 2 - should parse arguments without parentheses
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5024246Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5024745Z       duration_ms: 0.5905
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5038678Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5039105Z     # Subtest: should handle empty input
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5039573Z     ok 3 - should handle empty input
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5040070Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5040316Z       duration_ms: 0.2562
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5040611Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5040908Z     # Subtest: should handle null input
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5041347Z     ok 4 - should handle null input
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5041704Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5041939Z       duration_ms: 0.1173
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5042229Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5042523Z     # Subtest: should filter out comments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5042979Z     ok 5 - should filter out comments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5043339Z       ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5043575Z       duration_ms: 0.6319
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5043876Z       ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5044106Z     1..5
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5044433Z ok 4 - parseLinoArguments (legacy)
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5044801Z   ---
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5045032Z   duration_ms: 4.4067
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5045311Z   type: 'suite'
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5045542Z   ...
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5184150Z 1..4
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5184552Z # tests 58
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5184967Z # suites 16
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5186060Z # pass 58
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5186403Z # fail 0
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5186662Z # cancelled 0
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5187417Z # skipped 0
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5187685Z # todo 0
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5193213Z # duration_ms 328.9445
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.6751490Z Post job cleanup.
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9164390Z Post job cleanup.
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1460992Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1734330Z git version 2.52.0.windows.1
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1812641Z Temporarily overriding HOME='D:\a\_temp\ae703387-5854-428c-91ca-c5383da3e32a' before making global git config changes
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1813463Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1824317Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2128810Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2445659Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.8151439Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.8401498Z http.https://github.com/.extraheader
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.8448882Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.8745998Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:06.3986769Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4282361Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (node on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:06.9553388Z Cleaning up orphan processes
+Test (node on macos-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:42.9805540Z Current runner version: '2.330.0'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9824580Z ##[group]Runner Image Provisioner
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9825200Z Hosted Compute Agent
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9825540Z Version: 20251211.462
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9825910Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9826340Z Build Date: 2025-12-11T16:28:49Z
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9826740Z Worker ID: {e77191a1-6b1f-475f-bd9e-6de88bd9aa94}
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9827160Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9827490Z ##[group]Operating System
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9827850Z macOS
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9828140Z 15.7.3
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9828410Z 24G419
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9828710Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9829010Z ##[group]Runner Image
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9829350Z Image: macos-15-arm64
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9829670Z Version: 20260112.0107.1
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9830390Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260112.0107/images/macos/macos-15-arm64-Readme.md
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9831500Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260112.0107
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9832130Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9833950Z ##[group]GITHUB_TOKEN Permissions
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9838200Z Actions: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9839270Z ArtifactMetadata: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9844050Z Attestations: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9844380Z Checks: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9844680Z Contents: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9845000Z Deployments: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9845320Z Discussions: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9845650Z Issues: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9846000Z Metadata: read
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9846400Z Models: read
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9846710Z Packages: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9847040Z Pages: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9847340Z PullRequests: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9849210Z RepositoryProjects: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9849690Z SecurityEvents: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9850040Z Statuses: write
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9850360Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9852700Z Secret source: Actions
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:42.9853110Z Prepare workflow directory
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:43.0473560Z Prepare all required actions
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:43.0539720Z Getting action download info
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:43.6068230Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:43.9147760Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:44.0238700Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:44.6952500Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.6718520Z Complete job name: Test (node on macos-latest)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7300490Z ##[group]Run actions/checkout@v4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7301290Z with:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7301830Z   repository: link-foundation/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7302790Z   token: ***
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7303270Z   ssh-strict: true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7303780Z   ssh-user: git
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7304290Z   persist-credentials: true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7304850Z   clean: true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7305370Z   sparse-checkout-cone-mode: true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7306090Z   fetch-depth: 1
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7306580Z   fetch-tags: false
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7307110Z   show-progress: true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7307630Z   lfs: false
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7308110Z   submodules: false
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7308620Z   set-safe-directory: true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:45.7309310Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1719060Z Syncing repository: link-foundation/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1721860Z ##[group]Getting Git version info
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1723570Z Working directory is '/Users/runner/work/lino-arguments/lino-arguments'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.1724940Z [command]/opt/homebrew/bin/git version
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2142610Z git version 2.52.0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2199510Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2231360Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/8a06505f-aaea-4eab-b912-bb9ff6e48633/.gitconfig'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2239720Z Temporarily overriding HOME='/Users/runner/work/_temp/8a06505f-aaea-4eab-b912-bb9ff6e48633' before making global git config changes
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2242320Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2250210Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2431600Z Deleting the contents of '/Users/runner/work/lino-arguments/lino-arguments'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2434330Z ##[group]Initializing the repository
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2445280Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-arguments/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2760080Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2761660Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2771120Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2776180Z hint: call:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2777130Z hint:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2777880Z hint: 	git config --global init.defaultBranch <name>
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2778620Z hint:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2779330Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2780520Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2781990Z hint:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2782480Z hint: 	git branch -m <name>
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2783040Z hint:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2783860Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2785180Z Initialized empty Git repository in /Users/runner/work/lino-arguments/lino-arguments/.git/
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2794020Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2903760Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2906290Z ##[group]Disabling automatic garbage collection
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2910640Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3001180Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3007270Z ##[group]Setting up auth
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3013330Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.3090820Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.4412070Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.4495850Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.5444190Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.5514370Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.6385440Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.6463200Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.6464120Z ##[group]Fetching the repository
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:46.6469420Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2311290Z From https://github.com/link-foundation/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2314560Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2483930Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2485940Z ##[group]Determining the checkout info
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2488060Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2491900Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2617710Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2707360Z ##[group]Checking out the ref
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.2708720Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3099810Z Switched to a new branch 'main'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3109590Z branch 'main' set up to track 'origin/main'.
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3117320Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3265820Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3393230Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3764140Z ##[group]Run actions/setup-node@v4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3764620Z with:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3764970Z   node-version: 20.x
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3765390Z   always-auth: false
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3765780Z   check-latest: false
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3766360Z   token: ***
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.3766730Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.5705380Z Found in cache @ /Users/runner/hostedtoolcache/node/20.19.6/arm64
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:47.5706930Z ##[group]Environment details
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.2843480Z node: v20.19.6
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.2847800Z npm: 10.8.2
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.2849370Z yarn: 1.22.22
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.2865670Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.3029930Z ##[group]Run npm install
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.3030300Z [36;1mnpm install[0m
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.3077660Z shell: /bin/bash -e {0}
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:48.3077960Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4789430Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4807710Z > lino-arguments@0.3.0 prepare
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4808290Z > husky || true
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4808420Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5484680Z .git can't be found
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5485880Z added 234 packages, and audited 235 packages in 3s
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5486100Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5486270Z 59 packages are looking for funding
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5486600Z   run `npm fund` for details
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5522840Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5524920Z 1 moderate severity vulnerability
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5525500Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5525850Z To address all issues, run:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5526230Z   npm audit fix
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5526620Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5527020Z Run `npm audit` for details.
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5709630Z ##[group]Run npm test
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5738220Z [36;1mnpm test[0m
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5787040Z shell: /bin/bash -e {0}
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5787370Z ##[endgroup]
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.7914660Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.7915560Z > lino-arguments@0.3.0 test
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.7916300Z > node --test tests/
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.7916620Z 
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.8401220Z TAP version 13
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9386100Z # 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9488510Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9595890Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9701740Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9837720Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.9952270Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0062460Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0172110Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0199800Z # 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0244800Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0246930Z # 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0250530Z # Subtest: Case Conversion Utilities
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0251020Z     # Subtest: toUpperCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0251860Z         # Subtest: should convert camelCase to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0252310Z         ok 1 - should convert camelCase to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0252720Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0253060Z           duration_ms: 0.840458
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0253300Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0253720Z         # Subtest: should convert kebab-case to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0254170Z         ok 2 - should convert kebab-case to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0254430Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0254610Z           duration_ms: 0.174833
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0254890Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0255210Z         # Subtest: should convert snake_case to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0255630Z         ok 3 - should convert snake_case to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0255860Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0256170Z           duration_ms: 0.073584
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0256370Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0256630Z         # Subtest: should convert PascalCase to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0257040Z         ok 4 - should convert PascalCase to UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0257250Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0257490Z           duration_ms: 0.073042
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0257730Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0258010Z         # Subtest: should handle already UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0258330Z         ok 5 - should handle already UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0258770Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0259060Z           duration_ms: 0.062625
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0259300Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0259570Z         1..5
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0259810Z     ok 1 - toUpperCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0260010Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0260200Z       duration_ms: 1.943541
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0260570Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0260720Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0260870Z     # Subtest: toCamelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0261140Z         # Subtest: should convert kebab-case to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0261460Z         ok 1 - should convert kebab-case to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0261680Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0262550Z           duration_ms: 0.188042
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0262840Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0263110Z         # Subtest: should convert UPPER_CASE to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0263510Z         ok 2 - should convert UPPER_CASE to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0263730Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0263910Z           duration_ms: 0.060834
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0264080Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0264330Z         # Subtest: should convert snake_case to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0264650Z         ok 3 - should convert snake_case to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0264870Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0265050Z           duration_ms: 0.074708
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0265230Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0265470Z         # Subtest: should convert PascalCase to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0265800Z         ok 4 - should convert PascalCase to camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0266020Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0266260Z           duration_ms: 0.308209
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0266480Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0266730Z         # Subtest: should handle already camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0267040Z         ok 5 - should handle already camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0267310Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0267570Z           duration_ms: 0.0765
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0267820Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0267990Z         1..5
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0268130Z     ok 2 - toCamelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0268290Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0268450Z       duration_ms: 0.929959
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0268620Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0268770Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0268940Z     # Subtest: toKebabCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0269200Z         # Subtest: should convert camelCase to kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0269730Z         ok 1 - should convert camelCase to kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0269970Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0270140Z           duration_ms: 0.15975
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0270310Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0270540Z         # Subtest: should convert UPPER_CASE to kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0270880Z         ok 2 - should convert UPPER_CASE to kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0271140Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0271370Z           duration_ms: 0.147042
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0271660Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0271900Z         # Subtest: should convert PascalCase to kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0272220Z         ok 3 - should convert PascalCase to kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0272570Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0272790Z           duration_ms: 0.061625
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0273040Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0273280Z         # Subtest: should handle already kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0273560Z         ok 4 - should handle already kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0273780Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0273960Z           duration_ms: 0.077792
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0274140Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0274330Z         1..4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0274620Z     ok 3 - toKebabCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0274840Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0275070Z       duration_ms: 0.581959
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0275270Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0275430Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0275630Z     # Subtest: toSnakeCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0275970Z         # Subtest: should convert camelCase to snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0276370Z         ok 1 - should convert camelCase to snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0276630Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0276880Z           duration_ms: 0.163583
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0277120Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0277380Z         # Subtest: should convert kebab-case to snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0277740Z         ok 2 - should convert kebab-case to snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0277980Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0278260Z           duration_ms: 1.362083
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0278430Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0278670Z         # Subtest: should convert UPPER_CASE to snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0278990Z         ok 3 - should convert UPPER_CASE to snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0279490Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0279710Z           duration_ms: 0.237458
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0279900Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0280110Z         # Subtest: should handle already snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0281330Z         ok 4 - should handle already snake_case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0281990Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0282220Z           duration_ms: 0.443042
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0282460Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0282660Z         1..4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0282920Z     ok 4 - toSnakeCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0283080Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0283230Z       duration_ms: 2.40025
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0283410Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0283550Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0283770Z     # Subtest: toPascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0284180Z         # Subtest: should convert camelCase to PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0284490Z         ok 1 - should convert camelCase to PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0284710Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0284900Z           duration_ms: 0.42225
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0285080Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0285310Z         # Subtest: should convert kebab-case to PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0285640Z         ok 2 - should convert kebab-case to PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0285870Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0286060Z           duration_ms: 0.251083
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0286230Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0286470Z         # Subtest: should convert snake_case to PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0286800Z         ok 3 - should convert snake_case to PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0287020Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0287210Z           duration_ms: 0.166041
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0287380Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0287600Z         # Subtest: should handle already PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0288180Z         ok 4 - should handle already PascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0288390Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0288580Z           duration_ms: 0.145375
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0288810Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0288990Z         1..4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0289140Z     ok 5 - toPascalCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0289300Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0289460Z       duration_ms: 1.21925
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0289640Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0289790Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0289920Z     1..5
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0290130Z ok 1 - Case Conversion Utilities
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0290330Z   ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0290480Z   duration_ms: 7.979166
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0290660Z   type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0290820Z   ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0290960Z # Subtest: getenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0291220Z     # Subtest: should find variable in UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0291550Z     ok 1 - should find variable in UPPER_CASE
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0291760Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0291920Z       duration_ms: 0.772875
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0293050Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0293340Z     # Subtest: should find variable in camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0293690Z     ok 2 - should find variable in camelCase
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0293910Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0294090Z       duration_ms: 0.330084
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0294290Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0294730Z     # Subtest: should find variable in kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0295050Z     ok 3 - should find variable in kebab-case
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0295260Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0295420Z       duration_ms: 0.223542
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0295610Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0295850Z     # Subtest: should return default value when not found
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0296190Z     ok 4 - should return default value when not found
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0296430Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0296580Z       duration_ms: 0.493666
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0296750Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0297050Z     # Subtest: should return empty string as default when not specified
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0297520Z     ok 5 - should return empty string as default when not specified
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0297780Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0297930Z       duration_ms: 0.095958
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0298350Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0298570Z     # Subtest: should try original key first
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0298840Z     ok 6 - should try original key first
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299050Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299200Z       duration_ms: 0.0955
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299360Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299500Z     1..6
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299630Z ok 2 - getenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299820Z   ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0299990Z   duration_ms: 2.270667
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0300170Z   type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0300310Z   ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0300480Z # Subtest: makeConfig
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0300700Z     # Subtest: Hero Example (defaults)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0301010Z         # Subtest: should work with minimal configuration
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0301360Z         ok 1 - should work with minimal configuration
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0301580Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0301770Z           duration_ms: 9.16025
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0301960Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0302230Z         # Subtest: should use CLI arguments with highest priority
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0302600Z         ok 2 - should use CLI arguments with highest priority
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0302840Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0303060Z           duration_ms: 3.964708
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0303240Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0303520Z         # Subtest: should convert kebab-case to camelCase in result
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0303920Z         ok 3 - should convert kebab-case to camelCase in result
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0304160Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0304340Z           duration_ms: 2.435584
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0304530Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0304670Z         1..3
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0304860Z     ok 1 - Hero Example (defaults)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0305240Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0305400Z       duration_ms: 15.690375
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0305580Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0305750Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0305950Z     # Subtest: Environment Loading Priority
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0306250Z         # Subtest: should load .lenv file by default
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0306550Z         ok 1 - should load .lenv file by default
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0306790Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0306960Z           duration_ms: 2.622
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0307140Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0307420Z         # Subtest: should handle --configuration flag
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0307740Z         ok 2 - should handle --configuration flag
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0307970Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0308150Z           duration_ms: 3.693375
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0308320Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0308630Z         # Subtest: should prioritize CLI over environment
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0308950Z         ok 3 - should prioritize CLI over environment
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0309180Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0309370Z           duration_ms: 3.889666
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0309540Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0309800Z         # Subtest: should handle missing .lenv file gracefully
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0320910Z         ok 4 - should handle missing .lenv file gracefully
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0321150Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0321320Z           duration_ms: 1.227875
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0321480Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0321610Z         1..4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0321790Z     ok 2 - Environment Loading Priority
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0321970Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0322130Z       duration_ms: 11.563959
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0322330Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0322470Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0322710Z     # Subtest: Case Conversion in Environment Loading
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0323090Z         # Subtest: should convert all keys to UPPER_CASE in process.env
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0323480Z         ok 1 - should convert all keys to UPPER_CASE in process.env
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0323720Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0323860Z           duration_ms: 1.302
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0324020Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0324610Z         # Subtest: should find env vars in any case format via getenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0325000Z         ok 2 - should find env vars in any case format via getenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0325230Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0325400Z           duration_ms: 1.936875
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0325550Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0325680Z         1..2
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0325890Z     ok 3 - Case Conversion in Environment Loading
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0326090Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0326220Z       duration_ms: 3.3125
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0326380Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0326520Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0326690Z     # Subtest: Configuration Options
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0326960Z         # Subtest: should support disabling lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0327230Z         ok 1 - should support disabling lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0327440Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0327600Z           duration_ms: 1.493541
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0327770Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0328040Z         # Subtest: should support enabling env/dotenvx (deprecated)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0328410Z         ok 2 - should support enabling env/dotenvx (deprecated)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0328630Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0330070Z           duration_ms: 1.471708
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0331120Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0332110Z         # Subtest: should support disabling getenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0332830Z         ok 3 - should support disabling getenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0333040Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0333220Z           duration_ms: 0.644833
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0333390Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0333640Z         # Subtest: should support configuration alias -c
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0333950Z         ok 4 - should support configuration alias -c
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0334170Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0334680Z           duration_ms: 2.068625
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0334850Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0334980Z         1..4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0335150Z     ok 4 - Configuration Options
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0335320Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0335470Z       duration_ms: 5.78575
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0335630Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0335770Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0335950Z     # Subtest: Complete Priority Chain
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0336380Z         # Subtest: should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0336890Z         ok 1 - should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0337190Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0337360Z           duration_ms: 6.16175
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0337520Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0337640Z         1..1
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0337820Z     ok 5 - Complete Priority Chain
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0337990Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0338130Z       duration_ms: 6.223
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0338290Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0338420Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0338630Z     # Subtest: Built-in Flag Conflicts (Issue \#14)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0339070Z         # Subtest: should allow user-defined --version option by calling .version(false)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0339550Z         ok 1 - should allow user-defined --version option by calling .version(false)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0339840Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0340020Z           duration_ms: 0.993833
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0340170Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0340420Z         # Subtest: should allow user-defined --help option
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0340730Z         ok 2 - should allow user-defined --help option
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0340940Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0341130Z           duration_ms: 0.649375
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0341380Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0341630Z         # Subtest: should work with --version in strict mode
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0341980Z         ok 3 - should work with --version in strict mode
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0342210Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0342380Z           duration_ms: 0.580916
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0342540Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0342780Z         # Subtest: should handle --version with boolean type
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0343320Z         ok 4 - should handle --version with boolean type
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0343540Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0343710Z           duration_ms: 0.493166
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0343870Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0344130Z         # Subtest: should allow users to explicitly enable help
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0344470Z         ok 5 - should allow users to explicitly enable help
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0344690Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0344860Z           duration_ms: 1.973791
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0345630Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0346270Z         # Subtest: should work with multiple custom options including version
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0346710Z         ok 6 - should work with multiple custom options including version
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0346970Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0347150Z           duration_ms: 1.060833
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0347310Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0347430Z         1..6
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0347650Z     ok 6 - Built-in Flag Conflicts (Issue \#14)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0347850Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0347980Z       duration_ms: 5.877166
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0348150Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0348280Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0348530Z     # Subtest: Explicitly Enabling Built-in Version and Help
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0348930Z         # Subtest: should allow explicitly enabling built-in --version
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0349320Z         ok 1 - should allow explicitly enabling built-in --version
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0349550Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0349730Z           duration_ms: 0.757083
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0349900Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0350200Z         # Subtest: should allow explicitly enabling both --version and --help
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0350820Z         ok 2 - should allow explicitly enabling both --version and --help
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0351070Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0351240Z           duration_ms: 0.82175
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0351410Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0351710Z         # Subtest: should allow version with alias
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0352000Z         ok 3 - should allow version with alias
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0352190Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0352360Z           duration_ms: 0.848834
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0352520Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0352730Z         # Subtest: should allow help with alias
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0352990Z         ok 4 - should allow help with alias
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0353180Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0353350Z           duration_ms: 2.231542
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0353510Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0353830Z         # Subtest: should work with both built-in version/help and custom options
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0354280Z         ok 5 - should work with both built-in version/help and custom options
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0354540Z           ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0354710Z           duration_ms: 1.353792
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0354880Z           ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0355000Z         1..5
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0355250Z     ok 7 - Explicitly Enabling Built-in Version and Help
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0355460Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0355600Z       duration_ms: 6.358083
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0355760Z       type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0355890Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356000Z     1..7
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356140Z ok 3 - makeConfig
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356270Z   ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356400Z   duration_ms: 55.014792
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356550Z   type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356680Z   ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0356900Z # Subtest: parseLinoArguments (legacy)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0357210Z     # Subtest: should parse simple links notation format
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0357530Z     ok 1 - should parse simple links notation format
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0357730Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0357870Z       duration_ms: 1.286291
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0358020Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0358260Z     # Subtest: should parse arguments without parentheses
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0358580Z     ok 2 - should parse arguments without parentheses
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0358940Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0359090Z       duration_ms: 0.250667
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0359240Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0359430Z     # Subtest: should handle empty input
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0359680Z     ok 3 - should handle empty input
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0359850Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0359980Z       duration_ms: 0.1475
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0360200Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0360390Z     # Subtest: should handle null input
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0360630Z     ok 4 - should handle null input
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0360820Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0360970Z       duration_ms: 0.057625
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0361120Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0361300Z     # Subtest: should filter out comments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0362050Z     ok 5 - should filter out comments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0362830Z       ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0363040Z       duration_ms: 0.562916
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0363190Z       ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0363480Z     1..5
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0363690Z ok 4 - parseLinoArguments (legacy)
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0363870Z   ---
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0363990Z   duration_ms: 2.398916
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0364150Z   type: 'suite'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0364280Z   ...
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0364390Z 1..4
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0364500Z # tests 58
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0364620Z # suites 16
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0364760Z # pass 58
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0365390Z # fail 0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0365530Z # cancelled 0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0365670Z # skipped 0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0365790Z # todo 0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0365940Z # duration_ms 181.45275
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0463750Z Post job cleanup.
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.2137890Z Post job cleanup.
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3200300Z [command]/opt/homebrew/bin/git version
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3288590Z git version 2.52.0
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3325190Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/ac7eda2e-cc9f-4b3e-b20d-41da8fdac2f7/.gitconfig'
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3338730Z Temporarily overriding HOME='/Users/runner/work/_temp/ac7eda2e-cc9f-4b3e-b20d-41da8fdac2f7' before making global git config changes
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3340910Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3356560Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3442820Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.3519280Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.4460660Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.4520430Z http.https://github.com/.extraheader
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.4528830Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.4597010Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.6214120Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.6215560Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.7826730Z Cleaning up orphan processes
+Test (bun on windows-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:47.8944614Z Current runner version: '2.330.0'
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8973762Z ##[group]Runner Image Provisioner
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8974525Z Hosted Compute Agent
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8975066Z Version: 20251211.462
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8975624Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8976246Z Build Date: 2025-12-11T16:28:49Z
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8976897Z Worker ID: {039ec83f-6bcc-4d32-af90-57a440d841ef}
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8977497Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8977980Z ##[group]Operating System
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8978514Z Microsoft Windows Server 2025
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8979031Z 10.0.26100
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8979807Z Datacenter
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8980413Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8980840Z ##[group]Runner Image
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8981326Z Image: windows-2025
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8981814Z Version: 20260105.172.1
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8983129Z Included Software: https://github.com/actions/runner-images/blob/win25/20260105.172/images/windows/Windows2025-Readme.md
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8984590Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20260105.172
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8985426Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8988477Z ##[group]GITHUB_TOKEN Permissions
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8990834Z Actions: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8991357Z ArtifactMetadata: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8991886Z Attestations: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8992396Z Checks: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8992820Z Contents: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8993292Z Deployments: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8993723Z Discussions: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8994179Z Issues: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8994590Z Metadata: read
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8995043Z Models: read
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8995448Z Packages: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8995918Z Pages: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8996391Z PullRequests: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8996927Z RepositoryProjects: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8997464Z SecurityEvents: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8997909Z Statuses: write
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.8998415Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.9000417Z Secret source: Actions
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.9001187Z Prepare workflow directory
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.9441190Z Prepare all required actions
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:47.9479746Z Getting action download info
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:48.2512847Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:48.3812905Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5356514Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:48.7919397Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.2309271Z Complete job name: Test (bun on windows-latest)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3488691Z ##[group]Run actions/checkout@v4
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3489685Z with:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3490094Z   repository: link-foundation/lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3490808Z   token: ***
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3491187Z   ssh-strict: true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3491530Z   ssh-user: git
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3491877Z   persist-credentials: true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3492277Z   clean: true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3492635Z   sparse-checkout-cone-mode: true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3493075Z   fetch-depth: 1
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3493413Z   fetch-tags: false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3493776Z   show-progress: true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3494120Z   lfs: false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3494453Z   submodules: false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3494816Z   set-safe-directory: true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.3495440Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.5156112Z Syncing repository: link-foundation/lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.5158105Z ##[group]Getting Git version info
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.5159114Z Working directory is 'D:\a\lino-arguments\lino-arguments'
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.6067226Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7476934Z git version 2.52.0.windows.1
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7533620Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7559017Z Temporarily overriding HOME='D:\a\_temp\7f406019-c2d9-4ca1-971c-15a6fd88a604' before making global git config changes
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7560577Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7570740Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7929316Z Deleting the contents of 'D:\a\lino-arguments\lino-arguments'
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7936104Z ##[group]Initializing the repository
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.7946268Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-arguments\lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.8470882Z Initialized empty Git repository in D:/a/lino-arguments/lino-arguments/.git/
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.8518249Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.8884117Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.8885099Z ##[group]Disabling automatic garbage collection
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.8895261Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.9212876Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.9214557Z ##[group]Setting up auth
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.9228734Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:49.9657692Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:50.9123316Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:50.9430894Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.4862910Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5160855Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0508871Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0836242Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0837365Z ##[group]Fetching the repository
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.0851934Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8263443Z From https://github.com/link-foundation/lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8264165Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8470688Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8471345Z ##[group]Determining the checkout info
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8473388Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8484849Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8859989Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9169674Z ##[group]Checking out the ref
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9179849Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.0057329Z branch 'main' set up to track 'origin/main'.
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.0066602Z Switched to a new branch 'main'
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.0109068Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.0479050Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.0795686Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1457895Z ##[group]Run actions/setup-node@v4
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1458230Z with:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1459185Z   node-version: 20.x
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1459384Z   always-auth: false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1459571Z   check-latest: false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1459900Z   token: ***
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1460060Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.3874246Z Found in cache @ C:\hostedtoolcache\windows\node\20.19.6\x64
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.3889764Z ##[group]Environment details
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6151335Z node: v20.19.6
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6151652Z npm: 10.8.2
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6151897Z yarn: 1.22.22
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6152996Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6455055Z ##[group]Run oven-sh/setup-bun@v2
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6455349Z with:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6455502Z   bun-version: latest
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6455682Z   no-cache: false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6455842Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9416315Z Downloading a new version of Bun: https://bun.sh/download/latest/win32/x64?avx2=true&profile=false
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:57.7445271Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\c5bf2b4b-35c9-4d9c-af28-e13193acd650.zip', 'D:\a\_temp\fad55eed-bc09-4b3d-93aa-902a22039643', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\c5bf2b4b-35c9-4d9c-af28-e13193acd650.zip' -DestinationPath 'D:\a\_temp\fad55eed-bc09-4b3d-93aa-902a22039643' -Force } else { throw $_ } } ;"
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7349313Z [command]C:\Users\runneradmin\.bun\bin\bun.exe --revision
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2832014Z 1.3.6+d530ed993
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.3149898Z ##[group]Run npm install
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.3150590Z [36;1mnpm install[0m
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.3222371Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:03.3222725Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.0943590Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.0944163Z > lino-arguments@0.3.0 prepare
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.0944602Z > husky || true
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.0944776Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2046620Z .git can't be found
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2047522Z added 234 packages, and audited 235 packages in 5s
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2047861Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2048044Z 59 packages are looking for funding
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2048349Z   run `npm fund` for details
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2078396Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2078876Z 1 moderate severity vulnerability
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2079211Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2079399Z To address all issues, run:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2079788Z   npm audit fix
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2079973Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.2080144Z Run `npm audit` for details.
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4285148Z ##[group]Run bun test
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4285410Z [36;1mbun test[0m
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4353809Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4354151Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.7085946Z bun test v1.3.6 (d530ed99)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.7370788Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.7371506Z ##[group]tests\index.test.js:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8185077Z (pass) Case Conversion Utilities > toUpperCase > should convert camelCase to UPPER_CASE
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8186463Z (pass) Case Conversion Utilities > toUpperCase > should convert kebab-case to UPPER_CASE
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8187656Z (pass) Case Conversion Utilities > toUpperCase > should convert snake_case to UPPER_CASE
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8189351Z (pass) Case Conversion Utilities > toUpperCase > should convert PascalCase to UPPER_CASE [16.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8191228Z (pass) Case Conversion Utilities > toUpperCase > should handle already UPPER_CASE
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8193955Z (pass) Case Conversion Utilities > toCamelCase > should convert kebab-case to camelCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8195132Z (pass) Case Conversion Utilities > toCamelCase > should convert UPPER_CASE to camelCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8196993Z (pass) Case Conversion Utilities > toCamelCase > should convert snake_case to camelCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8198335Z (pass) Case Conversion Utilities > toCamelCase > should convert PascalCase to camelCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8199642Z (pass) Case Conversion Utilities > toCamelCase > should handle already camelCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8201146Z (pass) Case Conversion Utilities > toKebabCase > should convert camelCase to kebab-case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8202545Z (pass) Case Conversion Utilities > toKebabCase > should convert UPPER_CASE to kebab-case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8204116Z (pass) Case Conversion Utilities > toKebabCase > should convert PascalCase to kebab-case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8205466Z (pass) Case Conversion Utilities > toKebabCase > should handle already kebab-case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8220381Z (pass) Case Conversion Utilities > toSnakeCase > should convert camelCase to snake_case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8221950Z (pass) Case Conversion Utilities > toSnakeCase > should convert kebab-case to snake_case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8226951Z (pass) Case Conversion Utilities > toSnakeCase > should convert UPPER_CASE to snake_case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8236354Z (pass) Case Conversion Utilities > toSnakeCase > should handle already snake_case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8242892Z (pass) Case Conversion Utilities > toPascalCase > should convert camelCase to PascalCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8244506Z (pass) Case Conversion Utilities > toPascalCase > should convert kebab-case to PascalCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8246007Z (pass) Case Conversion Utilities > toPascalCase > should convert snake_case to PascalCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8247716Z (pass) Case Conversion Utilities > toPascalCase > should handle already PascalCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8248931Z (pass) getenv > should find variable in UPPER_CASE
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8249756Z (pass) getenv > should find variable in camelCase
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8250581Z (pass) getenv > should find variable in kebab-case
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8251348Z (pass) getenv > should return default value when not found
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8252512Z (pass) getenv > should return empty string as default when not specified
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8253510Z (pass) getenv > should try original key first
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8440757Z (pass) makeConfig > Hero Example (defaults) > should work with minimal configuration [16.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8483033Z (pass) makeConfig > Hero Example (defaults) > should use CLI arguments with highest priority
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8515693Z (pass) makeConfig > Hero Example (defaults) > should convert kebab-case to camelCase in result [15.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8525263Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8558104Z (pass) makeConfig > Environment Loading Priority > should load .lenv file by default
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8563883Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8581339Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8601352Z (pass) makeConfig > Environment Loading Priority > should handle --configuration flag
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8605938Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8624814Z (pass) makeConfig > Environment Loading Priority > should prioritize CLI over environment
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8649657Z (pass) makeConfig > Environment Loading Priority > should handle missing .lenv file gracefully
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8656190Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8680116Z (pass) makeConfig > Case Conversion in Environment Loading > should convert all keys to UPPER_CASE in process.env [16.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8711851Z (pass) makeConfig > Case Conversion in Environment Loading > should find env vars in any case format via getenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8738090Z (pass) makeConfig > Configuration Options > should support disabling lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8765862Z (pass) makeConfig > Configuration Options > should support enabling env/dotenvx (deprecated)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8790023Z (pass) makeConfig > Configuration Options > should support disabling getenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8807448Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8821103Z (pass) makeConfig > Configuration Options > should support configuration alias -c [16.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8828461Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8848526Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8857215Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8871041Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8879404Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8927770Z (pass) makeConfig > Complete Priority Chain > should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8944317Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --version option by calling .version(false)
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8986305Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --help option [15.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9010568Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with --version in strict mode
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9030040Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should handle --version with boolean type
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9095131Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow users to explicitly enable help
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9096991Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with multiple custom options including version
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9099169Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling built-in --version
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9121320Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling both --version and --help
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9139862Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow version with alias [16.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9157662Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow help with alias
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9178876Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should work with both built-in version/help and custom options
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9212841Z (pass) parseLinoArguments (legacy) > should parse simple links notation format
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9219717Z (pass) parseLinoArguments (legacy) > should parse arguments without parentheses
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9221194Z (pass) parseLinoArguments (legacy) > should handle empty input
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9222005Z (pass) parseLinoArguments (legacy) > should handle null input
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9229095Z (pass) parseLinoArguments (legacy) > should filter out comments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9229532Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9229924Z ##[endgroup]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9230644Z 
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9230851Z  58 pass
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9231148Z  0 fail
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9231475Z Ran 58 tests across 1 file. [215.00ms]
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.0638323Z Post job cleanup.
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.3537996Z Post job cleanup.
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.6157864Z Post job cleanup.
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.8559649Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.8858433Z git version 2.52.0.windows.1
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.8945007Z Temporarily overriding HOME='D:\a\_temp\96e44a5e-09af-4dc7-8b65-f6a1d44b3613' before making global git config changes
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.8946173Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.8962806Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.9306470Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:10.9621919Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:11.5265785Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:11.5575371Z http.https://github.com/.extraheader
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:11.5620843Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:11.5925013Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:12.1576207Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:12.1897134Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (bun on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:12.7942031Z Cleaning up orphan processes
+Test (deno on ubuntu-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:42.6086385Z Current runner version: '2.330.0'
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6108581Z ##[group]Runner Image Provisioner
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6109518Z Hosted Compute Agent
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6110128Z Version: 20251211.462
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6110727Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6111404Z Build Date: 2025-12-11T16:28:49Z
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6112130Z Worker ID: {57446603-7ace-4680-8dd0-1fc803383306}
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6112828Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6113306Z ##[group]Operating System
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6113907Z Ubuntu
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6114339Z 24.04.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6114784Z LTS
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6115529Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6116034Z ##[group]Runner Image
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6116713Z Image: ubuntu-24.04
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6117225Z Version: 20260105.202.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6118237Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6119747Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6120765Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6123242Z ##[group]GITHUB_TOKEN Permissions
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6125471Z Actions: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6126020Z ArtifactMetadata: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6126963Z Attestations: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6127466Z Checks: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6127962Z Contents: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6128406Z Deployments: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6129006Z Discussions: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6129456Z Issues: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6129980Z Metadata: read
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6130482Z Models: read
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6130956Z Packages: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6131411Z Pages: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6131982Z PullRequests: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6132609Z RepositoryProjects: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6133140Z SecurityEvents: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6133720Z Statuses: write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6134172Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6136592Z Secret source: Actions
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6137571Z Prepare workflow directory
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6534837Z Prepare all required actions
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:42.6570889Z Getting action download info
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.0703761Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.1742031Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:43.3002124Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.0191451Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.7942402Z Complete job name: Test (deno on ubuntu-latest)
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8781600Z ##[group]Run actions/checkout@v4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8782804Z with:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8783577Z   repository: link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8784863Z   token: ***
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8785531Z   ssh-strict: true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8786668Z   ssh-user: git
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8787417Z   persist-credentials: true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8788242Z   clean: true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8788982Z   sparse-checkout-cone-mode: true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8789889Z   fetch-depth: 1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8790605Z   fetch-tags: false
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8791335Z   show-progress: true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8792091Z   lfs: false
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8792770Z   submodules: false
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8793541Z   set-safe-directory: true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.8794646Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.9901558Z Syncing repository: link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.9904048Z ##[group]Getting Git version info
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.9905477Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:44.9907639Z [command]/usr/bin/git version
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0861943Z git version 2.52.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0889434Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0912317Z Temporarily overriding HOME='/home/runner/work/_temp/73050c77-41c2-4b6a-80dc-2dbf4b18de9c' before making global git config changes
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0917632Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0921565Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0992801Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.0995995Z ##[group]Initializing the repository
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1000680Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1489237Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1491597Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1493326Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1494680Z hint: call:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1495322Z hint:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1496428Z hint: 	git config --global init.defaultBranch <name>
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1497533Z hint:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1498542Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1500261Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1501607Z hint:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1502269Z hint: 	git branch -m <name>
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1503083Z hint:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1504175Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1536411Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1550852Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1636466Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1638745Z ##[group]Disabling automatic garbage collection
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1640884Z [command]/usr/bin/git config --local gc.auto 0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1670269Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1672363Z ##[group]Setting up auth
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1677827Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.1710166Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3090631Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3120702Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3336442Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3366447Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3583028Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3617056Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3617790Z ##[group]Fetching the repository
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:45.3626786Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2077482Z From https://github.com/link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2078342Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2160827Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2161427Z ##[group]Determining the checkout info
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2163903Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2168802Z [command]/usr/bin/git sparse-checkout disable
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2250193Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2275010Z ##[group]Checking out the ref
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2279234Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2482452Z Switched to a new branch 'main'
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2484986Z branch 'main' set up to track 'origin/main'.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2490761Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2524503Z [command]/usr/bin/git log -1 --format=%H
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2545738Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2863980Z ##[group]Run actions/setup-node@v4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2864273Z with:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2864447Z   node-version: 20.x
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2864649Z   always-auth: false
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2864833Z   check-latest: false
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2865149Z   token: ***
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.2865322Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.4873992Z Found in cache @ /opt/hostedtoolcache/node/20.19.6/x64
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:46.4881407Z ##[group]Environment details
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5061672Z node: v20.19.6
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5062216Z npm: 10.8.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5062493Z yarn: 1.22.22
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5063495Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5177429Z ##[group]Run denoland/setup-deno@v2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5177713Z with:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5177884Z   deno-version: v2.x
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5178087Z   deno-binary-name: deno
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5178283Z   cache: false
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.5178460Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.8093235Z Going to install stable version 2.6.4.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:48.8105286Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.6.4/deno-x86_64-unknown-linux-gnu.zip.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:49.4221869Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/70c57cf6-8cf4-4af2-9af0-b3b9346c48c4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.5213409Z Cached Deno to /opt/hostedtoolcache/deno/2.6.4/x64.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.5222094Z Installation complete.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.5367588Z ##[group]Run npm install
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.5367898Z [36;1mnpm install[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.5685334Z shell: /usr/bin/bash -e {0}
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:50.5685591Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0473915Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0474821Z > lino-arguments@0.3.0 prepare
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0475445Z > husky || true
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0475699Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0884027Z .git can't be found
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0884972Z added 234 packages, and audited 235 packages in 3s
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0885663Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0885949Z 59 packages are looking for funding
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0887065Z   run `npm fund` for details
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0904427Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0905352Z 1 moderate severity vulnerability
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0906400Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0906937Z To address all issues, run:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0912364Z   npm audit fix
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0912602Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0912823Z Run `npm audit` for details.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1132681Z ##[group]Run deno test --allow-read --allow-env --allow-write
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1133134Z [36;1mdeno test --allow-read --allow-env --allow-write[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1165499Z shell: /usr/bin/bash -e {0}
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1165730Z ##[endgroup]
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1297827Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fcli
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1301543Z [0m[32mDownload[0m https://registry.npmjs.org/eslint
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1302578Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1303649Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1304545Z [0m[32mDownload[0m https://registry.npmjs.org/getenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1305360Z [0m[32mDownload[0m https://registry.npmjs.org/husky
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1306412Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1307336Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1308266Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1309112Z [0m[32mDownload[0m https://registry.npmjs.org/prettier
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1309960Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1310807Z [0m[32mDownload[0m https://registry.npmjs.org/yargs
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3852637Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fapply-release-plan
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3853858Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fassemble-release-plan
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3855025Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fchangelog-git
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3856356Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fconfig
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3857546Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ferrors
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3858767Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-dependents-graph
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3860068Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-release-plan
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3861218Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fgit
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3862395Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2flogger
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3863521Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fpre
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3864662Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fread
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3865835Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fshould-skip-package
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3867251Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ftypes
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3868295Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fwrite
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3869444Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer%2fexternal-editor
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3870617Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2fget-packages
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3871653Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3872581Z [0m[32mDownload[0m https://registry.npmjs.org/ci-info
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3873473Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3874368Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3875327Z [0m[32mDownload[0m https://registry.npmjs.org/mri
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3876469Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3877559Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3878633Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3879585Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3880471Z [0m[32mDownload[0m https://registry.npmjs.org/semver
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3881341Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.3882307Z [0m[32mDownload[0m https://registry.npmjs.org/term-size
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4884004Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2feslint-utils
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4885263Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2fregexpp
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4886529Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-array
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4887602Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-helpers
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4888552Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fcore
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4889475Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2feslintrc
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4890356Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fjs
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4891277Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fplugin-kit
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4892206Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fnode
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4893232Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fmodule-importer
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4894265Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fretry
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4894863Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2festree
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4895361Z [0m[32mDownload[0m https://registry.npmjs.org/ajv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4895820Z [0m[32mDownload[0m https://registry.npmjs.org/chalk
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4896749Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4897212Z [0m[32mDownload[0m https://registry.npmjs.org/debug
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4897750Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4898292Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4898891Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4899410Z [0m[32mDownload[0m https://registry.npmjs.org/espree
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4899865Z [0m[32mDownload[0m https://registry.npmjs.org/esquery
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4900313Z [0m[32mDownload[0m https://registry.npmjs.org/esutils
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4900799Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4901316Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4901791Z [0m[32mDownload[0m https://registry.npmjs.org/find-up
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4902260Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4902713Z [0m[32mDownload[0m https://registry.npmjs.org/ignore
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4903165Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4903627Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4904097Z [0m[32mDownload[0m https://registry.npmjs.org/jiti
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4904672Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4905254Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4905719Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4906408Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.4906912Z [0m[32mDownload[0m https://registry.npmjs.org/optionator
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6062439Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2feslint
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6063683Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6064796Z [0m[32mDownload[0m https://registry.npmjs.org/synckit
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6603385Z [0m[32mDownload[0m https://registry.npmjs.org/commander
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6604471Z [0m[32mDownload[0m https://registry.npmjs.org/listr2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6605618Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6608247Z [0m[32mDownload[0m https://registry.npmjs.org/nano-spawn
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6608936Z [0m[32mDownload[0m https://registry.npmjs.org/pidtree
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6609480Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6610196Z [0m[32mDownload[0m https://registry.npmjs.org/yaml
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7280254Z [0m[32mDownload[0m https://registry.npmjs.org/cliui
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7281412Z [0m[32mDownload[0m https://registry.npmjs.org/escalade
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7282546Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7283312Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7283984Z [0m[32mDownload[0m https://registry.npmjs.org/string-width
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7284576Z [0m[32mDownload[0m https://registry.npmjs.org/y18n
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7285157Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7812227Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-version-range-type
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7813253Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7813814Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7814357Z [0m[32mDownload[0m https://registry.npmjs.org/outdent
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:54.9327216Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.0429921Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.0766397Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fparse
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.0767302Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.1254003Z [0m[32mDownload[0m https://registry.npmjs.org/human-id
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.1663145Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fnode
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.1663932Z [0m[32mDownload[0m https://registry.npmjs.org/chardet
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.1664440Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3939532Z [0m[32mDownload[0m https://registry.npmjs.org/@babel%2fruntime
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3940523Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2ffind-root
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3941222Z [0m[32mDownload[0m https://registry.npmjs.org/globby
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3941882Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5216913Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5578717Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5579533Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5580102Z [0m[32mDownload[0m https://registry.npmjs.org/universalify
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.6097978Z [0m[32mDownload[0m https://registry.npmjs.org/p-try
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.6466381Z [0m[32mDownload[0m https://registry.npmjs.org/quansync
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.6902688Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7287378Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fobject-schema
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7956470Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fjson-schema
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8459615Z [0m[32mDownload[0m https://registry.npmjs.org/globals
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8460343Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8461018Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8461705Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8987485Z [0m[32mDownload[0m https://registry.npmjs.org/levn
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.9367741Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fcore
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.9841333Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.9842187Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:55.9842884Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.0223990Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.0224718Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.0696837Z [0m[32mDownload[0m https://registry.npmjs.org/path-key
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.0697811Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.0698484Z [0m[32mDownload[0m https://registry.npmjs.org/which
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.1197665Z [0m[32mDownload[0m https://registry.npmjs.org/ms
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.1601777Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.1602366Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.2052817Z [0m[32mDownload[0m https://registry.npmjs.org/acorn
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.2502643Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.2503245Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.3521383Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.3522125Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.3928669Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4318717Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4678198Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4678931Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4679477Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4680240Z [0m[32mDownload[0m https://registry.npmjs.org/type-check
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4680757Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5136592Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5688607Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr%2fcore
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6287778Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6288627Z [0m[32mDownload[0m https://registry.npmjs.org/colorette
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6289191Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6289720Z [0m[32mDownload[0m https://registry.npmjs.org/log-update
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6290276Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6290803Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.7052138Z [0m[32mDownload[0m https://registry.npmjs.org/braces
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.7052756Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.7523323Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.7524243Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.7972927Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.8429202Z [0m[32mDownload[0m https://registry.npmjs.org/p-map
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.8790813Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9157770Z [0m[32mDownload[0m https://registry.npmjs.org/array-union
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9158553Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9159198Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9159799Z [0m[32mDownload[0m https://registry.npmjs.org/merge2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9160381Z [0m[32mDownload[0m https://registry.npmjs.org/slash
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9687768Z [0m[32mDownload[0m https://registry.npmjs.org/pify
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9688337Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0164738Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0607186Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0979240Z [0m[32mDownload[0m https://registry.npmjs.org/argparse
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.1413304Z [0m[32mDownload[0m https://registry.npmjs.org/punycode
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.1738282Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.2282886Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.2788891Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.3277437Z [0m[32mDownload[0m https://registry.npmjs.org/isexe
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.3624490Z [0m[32mDownload[0m https://registry.npmjs.org/flatted
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.3625184Z [0m[32mDownload[0m https://registry.npmjs.org/keyv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.4103853Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.4472149Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.4472917Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.4832929Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.5176604Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.5177456Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.5619332Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.6051610Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.6394400Z [0m[32mDownload[0m https://registry.npmjs.org/path-type
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.6767627Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.stat
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.6768494Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.walk
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.7243031Z [0m[32mDownload[0m https://registry.npmjs.org/esprima
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.7686318Z [0m[32mDownload[0m https://registry.npmjs.org/callsites
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.8011795Z [0m[32mDownload[0m https://registry.npmjs.org/color-name
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.8423974Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.8874831Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.9234323Z [0m[32mDownload[0m https://registry.npmjs.org/environment
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.9581068Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:57.9991045Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.0330804Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.scandir
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.0331454Z [0m[32mDownload[0m https://registry.npmjs.org/fastq
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.0851183Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.1266812Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.1648636Z [0m[32mDownload[0m https://registry.npmjs.org/onetime
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.2057885Z [0m[32mDownload[0m https://registry.npmjs.org/is-number
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.2453033Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.2815916Z [0m[32mDownload[0m https://registry.npmjs.org/reusify
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.3164741Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.3528337Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4063062Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4064859Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4066464Z [0m[32mDownload[0m https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4067772Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere/-/test-anywhere-0.6.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4069034Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4070180Z [0m[32mDownload[0m https://registry.npmjs.org/husky/-/husky-9.1.7.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4071279Z [0m[32mDownload[0m https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4072558Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4100168Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4101407Z [0m[32mDownload[0m https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4102854Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4104167Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4105366Z [0m[32mDownload[0m https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4107040Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4108497Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4109943Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4111487Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4112743Z [0m[32mDownload[0m https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4113976Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4115204Z [0m[32mDownload[0m https://registry.npmjs.org/espree/-/espree-10.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4116636Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4117870Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4118952Z [0m[32mDownload[0m https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4120296Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4121330Z [0m[32mDownload[0m https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4122468Z [0m[32mDownload[0m https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4123845Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4125176Z [0m[32mDownload[0m https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4126443Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4127608Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4128710Z [0m[32mDownload[0m https://registry.npmjs.org/debug/-/debug-4.4.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4129872Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4130880Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4131613Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4132331Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4133008Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4133640Z [0m[32mDownload[0m https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4134282Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4134900Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4135819Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4136965Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4137550Z [0m[32mDownload[0m https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4138289Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4139099Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4139852Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4140770Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4141464Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4142106Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4142761Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4143347Z [0m[32mDownload[0m https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4143950Z [0m[32mDownload[0m https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4144580Z [0m[32mDownload[0m https://registry.npmjs.org/commander/-/commander-14.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4145214Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4145844Z [0m[32mDownload[0m https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4146606Z [0m[32mDownload[0m https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4147278Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4148005Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4148763Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4149639Z [0m[32mDownload[0m https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4150222Z [0m[32mDownload[0m https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4150946Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4151591Z [0m[32mDownload[0m https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4152153Z [0m[32mDownload[0m https://registry.npmjs.org/semver/-/semver-7.7.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4152925Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4153754Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4154419Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4155211Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4156245Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4157002Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/read/-/read-0.6.6.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4157657Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4158431Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.14.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4159127Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4159920Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4160699Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4161340Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4161990Z [0m[32mDownload[0m https://registry.npmjs.org/mri/-/mri-1.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4162603Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4163334Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4164137Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4164997Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.14.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4165997Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4166820Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4167445Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4168088Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4168724Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4169353Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4170004Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4170626Z [0m[32mDownload[0m https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4171224Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4171841Z [0m[32mDownload[0m https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4172437Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4173031Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4173632Z [0m[32mDownload[0m https://registry.npmjs.org/globals/-/globals-14.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4174396Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4175011Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4175722Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4176607Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4177282Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4177878Z [0m[32mDownload[0m https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4178452Z [0m[32mDownload[0m https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4179057Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4179675Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4180356Z [0m[32mDownload[0m https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4181202Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4181934Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4182654Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4183334Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4183962Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4184597Z [0m[32mDownload[0m https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4185294Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4185975Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4186799Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4187522Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4188176Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4188751Z [0m[32mDownload[0m https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4189410Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4190308Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4190949Z [0m[32mDownload[0m https://registry.npmjs.org/which/-/which-2.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4191533Z [0m[32mDownload[0m https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4192154Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4192777Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4193399Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4194024Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4194719Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4195372Z [0m[32mDownload[0m https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4195981Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4196666Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4197260Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4197886Z [0m[32mDownload[0m https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4198660Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4199343Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4200003Z [0m[32mDownload[0m https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4200650Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4201295Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4202092Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4202832Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4203477Z [0m[32mDownload[0m https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4204157Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4204869Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4205545Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4206294Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4206901Z [0m[32mDownload[0m https://registry.npmjs.org/globby/-/globby-11.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4207489Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4208129Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4208800Z [0m[32mDownload[0m https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4209432Z [0m[32mDownload[0m https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4210063Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/parse/-/parse-0.4.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4210684Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4211265Z [0m[32mDownload[0m https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4211875Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4212482Z [0m[32mDownload[0m https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4213100Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4213707Z [0m[32mDownload[0m https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4214462Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4215113Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4215802Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4216775Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4217529Z [0m[32mDownload[0m https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4218212Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4218882Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4219541Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4220227Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4220860Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4221458Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4222105Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4222919Z [0m[32mDownload[0m https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4223518Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4224163Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4224769Z [0m[32mDownload[0m https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4225343Z [0m[32mDownload[0m https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4225910Z [0m[32mDownload[0m https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4226668Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4227339Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4228015Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4228672Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4229332Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4229980Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4230625Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4231264Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4231910Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4232551Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4233183Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4233796Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4234405Z [0m[32mDownload[0m https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4234982Z [0m[32mDownload[0m https://registry.npmjs.org/pify/-/pify-4.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4235553Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4236259Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4236876Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4237464Z [0m[32mDownload[0m https://registry.npmjs.org/slash/-/slash-3.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4238164Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4238794Z [0m[32mDownload[0m https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4239399Z [0m[32mDownload[0m https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4239963Z [0m[32mDownload[0m https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4240579Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4241335Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4242032Z [0m[32mDownload[0m https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4242652Z [0m[32mDownload[0m https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4243399Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4244258Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4244938Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4245712Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4246551Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4247356Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4248129Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4248874Z [0m[32mDownload[0m https://registry.npmjs.org/environment/-/environment-1.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4249559Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4250235Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4250858Z [0m[32mDownload[0m https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4251474Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4252113Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4252759Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4253408Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4254054Z [0m[32mDownload[0m https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4255316Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4256264Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4256916Z [0m[32mDownload[0m https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4257518Z [0m[32mDownload[0m https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4258117Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4258744Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4259427Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4260081Z [0m[32mDownload[0m https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4260740Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4261436Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4262066Z [0m[32mDownload[0m https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4262739Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4858007Z [0m[32mInitialize[0m eslint-config-prettier@10.1.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4883274Z [0m[32mInitialize[0m eslint-plugin-prettier@5.5.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4961503Z [0m[32mInitialize[0m husky@9.1.7
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4962367Z [0m[32mInitialize[0m getenv@2.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4985722Z [0m[32mInitialize[0m prettier-linter-helpers@1.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5010043Z [0m[32mInitialize[0m lodash.merge@4.6.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5012278Z [0m[32mInitialize[0m escape-string-regexp@4.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5012998Z [0m[32mInitialize[0m synckit@0.11.11
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5017233Z [0m[32mInitialize[0m lino-env@0.2.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5017988Z [0m[32mInitialize[0m eslint-visitor-keys@4.2.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5020150Z [0m[32mInitialize[0m chalk@4.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5020787Z [0m[32mInitialize[0m find-up@5.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5021416Z [0m[32mInitialize[0m fast-deep-equal@3.1.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5021865Z [0m[32mInitialize[0m optionator@0.9.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5022232Z [0m[32mInitialize[0m test-anywhere@0.6.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5022625Z [0m[32mInitialize[0m natural-compare@1.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5022999Z [0m[32mInitialize[0m cross-spawn@7.0.6
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5023338Z [0m[32mInitialize[0m is-glob@4.0.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5163320Z [0m[32mInitialize[0m nano-spawn@2.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5164008Z [0m[32mInitialize[0m string-width@4.2.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5164623Z [0m[32mInitialize[0m escalade@3.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5164979Z [0m[32mInitialize[0m @types/estree@1.0.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5165323Z [0m[32mInitialize[0m cliui@8.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5165652Z [0m[32mInitialize[0m picocolors@1.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5166008Z [0m[32mInitialize[0m imurmurhash@0.1.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5166661Z [0m[32mInitialize[0m yargs-parser@21.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5167024Z [0m[32mInitialize[0m string-argv@0.3.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5167376Z [0m[32mInitialize[0m get-caller-file@2.0.5
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5167724Z [0m[32mInitialize[0m espree@10.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5168093Z [0m[32mInitialize[0m require-directory@2.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5194622Z [0m[32mInitialize[0m lint-staged@16.2.7
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5230696Z [0m[32mInitialize[0m debug@4.4.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5245479Z [0m[32mInitialize[0m y18n@5.0.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5247081Z [0m[32mInitialize[0m links-notation@0.11.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5248068Z [0m[32mInitialize[0m minimatch@3.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5249017Z [0m[32mInitialize[0m file-entry-cache@8.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5318085Z [0m[32mInitialize[0m esutils@2.0.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5318759Z [0m[32mInitialize[0m semver@7.7.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5319460Z [0m[32mInitialize[0m @changesets/cli@2.29.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5650044Z [0m[32mInitialize[0m listr2@9.0.5
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5650925Z [0m[32mInitialize[0m ignore@5.3.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5652129Z [0m[32mInitialize[0m json-stable-stringify-without-jsonify@1.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5667870Z [0m[32mInitialize[0m @changesets/get-dependents-graph@2.1.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5672357Z [0m[32mInitialize[0m @changesets/changelog-git@0.2.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5677938Z [0m[32mInitialize[0m @changesets/pre@2.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5685613Z [0m[32mInitialize[0m micromatch@4.0.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5688119Z [0m[32mInitialize[0m import-fresh@3.3.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5689162Z [0m[32mInitialize[0m globals@14.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5701846Z [0m[32mInitialize[0m mri@1.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5702629Z [0m[32mInitialize[0m @humanwhocodes/module-importer@1.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5703355Z [0m[32mInitialize[0m yargs@17.7.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5704046Z [0m[32mInitialize[0m @eslint/config-array@0.21.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5709988Z [0m[32mInitialize[0m levn@0.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5710607Z [0m[32mInitialize[0m eslint-scope@8.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5711589Z [0m[32mInitialize[0m spawndamnit@3.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5712241Z [0m[32mInitialize[0m resolve-from@5.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5712892Z [0m[32mInitialize[0m @humanfs/node@0.16.7
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5713811Z [0m[32mInitialize[0m commander@14.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5714447Z [0m[32mInitialize[0m enquirer@2.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5819367Z [0m[32mInitialize[0m @eslint/eslintrc@3.3.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5823800Z [0m[32mInitialize[0m @changesets/read@0.6.6
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5824432Z [0m[32mInitialize[0m esquery@1.7.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5825152Z [0m[32mInitialize[0m @eslint-community/regexpp@4.12.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5825851Z [0m[32mInitialize[0m @eslint/plugin-kit@0.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5826480Z [0m[32mInitialize[0m fast-diff@1.3.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5827208Z [0m[32mInitialize[0m package-manager-detector@0.2.11
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5827939Z [0m[32mInitialize[0m ansi-styles@4.3.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5828576Z [0m[32mInitialize[0m supports-color@7.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5829275Z [0m[32mInitialize[0m @eslint/js@9.39.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5830088Z [0m[32mInitialize[0m @changesets/should-skip-package@0.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5830872Z [0m[32mInitialize[0m ci-info@3.9.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5831481Z [0m[32mInitialize[0m js-yaml@4.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5832217Z [0m[32mInitialize[0m @humanwhocodes/retry@0.4.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5832870Z [0m[32mInitialize[0m p-limit@2.3.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5833208Z [0m[32mInitialize[0m fs-extra@7.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5833531Z [0m[32mInitialize[0m yaml@2.8.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5834088Z [0m[32mInitialize[0m ansi-colors@4.1.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5834700Z [0m[32mInitialize[0m strip-json-comments@3.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5835401Z [0m[32mInitialize[0m pidtree@0.6.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5835849Z [0m[32mInitialize[0m term-size@2.2.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5836491Z [0m[32mInitialize[0m @changesets/types@6.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5836909Z [0m[32mInitialize[0m @eslint/config-helpers@0.4.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5837308Z [0m[32mInitialize[0m @changesets/config@3.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5837668Z [0m[32mInitialize[0m @pkgr/core@0.2.9
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5838042Z [0m[32mInitialize[0m json-schema-traverse@0.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5838771Z [0m[32mInitialize[0m @eslint/core@0.17.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5839441Z [0m[32mInitialize[0m eslint-visitor-keys@3.4.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5839819Z [0m[32mInitialize[0m which@2.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5840152Z [0m[32mInitialize[0m acorn-jsx@5.3.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5840488Z [0m[32mInitialize[0m word-wrap@1.2.5
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5840871Z [0m[32mInitialize[0m @manypkg/get-packages@1.1.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5841267Z [0m[32mInitialize[0m @changesets/write@0.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5841631Z [0m[32mInitialize[0m @changesets/git@3.0.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5841967Z [0m[32mInitialize[0m ms@2.1.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5842378Z [0m[32mInitialize[0m @changesets/assemble-release-plan@6.0.9
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5842858Z [0m[32mInitialize[0m @eslint-community/eslint-utils@4.9.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5843276Z [0m[32mInitialize[0m @changesets/errors@0.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5843702Z [0m[32mInitialize[0m @changesets/get-release-plan@4.0.14
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5844143Z [0m[32mInitialize[0m @inquirer/external-editor@1.0.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5844523Z [0m[32mInitialize[0m glob-parent@6.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5844864Z [0m[32mInitialize[0m acorn@8.15.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5845223Z [0m[32mInitialize[0m @changesets/logger@0.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5845673Z [0m[32mInitialize[0m @changesets/apply-release-plan@7.0.14
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5846326Z [0m[32mInitialize[0m is-extglob@2.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5846729Z [0m[32mInitialize[0m fast-levenshtein@2.0.6
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5847089Z [0m[32mInitialize[0m universalify@0.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5847421Z [0m[32mInitialize[0m wrap-ansi@9.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5847780Z [0m[32mInitialize[0m brace-expansion@1.1.12
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5848137Z [0m[32mInitialize[0m eventemitter3@5.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5848474Z [0m[32mInitialize[0m log-update@6.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5848810Z [0m[32mInitialize[0m prelude-ls@1.2.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5849133Z [0m[32mInitialize[0m globby@11.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5849650Z [0m[32mInitialize[0m estraverse@5.3.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5849997Z [0m[32mInitialize[0m rfdc@1.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5850556Z [0m[32mInitialize[0m braces@3.0.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5851221Z [0m[32mInitialize[0m locate-path@6.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5851878Z [0m[32mInitialize[0m picomatch@2.3.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5852519Z [0m[32mInitialize[0m path-key@3.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5858590Z [0m[32mInitialize[0m p-try@2.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5859202Z [0m[32mInitialize[0m chardet@2.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5861498Z [0m[32mInitialize[0m shebang-command@2.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5870033Z [0m[32mInitialize[0m flat-cache@4.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5872155Z [0m[32mInitialize[0m ajv@6.12.6
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5884008Z [0m[32mInitialize[0m esrecurse@4.3.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5884652Z [0m[32mInitialize[0m p-filter@2.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5885288Z [0m[32mInitialize[0m type-check@0.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5916830Z [0m[32mInitialize[0m colorette@2.0.20
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5917827Z [0m[32mInitialize[0m iconv-lite@0.7.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5918643Z [0m[32mInitialize[0m wrap-ansi@7.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5919527Z [0m[32mInitialize[0m strip-ansi@6.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5920373Z [0m[32mInitialize[0m path-exists@4.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5921266Z [0m[32mInitialize[0m @humanfs/core@0.19.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5923027Z [0m[32mInitialize[0m eslint@9.39.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5977718Z [0m[32mInitialize[0m lodash.startcase@4.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.5978784Z [0m[32mInitialize[0m detect-indent@6.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6000459Z [0m[32mInitialize[0m p-locate@5.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6001387Z [0m[32mInitialize[0m emoji-regex@8.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6002320Z [0m[32mInitialize[0m read-yaml-file@1.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6003192Z [0m[32mInitialize[0m deep-is@0.1.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6004046Z [0m[32mInitialize[0m is-subdir@1.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6004965Z [0m[32mInitialize[0m fs-extra@8.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6027658Z [0m[32mInitialize[0m quansync@0.2.11
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6029315Z [0m[32mInitialize[0m balanced-match@1.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6139037Z [0m[32mInitialize[0m @changesets/types@4.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6140040Z [0m[32mInitialize[0m cli-truncate@5.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6140773Z [0m[32mInitialize[0m parent-module@1.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6141583Z [0m[32mInitialize[0m resolve-from@4.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6147646Z [0m[32mInitialize[0m jsonfile@4.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6148501Z [0m[32mInitialize[0m @types/json-schema@7.0.15
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6149213Z [0m[32mInitialize[0m cli-cursor@5.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6149812Z [0m[32mInitialize[0m slash@3.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6150387Z [0m[32mInitialize[0m ansi-regex@5.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6150988Z [0m[32mInitialize[0m outdent@0.5.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6151575Z [0m[32mInitialize[0m has-flag@4.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6152276Z [0m[32mInitialize[0m fast-json-stable-stringify@2.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6153019Z [0m[32mInitialize[0m @changesets/parse@0.4.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6153768Z [0m[32mInitialize[0m is-fullwidth-code-point@3.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6154428Z [0m[32mInitialize[0m strip-bom@3.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6155031Z [0m[32mInitialize[0m safer-buffer@2.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6155638Z [0m[32mInitialize[0m signal-exit@4.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6156461Z [0m[32mInitialize[0m graceful-fs@4.2.11
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6157074Z [0m[32mInitialize[0m ansi-regex@6.2.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6157678Z [0m[32mInitialize[0m string-width@7.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6158263Z [0m[32mInitialize[0m dir-glob@3.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6265007Z [0m[32mInitialize[0m @eslint/object-schema@2.1.7
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6269913Z [0m[32mInitialize[0m js-yaml@3.14.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6271502Z [0m[32mInitialize[0m uri-js@4.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6272551Z [0m[32mInitialize[0m array-union@2.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6273817Z [0m[32mInitialize[0m keyv@4.5.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6278498Z [0m[32mInitialize[0m fast-glob@3.3.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6279860Z [0m[32mInitialize[0m to-regex-range@5.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6282817Z [0m[32mInitialize[0m color-name@1.1.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6283639Z [0m[32mInitialize[0m extendable-error@0.1.7
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6299433Z [0m[32mInitialize[0m pify@4.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6300051Z [0m[32mInitialize[0m punycode@2.3.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6300677Z [0m[32mInitialize[0m p-limit@3.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6301333Z [0m[32mInitialize[0m slice-ansi@7.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6301985Z [0m[32mInitialize[0m human-id@4.1.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6302656Z [0m[32mInitialize[0m color-convert@2.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6303298Z [0m[32mInitialize[0m find-up@4.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6303931Z [0m[32mInitialize[0m callsites@3.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6304551Z [0m[32mInitialize[0m merge2@1.4.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6305260Z [0m[32mInitialize[0m @manypkg/find-root@1.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6305972Z [0m[32mInitialize[0m json-buffer@3.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6307082Z [0m[32mInitialize[0m @changesets/get-version-range-type@0.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6319650Z [0m[32mInitialize[0m get-east-asian-width@1.4.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6320438Z [0m[32mInitialize[0m esprima@4.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6321079Z [0m[32mInitialize[0m strip-ansi@7.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6321704Z [0m[32mInitialize[0m path-type@4.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6322658Z [0m[32mInitialize[0m environment@1.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6342499Z [0m[32mInitialize[0m string-width@8.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6344909Z [0m[32mInitialize[0m emoji-regex@10.6.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6345307Z [0m[32mInitialize[0m locate-path@5.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6432472Z [0m[32mInitialize[0m p-map@2.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6433330Z [0m[32mInitialize[0m restore-cursor@5.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6434091Z [0m[32mInitialize[0m onetime@7.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6434680Z [0m[32mInitialize[0m p-locate@4.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6435356Z [0m[32mInitialize[0m shebang-regex@3.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6436021Z [0m[32mInitialize[0m glob-parent@5.1.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6524678Z [0m[32mInitialize[0m argparse@1.0.10
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6534356Z [0m[32mInitialize[0m ansi-escapes@7.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6535144Z [0m[32mInitialize[0m flatted@3.3.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6537265Z [0m[32mInitialize[0m is-number@7.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6537878Z [0m[32mInitialize[0m fill-range@7.1.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6538843Z [0m[32mInitialize[0m queue-microtask@1.2.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6539463Z [0m[32mInitialize[0m is-windows@1.0.2
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6539859Z [0m[32mInitialize[0m @nodelib/fs.walk@1.2.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6540227Z [0m[32mInitialize[0m argparse@2.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6587303Z [0m[32mInitialize[0m isexe@2.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6591605Z [0m[32mInitialize[0m is-fullwidth-code-point@5.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6592350Z [0m[32mInitialize[0m fastq@1.20.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6623469Z [0m[32mInitialize[0m concat-map@0.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6624853Z [0m[32mInitialize[0m @nodelib/fs.stat@2.0.5
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6649124Z [0m[32mInitialize[0m reusify@1.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6653128Z [0m[32mInitialize[0m @babel/runtime@7.28.6
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6654881Z [0m[32mInitialize[0m sprintf-js@1.0.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6657296Z [0m[32mInitialize[0m yocto-queue@0.1.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6682881Z [0m[32mInitialize[0m prettier@3.7.4
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6698116Z [0m[32mInitialize[0m mimic-function@5.0.1
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6742284Z [0m[32mInitialize[0m ansi-styles@6.2.3
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6764176Z [0m[32mInitialize[0m run-parallel@1.2.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6781364Z [0m[32mInitialize[0m better-path-resolve@1.0.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6973230Z [0m[32mInitialize[0m @types/node@12.20.55
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6982771Z [0m[32mInitialize[0m @nodelib/fs.scandir@2.1.5
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.7140415Z [0m[32mInitialize[0m prettier@2.8.8
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8191582Z [0m[38;5;245mrunning 58 tests from ./tests/index.test.js[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8198445Z should convert camelCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8199778Z should convert kebab-case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8202117Z should convert snake_case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8203407Z should convert PascalCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8204579Z should handle already UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8207331Z should convert kebab-case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8209047Z should convert UPPER_CASE to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8210731Z should convert snake_case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8213255Z should convert PascalCase to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8214629Z should handle already camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8217997Z should convert camelCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8220182Z should convert UPPER_CASE to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8221545Z should convert PascalCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8223250Z should handle already kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8224546Z should convert camelCase to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8225882Z should convert kebab-case to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8227465Z should convert UPPER_CASE to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8228725Z should handle already snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8230041Z should convert camelCase to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8232134Z should convert kebab-case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8234472Z should convert snake_case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8235733Z should handle already PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8241830Z should find variable in UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8243731Z should find variable in camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8246435Z should find variable in kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8248435Z should return default value when not found ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8250273Z should return empty string as default when not specified ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8251895Z should try original key first ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8378309Z should work with minimal configuration ... [0m[32mok[0m [0m[38;5;245m(12ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8421135Z should use CLI arguments with highest priority ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8455780Z should convert kebab-case to camelCase in result ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8465526Z should load .lenv file by default ...
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8465937Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8466942Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8500800Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8501967Z should load .lenv file by default ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8505359Z should handle --configuration flag ...
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8506515Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8508274Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8521275Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8537358Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8538134Z should handle --configuration flag ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8540341Z should prioritize CLI over environment ...
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8541016Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8541837Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8563259Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8564048Z should prioritize CLI over environment ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8589998Z should handle missing .lenv file gracefully ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8593047Z should convert all keys to UPPER_CASE in process.env ...
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8593725Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8594374Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8614117Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8614958Z should convert all keys to UPPER_CASE in process.env ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8640480Z should find env vars in any case format via getenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8667038Z should support disabling lenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8692237Z should support enabling env/dotenvx (deprecated) ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8715072Z should support disabling getenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8730834Z should support configuration alias -c ...
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8731507Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8732233Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8746837Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8747623Z should support configuration alias -c ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8751983Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ...
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8752686Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8753372Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8776556Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8786764Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8801039Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8811747Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8827327Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8828071Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ... [0m[32mok[0m [0m[38;5;245m(8ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8856791Z should allow user-defined --version option by calling .version(false) ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8882766Z should allow user-defined --help option ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8910570Z should work with --version in strict mode ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8934005Z should handle --version with boolean type ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8957548Z should allow users to explicitly enable help ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.8991645Z should work with multiple custom options including version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9017381Z should allow explicitly enabling built-in --version ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9040654Z should allow explicitly enabling both --version and --help ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9062568Z should allow version with alias ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9090517Z should allow help with alias ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9117808Z should work with both built-in version/help and custom options ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9137428Z should parse simple links notation format ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9141602Z should parse arguments without parentheses ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9143958Z should handle empty input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9144851Z should handle null input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9149760Z should filter out comments ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9180046Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9180662Z [0m[32mok[0m | 58 passed | 0 failed [0m[38;5;245m(99ms)[0m
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9181114Z 
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9397673Z Post job cleanup.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0572564Z Caching is not enabled. Caching is skipped.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0673491Z Post job cleanup.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.2326752Z Post job cleanup.
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3266841Z [command]/usr/bin/git version
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3302668Z git version 2.52.0
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3347144Z Temporarily overriding HOME='/home/runner/work/_temp/8d4897f1-8155-4128-9ef9-77e8314cda6b' before making global git config changes
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3348691Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3360849Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3394491Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3427181Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3685338Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3705265Z http.https://github.com/.extraheader
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3718746Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3749529Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3965997Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3995378Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on ubuntu-latest)	UNKNOWN STEP	2026-01-13T21:25:59.4316003Z Cleaning up orphan processes
+Test (deno on macos-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:49.1879390Z Current runner version: '2.330.0'
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1897950Z ##[group]Runner Image Provisioner
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1898480Z Hosted Compute Agent
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1898890Z Version: 20251211.462
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1899310Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1899810Z Build Date: 2025-12-11T16:28:49Z
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1900360Z Worker ID: {7f34fb2c-ae1e-47d0-ada2-0008ca7af4ad}
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1900850Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1901190Z ##[group]Operating System
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1901600Z macOS
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1901930Z 15.7.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1902230Z 24G419
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1902540Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1902860Z ##[group]Runner Image
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1903200Z Image: macos-15-arm64
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1903530Z Version: 20260105.0094.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1904240Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260105.0094/images/macos/macos-15-arm64-Readme.md
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1905350Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260105.0094
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1906000Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1907940Z ##[group]GITHUB_TOKEN Permissions
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1909220Z Actions: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1909790Z ArtifactMetadata: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1910150Z Attestations: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1910480Z Checks: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1910790Z Contents: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1911110Z Deployments: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1911420Z Discussions: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1911750Z Issues: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1912060Z Metadata: read
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1912400Z Models: read
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1912700Z Packages: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1913040Z Pages: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1913390Z PullRequests: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1915810Z RepositoryProjects: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1916270Z SecurityEvents: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1916610Z Statuses: write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1916950Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1918890Z Secret source: Actions
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.1919330Z Prepare workflow directory
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.2226940Z Prepare all required actions
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.2256330Z Getting action download info
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.5380130Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.8654670Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:49.9846080Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:51.5602790Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.0213390Z Complete job name: Test (deno on macos-latest)
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1082520Z ##[group]Run actions/checkout@v4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1087170Z with:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1088870Z   repository: link-foundation/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1091610Z   token: ***
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1093120Z   ssh-strict: true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1094780Z   ssh-user: git
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1096990Z   persist-credentials: true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1098910Z   clean: true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1100580Z   sparse-checkout-cone-mode: true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1102670Z   fetch-depth: 1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1104250Z   fetch-tags: false
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1106180Z   show-progress: true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1107750Z   lfs: false
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1109060Z   submodules: false
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1110370Z   set-safe-directory: true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.1122160Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5369850Z Syncing repository: link-foundation/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5372020Z ##[group]Getting Git version info
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5373070Z Working directory is '/Users/runner/work/lino-arguments/lino-arguments'
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5374290Z [command]/opt/homebrew/bin/git version
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5665550Z git version 2.52.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5728120Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5745160Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/1f2f5e6e-7d5f-41d1-b669-62c47b8e5fd5/.gitconfig'
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5754340Z Temporarily overriding HOME='/Users/runner/work/_temp/1f2f5e6e-7d5f-41d1-b669-62c47b8e5fd5' before making global git config changes
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5757110Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5758960Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5875440Z Deleting the contents of '/Users/runner/work/lino-arguments/lino-arguments'
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5878050Z ##[group]Initializing the repository
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5881990Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-arguments/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6068390Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6073850Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6075470Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6076870Z hint: call:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6077500Z hint:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6081800Z hint: 	git config --global init.defaultBranch <name>
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6082720Z hint:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6083580Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6084800Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6088910Z hint:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6089570Z hint: 	git branch -m <name>
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6090530Z hint:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6091420Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6093460Z Initialized empty Git repository in /Users/runner/work/lino-arguments/lino-arguments/.git/
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6138380Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6199130Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6200350Z ##[group]Disabling automatic garbage collection
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6201580Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6262650Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6263550Z ##[group]Setting up auth
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6267270Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6335090Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.8266660Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.8448770Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.9750290Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.9851980Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0876400Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0932370Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0932860Z ##[group]Fetching the repository
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:54.0938290Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3125540Z From https://github.com/link-foundation/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3227390Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3334090Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3334510Z ##[group]Determining the checkout info
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3334870Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3335800Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3336550Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3657180Z ##[group]Checking out the ref
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.3665150Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4065960Z Switched to a new branch 'main'
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4168660Z branch 'main' set up to track 'origin/main'.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4278990Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4309410Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4310280Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4708650Z ##[group]Run actions/setup-node@v4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4708910Z with:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4709030Z   node-version: 20.x
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4709170Z   always-auth: false
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4709360Z   check-latest: false
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4709660Z   token: ***
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4709840Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8532980Z Found in cache @ /Users/runner/hostedtoolcache/node/20.19.6/arm64
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:55.8635980Z ##[group]Environment details
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5845520Z node: v20.19.6
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5946490Z npm: 10.8.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5967610Z yarn: 1.22.22
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5970420Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6127440Z ##[group]Run denoland/setup-deno@v2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6127730Z with:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6127940Z   deno-version: v2.x
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6128140Z   deno-binary-name: deno
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6128330Z   cache: false
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.6128470Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0392530Z Going to install stable version 2.6.4.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0543240Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.6.4/deno-aarch64-apple-darwin.zip.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.9794170Z [command]/usr/bin/unzip -o -q /Users/runner/work/_temp/264363f9-db36-43a6-b52c-97eb586acffc
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.9938960Z Cached Deno to /Users/runner/hostedtoolcache/deno/2.6.4/arm64.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0032870Z Installation complete.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0091000Z ##[group]Run npm install
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0091340Z [36;1mnpm install[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0148390Z shell: /bin/bash -e {0}
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.0148590Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.5517180Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.5535340Z > lino-arguments@0.3.0 prepare
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.5537080Z > husky || true
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.5537750Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6876660Z .git can't be found
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6879530Z added 234 packages, and audited 235 packages in 3s
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6900000Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6904810Z 59 packages are looking for funding
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6912450Z   run `npm fund` for details
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6913290Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6930310Z 1 moderate severity vulnerability
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6930870Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6931210Z To address all issues, run:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6931930Z   npm audit fix
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6932200Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.6932650Z Run `npm audit` for details.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7131450Z ##[group]Run deno test --allow-read --allow-env --allow-write
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7132050Z [36;1mdeno test --allow-read --allow-env --allow-write[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7175940Z shell: /bin/bash -e {0}
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.7176270Z ##[endgroup]
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8618190Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fcli
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8624020Z [0m[32mDownload[0m https://registry.npmjs.org/eslint
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8624670Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8625260Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8626030Z [0m[32mDownload[0m https://registry.npmjs.org/getenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8626650Z [0m[32mDownload[0m https://registry.npmjs.org/husky
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8627170Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8627800Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8634740Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8635400Z [0m[32mDownload[0m https://registry.npmjs.org/prettier
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8636200Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:02.8637300Z [0m[32mDownload[0m https://registry.npmjs.org/yargs
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1103290Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fapply-release-plan
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1107460Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fassemble-release-plan
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1108100Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fchangelog-git
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1108670Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fconfig
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1207600Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ferrors
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1208670Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-dependents-graph
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1209360Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-release-plan
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1209950Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fgit
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1210470Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2flogger
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1210960Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fpre
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1211420Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fread
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1212040Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fshould-skip-package
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1212660Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ftypes
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1213200Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fwrite
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1213840Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer%2fexternal-editor
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1214430Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2fget-packages
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1214950Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1215550Z [0m[32mDownload[0m https://registry.npmjs.org/ci-info
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1215950Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1216420Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1216930Z [0m[32mDownload[0m https://registry.npmjs.org/mri
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1217410Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1217930Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1218370Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1218860Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1219310Z [0m[32mDownload[0m https://registry.npmjs.org/semver
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1219770Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.1220300Z [0m[32mDownload[0m https://registry.npmjs.org/term-size
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2683120Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2feslint-utils
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2683950Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2fregexpp
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2684570Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-array
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2685190Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-helpers
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2685810Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fcore
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2686380Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2feslintrc
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2687000Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fjs
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2687500Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fplugin-kit
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2687970Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fnode
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2688650Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fmodule-importer
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2689510Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fretry
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2690010Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2festree
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2690510Z [0m[32mDownload[0m https://registry.npmjs.org/ajv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2690940Z [0m[32mDownload[0m https://registry.npmjs.org/chalk
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2691400Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2691900Z [0m[32mDownload[0m https://registry.npmjs.org/debug
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2692430Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2692930Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2693430Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2693920Z [0m[32mDownload[0m https://registry.npmjs.org/espree
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2694400Z [0m[32mDownload[0m https://registry.npmjs.org/esquery
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2694780Z [0m[32mDownload[0m https://registry.npmjs.org/esutils
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2695220Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2695650Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2696060Z [0m[32mDownload[0m https://registry.npmjs.org/find-up
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2696520Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2696990Z [0m[32mDownload[0m https://registry.npmjs.org/ignore
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2697460Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2698040Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2698440Z [0m[32mDownload[0m https://registry.npmjs.org/jiti
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2698920Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2699470Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2699860Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2700330Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.2700790Z [0m[32mDownload[0m https://registry.npmjs.org/optionator
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4386300Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2feslint
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4388100Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.4389420Z [0m[32mDownload[0m https://registry.npmjs.org/synckit
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5145840Z [0m[32mDownload[0m https://registry.npmjs.org/commander
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5147200Z [0m[32mDownload[0m https://registry.npmjs.org/listr2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5148290Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5148740Z [0m[32mDownload[0m https://registry.npmjs.org/nano-spawn
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5149260Z [0m[32mDownload[0m https://registry.npmjs.org/pidtree
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5149660Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.5150420Z [0m[32mDownload[0m https://registry.npmjs.org/yaml
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7069710Z [0m[32mDownload[0m https://registry.npmjs.org/cliui
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7109080Z [0m[32mDownload[0m https://registry.npmjs.org/escalade
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7120330Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7122300Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7124030Z [0m[32mDownload[0m https://registry.npmjs.org/string-width
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7125650Z [0m[32mDownload[0m https://registry.npmjs.org/y18n
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7127070Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7713810Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-version-range-type
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7715300Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7716490Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.7718540Z [0m[32mDownload[0m https://registry.npmjs.org/outdent
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.8689820Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9068350Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9393990Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fparse
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9394620Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0068700Z [0m[32mDownload[0m https://registry.npmjs.org/human-id
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0578110Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fnode
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0580090Z [0m[32mDownload[0m https://registry.npmjs.org/chardet
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0581470Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5674410Z [0m[32mDownload[0m https://registry.npmjs.org/@babel%2fruntime
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5675960Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2ffind-root
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5677620Z [0m[32mDownload[0m https://registry.npmjs.org/globby
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5678960Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.8103200Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.8516500Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.8517360Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.8517900Z [0m[32mDownload[0m https://registry.npmjs.org/universalify
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9348550Z [0m[32mDownload[0m https://registry.npmjs.org/p-try
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9640320Z [0m[32mDownload[0m https://registry.npmjs.org/quansync
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0157600Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0522340Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fobject-schema
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1137330Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fjson-schema
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2124410Z [0m[32mDownload[0m https://registry.npmjs.org/globals
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2127030Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2129000Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2129450Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2703160Z [0m[32mDownload[0m https://registry.npmjs.org/levn
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.3030770Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fcore
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.3709200Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.3710400Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.3711170Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.4207260Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.4207780Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.4889980Z [0m[32mDownload[0m https://registry.npmjs.org/path-key
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.4897640Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.4898360Z [0m[32mDownload[0m https://registry.npmjs.org/which
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.5542930Z [0m[32mDownload[0m https://registry.npmjs.org/ms
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.5774590Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.5775340Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.6118510Z [0m[32mDownload[0m https://registry.npmjs.org/acorn
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.6120250Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.6537240Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.7725680Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.7728020Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.8316160Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.8604210Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.9381590Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.9484240Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.9586510Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.9661210Z [0m[32mDownload[0m https://registry.npmjs.org/type-check
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.9662130Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.9908100Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.0293850Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr%2fcore
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.1406300Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.1485790Z [0m[32mDownload[0m https://registry.npmjs.org/colorette
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.1486610Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.1487180Z [0m[32mDownload[0m https://registry.npmjs.org/log-update
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.1487760Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.1488210Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.2320320Z [0m[32mDownload[0m https://registry.npmjs.org/braces
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.2321130Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.2780200Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.2780740Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.3107900Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.3583360Z [0m[32mDownload[0m https://registry.npmjs.org/p-map
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4097730Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4511610Z [0m[32mDownload[0m https://registry.npmjs.org/array-union
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4514790Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4518900Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4522290Z [0m[32mDownload[0m https://registry.npmjs.org/merge2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.4524920Z [0m[32mDownload[0m https://registry.npmjs.org/slash
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.5358340Z [0m[32mDownload[0m https://registry.npmjs.org/pify
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.5361780Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.5877460Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.6333150Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.6745690Z [0m[32mDownload[0m https://registry.npmjs.org/argparse
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.7240990Z [0m[32mDownload[0m https://registry.npmjs.org/punycode
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.7650110Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.7902170Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.8354170Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.8756500Z [0m[32mDownload[0m https://registry.npmjs.org/isexe
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.9481120Z [0m[32mDownload[0m https://registry.npmjs.org/flatted
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.9483160Z [0m[32mDownload[0m https://registry.npmjs.org/keyv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:06.9871760Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.0578010Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.0579480Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.1081870Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.1419780Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.1420450Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.1834520Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.2083410Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.2333800Z [0m[32mDownload[0m https://registry.npmjs.org/path-type
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.2763960Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.stat
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.2765950Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.walk
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.3360660Z [0m[32mDownload[0m https://registry.npmjs.org/esprima
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.4096040Z [0m[32mDownload[0m https://registry.npmjs.org/callsites
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.4618060Z [0m[32mDownload[0m https://registry.npmjs.org/color-name
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.4874430Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.5365850Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.5955130Z [0m[32mDownload[0m https://registry.npmjs.org/environment
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.6386920Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.6798150Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.7130400Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.scandir
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.7131620Z [0m[32mDownload[0m https://registry.npmjs.org/fastq
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.7683330Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.8032100Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.8693940Z [0m[32mDownload[0m https://registry.npmjs.org/onetime
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.8992820Z [0m[32mDownload[0m https://registry.npmjs.org/is-number
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:07.9463600Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.0077970Z [0m[32mDownload[0m https://registry.npmjs.org/reusify
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.0389500Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.0828800Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1579400Z [0m[32mDownload[0m https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1581000Z [0m[32mDownload[0m https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1582830Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1584680Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1586140Z [0m[32mDownload[0m https://registry.npmjs.org/husky/-/husky-9.1.7.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1587660Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1589290Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere/-/test-anywhere-0.6.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1590790Z [0m[32mDownload[0m https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1592450Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1594520Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1596300Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1599020Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1600180Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1600810Z [0m[32mDownload[0m https://registry.npmjs.org/espree/-/espree-10.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1601600Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1602360Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1602970Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1603610Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1604240Z [0m[32mDownload[0m https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1604850Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1605700Z [0m[32mDownload[0m https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1606490Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1607220Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1607790Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1608350Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1608860Z [0m[32mDownload[0m https://registry.npmjs.org/debug/-/debug-4.4.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1609370Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1611380Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1613240Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1615010Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1616910Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1618770Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1620620Z [0m[32mDownload[0m https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1622270Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1623490Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1624220Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1625020Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1625610Z [0m[32mDownload[0m https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1626290Z [0m[32mDownload[0m https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1626910Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1627580Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1628190Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1628730Z [0m[32mDownload[0m https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1630280Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1632140Z [0m[32mDownload[0m https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1633380Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1634460Z [0m[32mDownload[0m https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1635030Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1635600Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1636130Z [0m[32mDownload[0m https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1636630Z [0m[32mDownload[0m https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1637160Z [0m[32mDownload[0m https://registry.npmjs.org/commander/-/commander-14.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1637740Z [0m[32mDownload[0m https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1638300Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1638890Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1640260Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1640960Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1641570Z [0m[32mDownload[0m https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1642120Z [0m[32mDownload[0m https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1654640Z [0m[32mDownload[0m https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1655740Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1656450Z [0m[32mDownload[0m https://registry.npmjs.org/semver/-/semver-7.7.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1657050Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1657730Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.14.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1658380Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1659080Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1659720Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1660240Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1660930Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1661530Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1662090Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1662640Z [0m[32mDownload[0m https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1663120Z [0m[32mDownload[0m https://registry.npmjs.org/mri/-/mri-1.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1663660Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1664390Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1665000Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1665580Z [0m[32mDownload[0m https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1667170Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1667960Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.14.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1668660Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1669250Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1670600Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1671230Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/read/-/read-0.6.6.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1671860Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1672450Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1673020Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1673710Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1674360Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1675050Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1675680Z [0m[32mDownload[0m https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1676600Z [0m[32mDownload[0m https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1677150Z [0m[32mDownload[0m https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1677660Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1678210Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1678760Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1679320Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1679970Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1680570Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1681210Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1681990Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1682670Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1683190Z [0m[32mDownload[0m https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1683690Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1684170Z [0m[32mDownload[0m https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1684680Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1685220Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1686200Z [0m[32mDownload[0m https://registry.npmjs.org/globals/-/globals-14.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1687000Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1687630Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1688260Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1688880Z [0m[32mDownload[0m https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1689430Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1690100Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1690680Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1691210Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1692030Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1693130Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1693750Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1694290Z [0m[32mDownload[0m https://registry.npmjs.org/which/-/which-2.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1695000Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1695570Z [0m[32mDownload[0m https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1696170Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1696730Z [0m[32mDownload[0m https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1697410Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1698100Z [0m[32mDownload[0m https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1698680Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1699650Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1700240Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1700750Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1701320Z [0m[32mDownload[0m https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1701920Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1702530Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1703300Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1703920Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1704460Z [0m[32mDownload[0m https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1705050Z [0m[32mDownload[0m https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1705840Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1706610Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1707270Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1707820Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1708350Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1708890Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1709440Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1710020Z [0m[32mDownload[0m https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1710570Z [0m[32mDownload[0m https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1711100Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1711630Z [0m[32mDownload[0m https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1712170Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1712680Z [0m[32mDownload[0m https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1713210Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/parse/-/parse-0.4.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1713750Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1714360Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1715310Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1715940Z [0m[32mDownload[0m https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1716570Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1717130Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1717640Z [0m[32mDownload[0m https://registry.npmjs.org/globby/-/globby-11.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1718250Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1718860Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1719420Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1719960Z [0m[32mDownload[0m https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1720500Z [0m[32mDownload[0m https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1721240Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1721800Z [0m[32mDownload[0m https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1722370Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1722940Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1723490Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1724100Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1724650Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1725150Z [0m[32mDownload[0m https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1725680Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1726430Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1727020Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1727560Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1728110Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1728660Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1729190Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1729750Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1730330Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1730970Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1731590Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1732210Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1732930Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1733610Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1734200Z [0m[32mDownload[0m https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1734790Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1735370Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1735980Z [0m[32mDownload[0m https://registry.npmjs.org/pify/-/pify-4.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1736510Z [0m[32mDownload[0m https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1737320Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1737870Z [0m[32mDownload[0m https://registry.npmjs.org/slash/-/slash-3.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1738400Z [0m[32mDownload[0m https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1738960Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1739490Z [0m[32mDownload[0m https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1739990Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1740530Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1741060Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1741580Z [0m[32mDownload[0m https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1742120Z [0m[32mDownload[0m https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1743170Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1743740Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1744350Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1745100Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1745790Z [0m[32mDownload[0m https://registry.npmjs.org/environment/-/environment-1.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1746360Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1747030Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1747680Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1748230Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1748750Z [0m[32mDownload[0m https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1749320Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1749880Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1750450Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1751010Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1751550Z [0m[32mDownload[0m https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1752100Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1752650Z [0m[32mDownload[0m https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1753170Z [0m[32mDownload[0m https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1753710Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1754240Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1754780Z [0m[32mDownload[0m https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1755330Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1756680Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1757530Z [0m[32mDownload[0m https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1758100Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.1758710Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2130950Z [0m[32mInitialize[0m lodash.merge@4.6.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2212230Z [0m[32mInitialize[0m eslint-plugin-prettier@5.5.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2248850Z [0m[32mInitialize[0m getenv@2.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2265580Z [0m[32mInitialize[0m string-argv@0.3.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2273060Z [0m[32mInitialize[0m require-directory@2.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2434590Z [0m[32mInitialize[0m debug@4.4.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2435090Z [0m[32mInitialize[0m cliui@8.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2501760Z [0m[32mInitialize[0m esquery@1.7.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2528180Z [0m[32mInitialize[0m mri@1.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2542470Z [0m[32mInitialize[0m optionator@0.9.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2553440Z [0m[32mInitialize[0m eslint-config-prettier@10.1.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2553930Z [0m[32mInitialize[0m @humanwhocodes/module-importer@1.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2554330Z [0m[32mInitialize[0m micromatch@4.0.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2554690Z [0m[32mInitialize[0m yargs-parser@21.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2555080Z [0m[32mInitialize[0m chalk@4.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2646710Z [0m[32mInitialize[0m string-width@4.2.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2752810Z [0m[32mInitialize[0m fast-deep-equal@3.1.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.2883060Z [0m[32mInitialize[0m nano-spawn@2.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3072460Z [0m[32mInitialize[0m esutils@2.0.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3073170Z [0m[32mInitialize[0m minimatch@3.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3073680Z [0m[32mInitialize[0m @types/json-schema@7.0.15
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3074220Z [0m[32mInitialize[0m glob-parent@6.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3074730Z [0m[32mInitialize[0m picocolors@1.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3075060Z [0m[32mInitialize[0m husky@9.1.7
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3075400Z [0m[32mInitialize[0m acorn-jsx@5.3.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3075790Z [0m[32mInitialize[0m cross-spawn@7.0.6
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3076070Z [0m[32mInitialize[0m synckit@0.11.11
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3076340Z [0m[32mInitialize[0m commander@14.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3076610Z [0m[32mInitialize[0m find-up@5.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3076920Z [0m[32mInitialize[0m imurmurhash@0.1.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3077260Z [0m[32mInitialize[0m p-limit@2.3.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3077520Z [0m[32mInitialize[0m uri-js@4.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3077780Z [0m[32mInitialize[0m ci-info@3.9.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3078080Z [0m[32mInitialize[0m natural-compare@1.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3078460Z [0m[32mInitialize[0m prettier-linter-helpers@1.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3078780Z [0m[32mInitialize[0m ignore@5.3.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3079090Z [0m[32mInitialize[0m get-caller-file@2.0.5
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3079380Z [0m[32mInitialize[0m ansi-colors@4.1.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3257500Z [0m[32mInitialize[0m lino-env@0.2.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3400190Z [0m[32mInitialize[0m eslint-visitor-keys@3.4.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3523340Z [0m[32mInitialize[0m escape-string-regexp@4.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3721900Z [0m[32mInitialize[0m levn@0.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.3844330Z [0m[32mInitialize[0m file-entry-cache@8.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4117930Z [0m[32mInitialize[0m @eslint-community/eslint-utils@4.9.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4118470Z [0m[32mInitialize[0m spawndamnit@3.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4235000Z [0m[32mInitialize[0m is-glob@4.0.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4365470Z [0m[32mInitialize[0m flat-cache@4.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4492860Z [0m[32mInitialize[0m json-schema-traverse@0.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4599990Z [0m[32mInitialize[0m espree@10.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4670420Z [0m[32mInitialize[0m y18n@5.0.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4774990Z [0m[32mInitialize[0m escalade@3.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4878050Z [0m[32mInitialize[0m @eslint/config-helpers@0.4.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.4983190Z [0m[32mInitialize[0m resolve-from@5.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5084820Z [0m[32mInitialize[0m yaml@2.8.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5191700Z [0m[32mInitialize[0m json-stable-stringify-without-jsonify@1.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5297790Z [0m[32mInitialize[0m pidtree@0.6.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5307020Z [0m[32mInitialize[0m @eslint/core@0.17.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5410220Z [0m[32mInitialize[0m lint-staged@16.2.7
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5518320Z [0m[32mInitialize[0m ms@2.1.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5624140Z [0m[32mInitialize[0m eslint-visitor-keys@4.2.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5728150Z [0m[32mInitialize[0m path-exists@4.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5742620Z [0m[32mInitialize[0m eslint-scope@8.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.5964290Z [0m[32mInitialize[0m brace-expansion@1.1.12
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.6001340Z [0m[32mInitialize[0m fast-levenshtein@2.0.6
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.6530650Z [0m[32mInitialize[0m signal-exit@4.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.6764650Z [0m[32mInitialize[0m balanced-match@1.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.6949780Z [0m[32mInitialize[0m @changesets/git@3.0.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7098810Z [0m[32mInitialize[0m fill-range@7.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7233980Z [0m[32mInitialize[0m @types/estree@1.0.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7337920Z [0m[32mInitialize[0m listr2@9.0.5
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7444560Z [0m[32mInitialize[0m is-extglob@2.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7445050Z [0m[32mInitialize[0m globals@14.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7568850Z [0m[32mInitialize[0m @changesets/errors@0.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7601470Z [0m[32mInitialize[0m strip-json-comments@3.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7602140Z [0m[32mInitialize[0m @humanfs/node@0.16.7
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7602640Z [0m[32mInitialize[0m which@2.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7603170Z [0m[32mInitialize[0m @changesets/pre@2.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7603660Z [0m[32mInitialize[0m fs-extra@7.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7604150Z [0m[32mInitialize[0m ansi-styles@4.3.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7604670Z [0m[32mInitialize[0m word-wrap@1.2.5
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7605180Z [0m[32mInitialize[0m @eslint/config-array@0.21.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7605730Z [0m[32mInitialize[0m @changesets/logger@0.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7606340Z [0m[32mInitialize[0m @changesets/get-dependents-graph@2.1.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7606900Z [0m[32mInitialize[0m locate-path@6.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7607580Z [0m[32mInitialize[0m fast-json-stable-stringify@2.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7608110Z [0m[32mInitialize[0m estraverse@5.3.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7608590Z [0m[32mInitialize[0m acorn@8.15.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7609120Z [0m[32mInitialize[0m @eslint/plugin-kit@0.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7609630Z [0m[32mInitialize[0m @changesets/read@0.6.6
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7610140Z [0m[32mInitialize[0m lodash.startcase@4.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7610540Z [0m[32mInitialize[0m path-key@3.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7611000Z [0m[32mInitialize[0m type-check@0.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7611540Z [0m[32mInitialize[0m @humanwhocodes/retry@0.4.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7612050Z [0m[32mInitialize[0m import-fresh@3.3.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7645290Z [0m[32mInitialize[0m deep-is@0.1.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7647410Z [0m[32mInitialize[0m shebang-command@2.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7661900Z [0m[32mInitialize[0m jsonfile@4.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7663090Z [0m[32mInitialize[0m detect-indent@6.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7664150Z [0m[32mInitialize[0m @eslint-community/regexpp@4.12.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7665430Z [0m[32mInitialize[0m @changesets/should-skip-package@0.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7666480Z [0m[32mInitialize[0m term-size@2.2.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7667350Z [0m[32mInitialize[0m semver@7.7.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7668220Z [0m[32mInitialize[0m js-yaml@4.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7669150Z [0m[32mInitialize[0m @manypkg/get-packages@1.1.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7670110Z [0m[32mInitialize[0m test-anywhere@0.6.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7675340Z [0m[32mInitialize[0m package-manager-detector@0.2.11
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7675780Z [0m[32mInitialize[0m emoji-regex@8.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7676580Z [0m[32mInitialize[0m @inquirer/external-editor@1.0.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7692920Z [0m[32mInitialize[0m cli-truncate@5.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7693310Z [0m[32mInitialize[0m @changesets/get-release-plan@4.0.14
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7693760Z [0m[32mInitialize[0m @changesets/assemble-release-plan@6.0.9
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7694140Z [0m[32mInitialize[0m rfdc@1.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7697030Z [0m[32mInitialize[0m @changesets/types@6.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7697460Z [0m[32mInitialize[0m @changesets/cli@2.29.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7697840Z [0m[32mInitialize[0m links-notation@0.11.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7698200Z [0m[32mInitialize[0m @eslint/eslintrc@3.3.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7698570Z [0m[32mInitialize[0m yargs@17.7.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7698910Z [0m[32mInitialize[0m enquirer@2.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7699270Z [0m[32mInitialize[0m eventemitter3@5.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7699700Z [0m[32mInitialize[0m is-fullwidth-code-point@3.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7700070Z [0m[32mInitialize[0m p-try@2.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7706400Z [0m[32mInitialize[0m ajv@6.12.6
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7706980Z [0m[32mInitialize[0m wrap-ansi@7.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7707350Z [0m[32mInitialize[0m log-update@6.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7707870Z [0m[32mInitialize[0m p-filter@2.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7708250Z [0m[32mInitialize[0m strip-ansi@6.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7708770Z [0m[32mInitialize[0m @humanfs/core@0.19.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7709860Z [0m[32mInitialize[0m @changesets/changelog-git@0.2.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7710200Z [0m[32mInitialize[0m fs-extra@8.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7710470Z [0m[32mInitialize[0m keyv@4.5.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7710950Z [0m[32mInitialize[0m supports-color@7.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7711290Z [0m[32mInitialize[0m picomatch@2.3.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7711570Z [0m[32mInitialize[0m outdent@0.5.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7712010Z [0m[32mInitialize[0m universalify@0.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7712320Z [0m[32mInitialize[0m @changesets/config@3.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7712660Z [0m[32mInitialize[0m quansync@0.2.11
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7712950Z [0m[32mInitialize[0m flatted@3.3.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7714100Z [0m[32mInitialize[0m read-yaml-file@1.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7714390Z [0m[32mInitialize[0m esrecurse@4.3.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7714790Z [0m[32mInitialize[0m has-flag@4.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7715140Z [0m[32mInitialize[0m prelude-ls@1.2.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7715440Z [0m[32mInitialize[0m extendable-error@0.1.7
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7715890Z [0m[32mInitialize[0m is-subdir@1.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7716200Z [0m[32mInitialize[0m graceful-fs@4.2.11
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7716660Z [0m[32mInitialize[0m parent-module@1.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7716950Z [0m[32mInitialize[0m iconv-lite@0.7.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7717260Z [0m[32mInitialize[0m @changesets/write@0.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7717550Z [0m[32mInitialize[0m ansi-regex@5.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7717810Z [0m[32mInitialize[0m isexe@2.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7718220Z [0m[32mInitialize[0m color-convert@2.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7718810Z [0m[32mInitialize[0m @changesets/get-version-range-type@0.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7719160Z [0m[32mInitialize[0m p-locate@5.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7719430Z [0m[32mInitialize[0m eslint@9.39.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7719770Z [0m[32mInitialize[0m string-width@7.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7720980Z [0m[32mInitialize[0m resolve-from@4.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7721290Z [0m[32mInitialize[0m strip-ansi@7.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7721790Z [0m[32mInitialize[0m @eslint/object-schema@2.1.7
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7722140Z [0m[32mInitialize[0m braces@3.0.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7722750Z [0m[32mInitialize[0m string-width@8.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7723280Z [0m[32mInitialize[0m human-id@4.1.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7723810Z [0m[32mInitialize[0m json-buffer@3.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7724080Z [0m[32mInitialize[0m chardet@2.1.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7724380Z [0m[32mInitialize[0m js-yaml@3.14.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7724730Z [0m[32mInitialize[0m to-regex-range@5.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7725060Z [0m[32mInitialize[0m environment@1.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7725410Z [0m[32mInitialize[0m ansi-styles@6.2.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7725930Z [0m[32mInitialize[0m ansi-regex@6.2.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7727740Z [0m[32mInitialize[0m p-limit@3.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7730280Z [0m[32mInitialize[0m ansi-escapes@7.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7730720Z [0m[32mInitialize[0m @changesets/apply-release-plan@7.0.14
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7775670Z [0m[32mInitialize[0m wrap-ansi@9.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7776610Z [0m[32mInitialize[0m @eslint/js@9.39.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7777360Z [0m[32mInitialize[0m find-up@4.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7777700Z [0m[32mInitialize[0m fast-diff@1.3.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7778000Z [0m[32mInitialize[0m slash@3.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7778450Z [0m[32mInitialize[0m callsites@3.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7778800Z [0m[32mInitialize[0m concat-map@0.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7779170Z [0m[32mInitialize[0m argparse@2.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7779470Z [0m[32mInitialize[0m fast-glob@3.3.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7779800Z [0m[32mInitialize[0m array-union@2.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7780200Z [0m[32mInitialize[0m shebang-regex@3.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7780520Z [0m[32mInitialize[0m globby@11.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7780860Z [0m[32mInitialize[0m slice-ansi@7.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7781140Z [0m[32mInitialize[0m color-name@1.1.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7781430Z [0m[32mInitialize[0m is-windows@1.0.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7923580Z [0m[32mInitialize[0m punycode@2.3.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7925140Z [0m[32mInitialize[0m is-fullwidth-code-point@5.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7928430Z [0m[32mInitialize[0m locate-path@5.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7930200Z [0m[32mInitialize[0m colorette@2.0.20
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7931380Z [0m[32mInitialize[0m get-east-asian-width@1.4.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7931890Z [0m[32mInitialize[0m dir-glob@3.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7932320Z [0m[32mInitialize[0m strip-bom@3.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7932660Z [0m[32mInitialize[0m p-locate@4.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7933450Z [0m[32mInitialize[0m cli-cursor@5.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7933810Z [0m[32mInitialize[0m pify@4.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7934150Z [0m[32mInitialize[0m merge2@1.4.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7935860Z [0m[32mInitialize[0m better-path-resolve@1.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7936370Z [0m[32mInitialize[0m @manypkg/find-root@1.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7936750Z [0m[32mInitialize[0m run-parallel@1.2.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7937150Z [0m[32mInitialize[0m @changesets/types@4.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7937450Z [0m[32mInitialize[0m onetime@7.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7940010Z [0m[32mInitialize[0m mimic-function@5.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7946230Z [0m[32mInitialize[0m queue-microtask@1.2.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7949510Z [0m[32mInitialize[0m p-map@2.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7950280Z [0m[32mInitialize[0m @changesets/parse@0.4.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7951450Z [0m[32mInitialize[0m yocto-queue@0.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7952010Z [0m[32mInitialize[0m glob-parent@5.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7952360Z [0m[32mInitialize[0m restore-cursor@5.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7954170Z [0m[32mInitialize[0m is-number@7.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7954480Z [0m[32mInitialize[0m esprima@4.0.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7954820Z [0m[32mInitialize[0m emoji-regex@10.6.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7955140Z [0m[32mInitialize[0m @pkgr/core@0.2.9
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7955480Z [0m[32mInitialize[0m path-type@4.0.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7955810Z [0m[32mInitialize[0m sprintf-js@1.0.3
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7956110Z [0m[32mInitialize[0m @nodelib/fs.stat@2.0.5
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7957010Z [0m[32mInitialize[0m fastq@1.20.1
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7957310Z [0m[32mInitialize[0m @nodelib/fs.walk@1.2.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7957640Z [0m[32mInitialize[0m reusify@1.1.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7958000Z [0m[32mInitialize[0m @nodelib/fs.scandir@2.1.5
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7958360Z [0m[32mInitialize[0m argparse@1.0.10
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7959000Z [0m[32mInitialize[0m safer-buffer@2.1.2
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.7959500Z [0m[32mInitialize[0m @types/node@12.20.55
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.8078650Z [0m[32mInitialize[0m @babel/runtime@7.28.6
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.8301970Z [0m[32mInitialize[0m prettier@3.7.4
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:08.8567070Z [0m[32mInitialize[0m prettier@2.8.8
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4077650Z [0m[38;5;245mrunning 58 tests from ./tests/index.test.js[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4080410Z should convert camelCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4082240Z should convert kebab-case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4084130Z should convert snake_case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4086220Z should convert PascalCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4093940Z should handle already UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4095580Z should convert kebab-case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4097210Z should convert UPPER_CASE to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4102610Z should convert snake_case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4104420Z should convert PascalCase to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4113770Z should handle already camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4115060Z should convert camelCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4115920Z should convert UPPER_CASE to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4116520Z should convert PascalCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4117160Z should handle already kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4117690Z should convert camelCase to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4118220Z should convert kebab-case to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4118780Z should convert UPPER_CASE to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4119290Z should handle already snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4119800Z should convert camelCase to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4120350Z should convert kebab-case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4120970Z should convert snake_case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4121560Z should handle already PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4122510Z should find variable in UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4123750Z should find variable in camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4125330Z should find variable in kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4134530Z should return default value when not found ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4135510Z should return empty string as default when not specified ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4141280Z should try original key first ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4350180Z should work with minimal configuration ... [0m[32mok[0m [0m[38;5;245m(20ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4476550Z should use CLI arguments with highest priority ... [0m[32mok[0m [0m[38;5;245m(9ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4497180Z should convert kebab-case to camelCase in result ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4639810Z should load .lenv file by default ...
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4642680Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4643940Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4699200Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4805180Z should load .lenv file by default ... [0m[32mok[0m [0m[38;5;245m(20ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4822160Z should handle --configuration flag ...
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4823460Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4835160Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4837290Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4839280Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4839870Z should handle --configuration flag ... [0m[32mok[0m [0m[38;5;245m(12ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4886920Z should prioritize CLI over environment ...
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4888110Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4888940Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4892420Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4893180Z should prioritize CLI over environment ... [0m[32mok[0m [0m[38;5;245m(6ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4922630Z should handle missing .lenv file gracefully ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4932420Z should convert all keys to UPPER_CASE in process.env ...
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4943930Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4945650Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4953750Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4954540Z should convert all keys to UPPER_CASE in process.env ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.4983540Z should find env vars in any case format via getenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5172100Z should support disabling lenv ... [0m[32mok[0m [0m[38;5;245m(7ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5217710Z should support enabling env/dotenvx (deprecated) ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5225120Z should support disabling getenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5238550Z should support configuration alias -c ...
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5239700Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5240470Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5267470Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5269080Z should support configuration alias -c ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5282810Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ...
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5284280Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5285940Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5373910Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5382440Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5393970Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5397130Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5411130Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5414200Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ... [0m[32mok[0m [0m[38;5;245m(14ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5472280Z should allow user-defined --version option by calling .version(false) ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5500740Z should allow user-defined --help option ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5518880Z should work with --version in strict mode ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5541320Z should handle --version with boolean type ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5573510Z should allow users to explicitly enable help ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5606030Z should work with multiple custom options including version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5626310Z should allow explicitly enabling built-in --version ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5647230Z should allow explicitly enabling both --version and --help ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5662860Z should allow version with alias ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5702990Z should allow help with alias ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5724230Z should work with both built-in version/help and custom options ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5766990Z should parse simple links notation format ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5792990Z should parse arguments without parentheses ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5795530Z should handle empty input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5799740Z should handle null input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5801660Z should filter out comments ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5890420Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5891920Z [0m[32mok[0m | 58 passed | 0 failed [0m[38;5;245m(181ms)[0m
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.5895670Z 
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.6155390Z Post job cleanup.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.7969420Z Caching is not enabled. Caching is skipped.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.8057650Z Post job cleanup.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:09.9761450Z Post job cleanup.
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1014590Z [command]/opt/homebrew/bin/git version
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1264450Z git version 2.52.0
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1316240Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/898a3caf-4e12-4c3c-92e2-3e5874488eb3/.gitconfig'
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1317210Z Temporarily overriding HOME='/Users/runner/work/_temp/898a3caf-4e12-4c3c-92e2-3e5874488eb3' before making global git config changes
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1318330Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1319470Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1480520Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.1513250Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.2923960Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.2974330Z http.https://github.com/.extraheader
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.2982640Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.3110530Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.4069640Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.4125690Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:10.5389030Z Cleaning up orphan processes
+Test (bun on macos-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:52.5184160Z Current runner version: '2.330.0'
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5199940Z ##[group]Runner Image Provisioner
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5200420Z Hosted Compute Agent
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5200750Z Version: 20251211.462
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5201120Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5201540Z Build Date: 2025-12-11T16:28:49Z
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5201950Z Worker ID: {d0b86da6-75bc-4db2-8491-ecb7e1deedd8}
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5202360Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5202690Z ##[group]Operating System
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5203030Z macOS
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5203310Z 15.7.3
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5203570Z 24G419
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5203840Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5204140Z ##[group]Runner Image
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5204470Z Image: macos-15-arm64
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5205010Z Version: 20260105.0094.1
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5205690Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260105.0094/images/macos/macos-15-arm64-Readme.md
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5206740Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260105.0094
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5207360Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5209160Z ##[group]GITHUB_TOKEN Permissions
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5210400Z Actions: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5210720Z ArtifactMetadata: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5211050Z Attestations: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5211380Z Checks: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5211730Z Contents: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5212040Z Deployments: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5212380Z Discussions: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5212690Z Issues: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5213010Z Metadata: read
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5213400Z Models: read
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5213710Z Packages: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5214010Z Pages: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5214310Z PullRequests: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5214690Z RepositoryProjects: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5215040Z SecurityEvents: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5215470Z Statuses: write
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5215790Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5218390Z Secret source: Actions
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5218880Z Prepare workflow directory
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5469520Z Prepare all required actions
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.5496060Z Getting action download info
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8211740Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.3581500Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:53.5315230Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:54.9843700Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.4627130Z Complete job name: Test (bun on macos-latest)
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5372840Z ##[group]Run actions/checkout@v4
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5373840Z with:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5374390Z   repository: link-foundation/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5375360Z   token: ***
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5375840Z   ssh-strict: true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5376360Z   ssh-user: git
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5376870Z   persist-credentials: true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5377440Z   clean: true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5377970Z   sparse-checkout-cone-mode: true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5378590Z   fetch-depth: 1
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5379090Z   fetch-tags: false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5379640Z   show-progress: true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5380150Z   lfs: false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5380620Z   submodules: false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5381130Z   set-safe-directory: true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.5381900Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9009610Z Syncing repository: link-foundation/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9011620Z ##[group]Getting Git version info
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9013140Z Working directory is '/Users/runner/work/lino-arguments/lino-arguments'
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9014550Z [command]/opt/homebrew/bin/git version
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9536170Z git version 2.52.0
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9564570Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9570700Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/7d4117fd-a2af-4ae1-8faf-449dc0d19b08/.gitconfig'
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9581850Z Temporarily overriding HOME='/Users/runner/work/_temp/7d4117fd-a2af-4ae1-8faf-449dc0d19b08' before making global git config changes
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9583920Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9585520Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9679560Z Deleting the contents of '/Users/runner/work/lino-arguments/lino-arguments'
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9682350Z ##[group]Initializing the repository
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9686790Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-arguments/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9857480Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9858790Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9859910Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9860950Z hint: call:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9861430Z hint:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9862060Z hint: 	git config --global init.defaultBranch <name>
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9862780Z hint:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9863450Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9864550Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9865440Z hint:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9867050Z hint: 	git branch -m <name>
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9867890Z hint:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9868640Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9869950Z Initialized empty Git repository in /Users/runner/work/lino-arguments/lino-arguments/.git/
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9872270Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9943410Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9944350Z ##[group]Disabling automatic garbage collection
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:56.9945380Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0003240Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0004120Z ##[group]Setting up auth
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0007200Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0078600Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.0982350Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.1047970Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.1756090Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.1818430Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.2541360Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.2616850Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.2621740Z ##[group]Fetching the repository
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:57.2623490Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.3913320Z From https://github.com/link-foundation/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.3914170Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4009610Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4009990Z ##[group]Determining the checkout info
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4010500Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4015750Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4091180Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4152350Z ##[group]Checking out the ref
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4155140Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4402020Z Switched to a new branch 'main'
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4405660Z branch 'main' set up to track 'origin/main'.
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4410550Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4493480Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4552230Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4765220Z ##[group]Run actions/setup-node@v4
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4765460Z with:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4765590Z   node-version: 20.x
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4765740Z   always-auth: false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4765900Z   check-latest: false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4766170Z   token: ***
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4766320Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6197830Z Found in cache @ /Users/runner/hostedtoolcache/node/20.19.6/arm64
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:58.6202260Z ##[group]Environment details
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.2920480Z node: v20.19.6
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.2995710Z npm: 10.8.2
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.2997070Z yarn: 1.22.22
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.2997910Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3095770Z ##[group]Run oven-sh/setup-bun@v2
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3096050Z with:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3096340Z   bun-version: latest
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3096570Z   no-cache: false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.3096780Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5116100Z Downloading a new version of Bun: https://bun.sh/download/latest/darwin/arm64?avx2=true&profile=false
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.2205640Z [command]/usr/bin/unzip -o -q /Users/runner/work/_temp/b9098ac1-380e-45e3-979c-0b193d0b7ed0.zip
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.7345400Z [command]/Users/runner/.bun/bin/bun --revision
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.7449030Z 1.3.6+d530ed993
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.7539180Z ##[group]Run npm install
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.7539600Z [36;1mnpm install[0m
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.7591150Z shell: /bin/bash -e {0}
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:00.7591410Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9001690Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9003560Z > lino-arguments@0.3.0 prepare
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9004610Z > husky || true
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:03.9004810Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0336310Z .git can't be found
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0338220Z added 234 packages, and audited 235 packages in 3s
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0339480Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0340260Z 59 packages are looking for funding
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0344640Z   run `npm fund` for details
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0371890Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0372830Z 1 moderate severity vulnerability
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0399420Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0408910Z To address all issues, run:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0409560Z   npm audit fix
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0409750Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.0410140Z Run `npm audit` for details.
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.1119770Z ##[group]Run bun test
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.1120580Z [36;1mbun test[0m
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.1263460Z shell: /bin/bash -e {0}
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.1264080Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2050880Z bun test v1.3.6 (d530ed99)
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2310550Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2312880Z ##[group]tests/index.test.js:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2829320Z (pass) Case Conversion Utilities > toUpperCase > should convert camelCase to UPPER_CASE
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2831610Z (pass) Case Conversion Utilities > toUpperCase > should convert kebab-case to UPPER_CASE [0.03ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2833440Z (pass) Case Conversion Utilities > toUpperCase > should convert snake_case to UPPER_CASE
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2834150Z (pass) Case Conversion Utilities > toUpperCase > should convert PascalCase to UPPER_CASE [0.08ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2834910Z (pass) Case Conversion Utilities > toUpperCase > should handle already UPPER_CASE
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2835710Z (pass) Case Conversion Utilities > toCamelCase > should convert kebab-case to camelCase [0.06ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2836360Z (pass) Case Conversion Utilities > toCamelCase > should convert UPPER_CASE to camelCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2840470Z (pass) Case Conversion Utilities > toCamelCase > should convert snake_case to camelCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2841080Z (pass) Case Conversion Utilities > toCamelCase > should convert PascalCase to camelCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2841660Z (pass) Case Conversion Utilities > toCamelCase > should handle already camelCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2842350Z (pass) Case Conversion Utilities > toKebabCase > should convert camelCase to kebab-case
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2843170Z (pass) Case Conversion Utilities > toKebabCase > should convert UPPER_CASE to kebab-case [0.19ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2843830Z (pass) Case Conversion Utilities > toKebabCase > should convert PascalCase to kebab-case [0.02ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2844530Z (pass) Case Conversion Utilities > toKebabCase > should handle already kebab-case [0.01ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2845170Z (pass) Case Conversion Utilities > toSnakeCase > should convert camelCase to snake_case [0.02ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2845890Z (pass) Case Conversion Utilities > toSnakeCase > should convert kebab-case to snake_case [0.01ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2846630Z (pass) Case Conversion Utilities > toSnakeCase > should convert UPPER_CASE to snake_case [0.02ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2847260Z (pass) Case Conversion Utilities > toSnakeCase > should handle already snake_case
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2847860Z (pass) Case Conversion Utilities > toPascalCase > should convert camelCase to PascalCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2848540Z (pass) Case Conversion Utilities > toPascalCase > should convert kebab-case to PascalCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2849150Z (pass) Case Conversion Utilities > toPascalCase > should convert snake_case to PascalCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2849720Z (pass) Case Conversion Utilities > toPascalCase > should handle already PascalCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2850250Z (pass) getenv > should find variable in UPPER_CASE
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2850630Z (pass) getenv > should find variable in camelCase
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2851010Z (pass) getenv > should find variable in kebab-case
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2851480Z (pass) getenv > should return default value when not found
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2851980Z (pass) getenv > should return empty string as default when not specified
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2852490Z (pass) getenv > should try original key first
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2919060Z (pass) makeConfig > Hero Example (defaults) > should work with minimal configuration [8.04ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2933380Z (pass) makeConfig > Hero Example (defaults) > should use CLI arguments with highest priority [1.61ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2946160Z (pass) makeConfig > Hero Example (defaults) > should convert kebab-case to camelCase in result [1.11ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2951580Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2971900Z (pass) makeConfig > Environment Loading Priority > should load .lenv file by default [1.84ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2973500Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2974650Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2981230Z (pass) makeConfig > Environment Loading Priority > should handle --configuration flag [2.42ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.2989120Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3001080Z (pass) makeConfig > Environment Loading Priority > should prioritize CLI over environment [1.40ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3006780Z (pass) makeConfig > Environment Loading Priority > should handle missing .lenv file gracefully [0.99ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3011590Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3015520Z (pass) makeConfig > Case Conversion in Environment Loading > should convert all keys to UPPER_CASE in process.env [0.97ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3026210Z (pass) makeConfig > Case Conversion in Environment Loading > should find env vars in any case format via getenv [0.44ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3030060Z (pass) makeConfig > Configuration Options > should support disabling lenv [1.00ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3038330Z (pass) makeConfig > Configuration Options > should support enabling env/dotenvx (deprecated) [0.46ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3056760Z (pass) makeConfig > Configuration Options > should support disabling getenv [0.60ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3072920Z (pass) makeConfig > Configuration Options > should support configuration alias -c [1.95ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3074520Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3075620Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3090770Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3116270Z (pass) makeConfig > Complete Priority Chain > should demonstrate full priority: CLI > getenv > --configuration > .lenv [4.06ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3117380Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3139660Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --version option by calling .version(false) [1.81ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3140770Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3141990Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --help option [1.21ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3142780Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3143740Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with --version in strict mode [0.80ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3144680Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should handle --version with boolean type [0.35ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3181780Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow users to explicitly enable help [0.64ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3183080Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with multiple custom options including version
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3184130Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling built-in --version [0.80ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3185240Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling both --version and --help
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3186190Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow version with alias [1.63ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3187030Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow help with alias
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3188910Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should work with both built-in version/help and custom options [0.85ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3199680Z (pass) parseLinoArguments (legacy) > should parse simple links notation format [1.67ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3222150Z (pass) parseLinoArguments (legacy) > should parse arguments without parentheses [0.33ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3223230Z (pass) parseLinoArguments (legacy) > should handle empty input [0.50ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3225430Z (pass) parseLinoArguments (legacy) > should handle null input
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3227580Z (pass) parseLinoArguments (legacy) > should filter out comments [0.90ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3227960Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3228480Z ##[endgroup]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3230260Z 
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3230390Z  58 pass
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3230600Z  0 fail
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3230870Z Ran 58 tests across 1 file. [122.00ms]
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.3464110Z Post job cleanup.
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.5937580Z Post job cleanup.
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.7948240Z Post job cleanup.
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.8946750Z [command]/opt/homebrew/bin/git version
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9030580Z git version 2.52.0
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9055840Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/615ca73e-1e20-4bb2-9334-9814f2865182/.gitconfig'
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9062960Z Temporarily overriding HOME='/Users/runner/work/_temp/615ca73e-1e20-4bb2-9334-9814f2865182' before making global git config changes
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9063690Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9071200Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9142390Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:04.9207910Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0121310Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0166510Z http.https://github.com/.extraheader
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0183870Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0255340Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1197480Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.1240820Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on macos-latest)	UNKNOWN STEP	2026-01-13T21:26:05.2889700Z Cleaning up orphan processes
+Test (deno on windows-latest)	UNKNOWN STEP	﻿2026-01-13T21:25:52.8939070Z Current runner version: '2.330.0'
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8971237Z ##[group]Runner Image Provisioner
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8972326Z Hosted Compute Agent
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8973074Z Version: 20251211.462
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8974099Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8975625Z Build Date: 2025-12-11T16:28:49Z
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8976658Z Worker ID: {9a3c297a-d5ee-42ce-9da3-18a433cae07b}
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8977838Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8978558Z ##[group]Operating System
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8979404Z Microsoft Windows Server 2025
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8980234Z 10.0.26100
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8980932Z Datacenter
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8981550Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8982875Z ##[group]Runner Image
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8983730Z Image: windows-2025
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8984613Z Version: 20260105.172.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8986822Z Included Software: https://github.com/actions/runner-images/blob/win25/20260105.172/images/windows/Windows2025-Readme.md
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8989409Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20260105.172
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8991074Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8996144Z ##[group]GITHUB_TOKEN Permissions
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8999102Z Actions: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.8999904Z ArtifactMetadata: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9000655Z Attestations: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9001411Z Checks: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9002118Z Contents: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9002829Z Deployments: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9003643Z Discussions: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9004385Z Issues: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9005121Z Metadata: read
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9005835Z Models: read
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9006615Z Packages: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9007288Z Pages: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9008016Z PullRequests: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9008920Z RepositoryProjects: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9009758Z SecurityEvents: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9010598Z Statuses: write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9011339Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9014069Z Secret source: Actions
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9015042Z Prepare workflow directory
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9494211Z Prepare all required actions
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:52.9535816Z Getting action download info
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.3123674Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.4656404Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:53.6779298Z Download action repository 'oven-sh/setup-bun@v2' (SHA:b7a1c7ccf290d58743029c4f6903da283811b979)
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.1416698Z Download action repository 'denoland/setup-deno@v2' (SHA:e95548e56dfa95d4e1a28d6f422fafe75c4c26fb)
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.6119122Z Complete job name: Test (deno on windows-latest)
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7647755Z ##[group]Run actions/checkout@v4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7649097Z with:
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7650255Z   repository: link-foundation/lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7651592Z   token: ***
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7652339Z   ssh-strict: true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7653086Z   ssh-user: git
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7653841Z   persist-credentials: true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7654697Z   clean: true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7655462Z   sparse-checkout-cone-mode: true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7656393Z   fetch-depth: 1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7657131Z   fetch-tags: false
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7657895Z   show-progress: true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7658677Z   lfs: false
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7659378Z   submodules: false
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7660154Z   set-safe-directory: true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.7661258Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.9322438Z Syncing repository: link-foundation/lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.9326694Z ##[group]Getting Git version info
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:54.9329712Z Working directory is 'D:\a\lino-arguments\lino-arguments'
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.0745884Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4747515Z git version 2.52.0.windows.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4809031Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4831873Z Temporarily overriding HOME='D:\a\_temp\056b80a6-1895-41fb-b914-f19eb08adac4' before making global git config changes
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4834270Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.4843029Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5499941Z Deleting the contents of 'D:\a\lino-arguments\lino-arguments'
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5507015Z ##[group]Initializing the repository
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.5516537Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-arguments\lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.6474605Z Initialized empty Git repository in D:/a/lino-arguments/lino-arguments/.git/
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.6525155Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7106989Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7108891Z ##[group]Disabling automatic garbage collection
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7115205Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7432288Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7433627Z ##[group]Setting up auth
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7435111Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:55.7732262Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:57.3429339Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:57.3743847Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:57.9207919Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:57.9525057Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4617665Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4930611Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4931215Z ##[group]Fetching the repository
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:58.4943640Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5526138Z From https://github.com/link-foundation/lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5527147Z  * [new ref]         b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5905008Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5905486Z ##[group]Determining the checkout info
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5907575Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.5923031Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.6372699Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.6684516Z ##[group]Checking out the ref
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.6693046Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.7702479Z branch 'main' set up to track 'origin/main'.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.7710975Z Switched to a new branch 'main'
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.7751116Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.8180759Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.8457808Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9000981Z ##[group]Run actions/setup-node@v4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9001293Z with:
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9002162Z   node-version: 20.x
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9002361Z   always-auth: false
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9002542Z   check-latest: false
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9002851Z   token: ***
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:25:59.9003008Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:00.1559602Z Found in cache @ C:\hostedtoolcache\windows\node\20.19.6\x64
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:00.1570408Z ##[group]Environment details
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0611861Z node: v20.19.6
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0612334Z npm: 10.8.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0612555Z yarn: 1.22.22
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0614097Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0918919Z ##[group]Run denoland/setup-deno@v2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0919207Z with:
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0919356Z   deno-version: v2.x
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0919541Z   deno-binary-name: deno
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0919715Z   cache: false
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:05.0919863Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:06.2120345Z Going to install stable version 2.6.4.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:06.2133530Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.6.4/deno-x86_64-pc-windows-msvc.zip.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:06.7919723Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\e7a7c338-38d5-4bc1-8145-d96ee05d9b97', 'D:\a\_temp\02e296fb-6996-4a59-b484-df67dc641d1d', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\e7a7c338-38d5-4bc1-8145-d96ee05d9b97' -DestinationPath 'D:\a\_temp\02e296fb-6996-4a59-b484-df67dc641d1d' -Force } else { throw $_ } } ;"
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:13.9539281Z Cached Deno to C:\hostedtoolcache\windows\deno\2.6.4\x64.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:13.9557108Z Installation complete.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:13.9840602Z ##[group]Run npm install
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:13.9840975Z [36;1mnpm install[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:13.9914020Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:13.9914359Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.2744745Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.2745321Z > lino-arguments@0.3.0 prepare
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.2745890Z > husky || true
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.2746059Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4036601Z .git can't be found
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4037111Z added 234 packages, and audited 235 packages in 9s
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4037457Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4037671Z 59 packages are looking for funding
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4038119Z   run `npm fund` for details
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4061187Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4061716Z 1 moderate severity vulnerability
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4062046Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4062474Z To address all issues, run:
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4063019Z   npm audit fix
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4063354Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.4063989Z Run `npm audit` for details.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.6586398Z ##[group]Run deno test --allow-read --allow-env --allow-write
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.6586885Z [36;1mdeno test --allow-read --allow-env --allow-write[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.6657831Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.6658150Z ##[endgroup]
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9560953Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fcli
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9565538Z [0m[32mDownload[0m https://registry.npmjs.org/eslint
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9566948Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9568044Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9569013Z [0m[32mDownload[0m https://registry.npmjs.org/getenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9570053Z [0m[32mDownload[0m https://registry.npmjs.org/husky
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9570977Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9572268Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9573511Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9574394Z [0m[32mDownload[0m https://registry.npmjs.org/prettier
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9575265Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:23.9576175Z [0m[32mDownload[0m https://registry.npmjs.org/yargs
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5042129Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fapply-release-plan
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5043253Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fassemble-release-plan
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5044214Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fchangelog-git
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5045060Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fconfig
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5046441Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ferrors
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5048189Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-dependents-graph
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5050334Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-release-plan
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5051487Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fgit
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5052596Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2flogger
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5053643Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fpre
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5054639Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fread
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5055767Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fshould-skip-package
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5056880Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ftypes
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5057901Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fwrite
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5058965Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer%2fexternal-editor
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5060079Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2fget-packages
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5061053Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5061901Z [0m[32mDownload[0m https://registry.npmjs.org/ci-info
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5062701Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5063501Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5064235Z [0m[32mDownload[0m https://registry.npmjs.org/mri
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5064966Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5065849Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5066733Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5067565Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5068066Z [0m[32mDownload[0m https://registry.npmjs.org/semver
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5068708Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5071216Z [0m[32mDownload[0m https://registry.npmjs.org/term-size
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5996793Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2feslint-utils
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5998417Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2fregexpp
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.5999472Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-array
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6001829Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-helpers
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6003021Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fcore
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6004033Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2feslintrc
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6004985Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fjs
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6006800Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fplugin-kit
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6007804Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fnode
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6008936Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fmodule-importer
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6010449Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fretry
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6012293Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2festree
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6013150Z [0m[32mDownload[0m https://registry.npmjs.org/ajv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6013919Z [0m[32mDownload[0m https://registry.npmjs.org/chalk
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6014747Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6015521Z [0m[32mDownload[0m https://registry.npmjs.org/debug
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6016410Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6018119Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6019100Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6019994Z [0m[32mDownload[0m https://registry.npmjs.org/espree
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6020805Z [0m[32mDownload[0m https://registry.npmjs.org/esquery
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6021595Z [0m[32mDownload[0m https://registry.npmjs.org/esutils
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6022459Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6023837Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6025024Z [0m[32mDownload[0m https://registry.npmjs.org/find-up
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6025885Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6026710Z [0m[32mDownload[0m https://registry.npmjs.org/ignore
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6027539Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6028368Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6029507Z [0m[32mDownload[0m https://registry.npmjs.org/jiti
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6030540Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6031572Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6032402Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6033274Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.6034111Z [0m[32mDownload[0m https://registry.npmjs.org/optionator
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.8237192Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2feslint
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.8238171Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.8238796Z [0m[32mDownload[0m https://registry.npmjs.org/synckit
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9074896Z [0m[32mDownload[0m https://registry.npmjs.org/commander
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9076465Z [0m[32mDownload[0m https://registry.npmjs.org/listr2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9077351Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9078221Z [0m[32mDownload[0m https://registry.npmjs.org/nano-spawn
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9080063Z [0m[32mDownload[0m https://registry.npmjs.org/pidtree
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9080868Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:24.9081342Z [0m[32mDownload[0m https://registry.npmjs.org/yaml
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0210073Z [0m[32mDownload[0m https://registry.npmjs.org/cliui
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0210932Z [0m[32mDownload[0m https://registry.npmjs.org/escalade
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0211515Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0212348Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0213102Z [0m[32mDownload[0m https://registry.npmjs.org/string-width
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0213830Z [0m[32mDownload[0m https://registry.npmjs.org/y18n
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.0214596Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.1775307Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-version-range-type
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.1776239Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.1777414Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.1778826Z [0m[32mDownload[0m https://registry.npmjs.org/outdent
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.2683048Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.3019326Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.3395502Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fparse
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.3396521Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.4134858Z [0m[32mDownload[0m https://registry.npmjs.org/human-id
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.4840963Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fnode
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.4841966Z [0m[32mDownload[0m https://registry.npmjs.org/chardet
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:25.4842488Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.1966793Z [0m[32mDownload[0m https://registry.npmjs.org/@babel%2fruntime
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.1967515Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2ffind-root
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.1968679Z [0m[32mDownload[0m https://registry.npmjs.org/globby
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.1969285Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.4117064Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.4502792Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.4503702Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.4504283Z [0m[32mDownload[0m https://registry.npmjs.org/universalify
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.5187350Z [0m[32mDownload[0m https://registry.npmjs.org/p-try
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.5770954Z [0m[32mDownload[0m https://registry.npmjs.org/quansync
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.6242860Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.6484214Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fobject-schema
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.7399842Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fjson-schema
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.7939820Z [0m[32mDownload[0m https://registry.npmjs.org/globals
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.7940792Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.7941388Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.7941953Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.8981925Z [0m[32mDownload[0m https://registry.npmjs.org/levn
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:26.9735999Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fcore
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.0691100Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.0692165Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.0692821Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.1331809Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.1333120Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.2269642Z [0m[32mDownload[0m https://registry.npmjs.org/path-key
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.2270484Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.2270983Z [0m[32mDownload[0m https://registry.npmjs.org/which
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.2902854Z [0m[32mDownload[0m https://registry.npmjs.org/ms
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.4249665Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.4250240Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.4724679Z [0m[32mDownload[0m https://registry.npmjs.org/acorn
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.4725229Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.5158215Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.6089951Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.6090597Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.6469646Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.6865570Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.7146391Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.7147221Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.7148351Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.7149506Z [0m[32mDownload[0m https://registry.npmjs.org/type-check
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.7150351Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.7789968Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8066410Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr%2fcore
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8963083Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8963980Z [0m[32mDownload[0m https://registry.npmjs.org/colorette
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8964838Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8965694Z [0m[32mDownload[0m https://registry.npmjs.org/log-update
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8966158Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:27.8966593Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.0291299Z [0m[32mDownload[0m https://registry.npmjs.org/braces
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.0292000Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.0786503Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.0787136Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.1418262Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2046451Z [0m[32mDownload[0m https://registry.npmjs.org/p-map
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2678783Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2994223Z [0m[32mDownload[0m https://registry.npmjs.org/array-union
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2995277Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2996194Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2996881Z [0m[32mDownload[0m https://registry.npmjs.org/merge2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.2997383Z [0m[32mDownload[0m https://registry.npmjs.org/slash
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.3515999Z [0m[32mDownload[0m https://registry.npmjs.org/pify
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.3516556Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.4142612Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.4584991Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.5425477Z [0m[32mDownload[0m https://registry.npmjs.org/argparse
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.6077489Z [0m[32mDownload[0m https://registry.npmjs.org/punycode
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.7072965Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.7422217Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.7880289Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.9029668Z [0m[32mDownload[0m https://registry.npmjs.org/isexe
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.9385806Z [0m[32mDownload[0m https://registry.npmjs.org/flatted
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:28.9386494Z [0m[32mDownload[0m https://registry.npmjs.org/keyv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.0103482Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.0497664Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.0498399Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.1538176Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.2151395Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.2152216Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.2858231Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.3327220Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.3946201Z [0m[32mDownload[0m https://registry.npmjs.org/path-type
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.4354090Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.stat
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.4354816Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.walk
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.5520230Z [0m[32mDownload[0m https://registry.npmjs.org/esprima
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.5807591Z [0m[32mDownload[0m https://registry.npmjs.org/callsites
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.7026097Z [0m[32mDownload[0m https://registry.npmjs.org/color-name
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.7430792Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.8237943Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.8737257Z [0m[32mDownload[0m https://registry.npmjs.org/environment
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.9295469Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:29.9870458Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.0515838Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.scandir
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.0516687Z [0m[32mDownload[0m https://registry.npmjs.org/fastq
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.1350147Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.1947507Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.2508838Z [0m[32mDownload[0m https://registry.npmjs.org/onetime
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.2771947Z [0m[32mDownload[0m https://registry.npmjs.org/is-number
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.3251288Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.4019101Z [0m[32mDownload[0m https://registry.npmjs.org/reusify
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.4459919Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.4821657Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5586145Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere/-/test-anywhere-0.6.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5587349Z [0m[32mDownload[0m https://registry.npmjs.org/husky/-/husky-9.1.7.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5588452Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5589424Z [0m[32mDownload[0m https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5590447Z [0m[32mDownload[0m https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5591330Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5592431Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5593664Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5595853Z [0m[32mDownload[0m https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5597460Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5599085Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5600264Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5601194Z [0m[32mDownload[0m https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5602109Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5602992Z [0m[32mDownload[0m https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5604001Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5605337Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5606645Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5607798Z [0m[32mDownload[0m https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5608782Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5609935Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5610970Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5612090Z [0m[32mDownload[0m https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5612987Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5614093Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5615132Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5615837Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5617162Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5618189Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5619163Z [0m[32mDownload[0m https://registry.npmjs.org/espree/-/espree-10.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5620078Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5621131Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5622099Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5622977Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5623566Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5624411Z [0m[32mDownload[0m https://registry.npmjs.org/debug/-/debug-4.4.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5625329Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5626292Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5627216Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5628172Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5629140Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5630019Z [0m[32mDownload[0m https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5630903Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5631822Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5632752Z [0m[32mDownload[0m https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5633525Z [0m[32mDownload[0m https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5634372Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5635436Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5636044Z [0m[32mDownload[0m https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5637145Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5637945Z [0m[32mDownload[0m https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5638739Z [0m[32mDownload[0m https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5639647Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5641567Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5642603Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5643762Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5645024Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5646179Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.14.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5647455Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5648721Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5649716Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5650607Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5651627Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.14.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5652757Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5653702Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5654774Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5655833Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5656886Z [0m[32mDownload[0m https://registry.npmjs.org/semver/-/semver-7.7.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5657791Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5658596Z [0m[32mDownload[0m https://registry.npmjs.org/mri/-/mri-1.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5659346Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5660291Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5661013Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5661872Z [0m[32mDownload[0m https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5662824Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5663769Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5664652Z [0m[32mDownload[0m https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5665829Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5667146Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5668263Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/read/-/read-0.6.6.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5669337Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5670442Z [0m[32mDownload[0m https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5671313Z [0m[32mDownload[0m https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5672199Z [0m[32mDownload[0m https://registry.npmjs.org/commander/-/commander-14.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5673117Z [0m[32mDownload[0m https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5674022Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5674869Z [0m[32mDownload[0m https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5675679Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5677270Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5678386Z [0m[32mDownload[0m https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5679285Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5680107Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5680679Z [0m[32mDownload[0m https://registry.npmjs.org/globals/-/globals-14.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5681605Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5682625Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5683783Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5685049Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5686216Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5686956Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5687873Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5688829Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5689748Z [0m[32mDownload[0m https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5690524Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5691656Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5692459Z [0m[32mDownload[0m https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5694158Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5695225Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5695904Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5696751Z [0m[32mDownload[0m https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5697637Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5698447Z [0m[32mDownload[0m https://registry.npmjs.org/which/-/which-2.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5699226Z [0m[32mDownload[0m https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5700127Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5701494Z [0m[32mDownload[0m https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5702660Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5703554Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5704475Z [0m[32mDownload[0m https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5705424Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5706132Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5707098Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5708019Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5708930Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5709882Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5711046Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5711906Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5713163Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5714015Z [0m[32mDownload[0m https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5714587Z [0m[32mDownload[0m https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5715373Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5716442Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5717076Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5717705Z [0m[32mDownload[0m https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5719094Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5720844Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5722292Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5723450Z [0m[32mDownload[0m https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5724572Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5725767Z [0m[32mDownload[0m https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5726954Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5728259Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5729560Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5730842Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5732129Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5733302Z [0m[32mDownload[0m https://registry.npmjs.org/globby/-/globby-11.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5734442Z [0m[32mDownload[0m https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5735889Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5737041Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5738132Z [0m[32mDownload[0m https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5739228Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5741365Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/parse/-/parse-0.4.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5742727Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5743862Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5744960Z [0m[32mDownload[0m https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5746140Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5747297Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5748446Z [0m[32mDownload[0m https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5749539Z [0m[32mDownload[0m https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5750653Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5751805Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5753196Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5754375Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5755854Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5757126Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5758310Z [0m[32mDownload[0m https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5759402Z [0m[32mDownload[0m https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5760410Z [0m[32mDownload[0m https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5761488Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5762663Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5763731Z [0m[32mDownload[0m https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5764871Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5766149Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5767354Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5768484Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5769621Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5770811Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5772176Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5773441Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5774482Z [0m[32mDownload[0m https://registry.npmjs.org/pify/-/pify-4.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5775836Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5776981Z [0m[32mDownload[0m https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5778085Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5779189Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5780288Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5781452Z [0m[32mDownload[0m https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5782574Z [0m[32mDownload[0m https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5783856Z [0m[32mDownload[0m https://registry.npmjs.org/slash/-/slash-3.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5784897Z [0m[32mDownload[0m https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5786014Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5787176Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5788352Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5789590Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5790787Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5792004Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5793192Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5794382Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5795772Z [0m[32mDownload[0m https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5797222Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5798408Z [0m[32mDownload[0m https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5799424Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5800454Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5801512Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5802509Z [0m[32mDownload[0m https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5803569Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5804684Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5805805Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5806888Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5807985Z [0m[32mDownload[0m https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5809142Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5810281Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5811388Z [0m[32mDownload[0m https://registry.npmjs.org/environment/-/environment-1.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5812751Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5814139Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5815679Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5816459Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5817128Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5817766Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5818363Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5818932Z [0m[32mDownload[0m https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5819548Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5820159Z [0m[32mDownload[0m https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5820728Z [0m[32mDownload[0m https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5821485Z [0m[32mDownload[0m https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5822137Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5822808Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.5823495Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6390678Z [0m[32mInitialize[0m file-entry-cache@8.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6490293Z [0m[32mInitialize[0m escape-string-regexp@4.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6562739Z [0m[32mInitialize[0m lodash.merge@4.6.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6795161Z [0m[32mInitialize[0m husky@9.1.7
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6798938Z [0m[32mInitialize[0m glob-parent@6.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6886082Z [0m[32mInitialize[0m esutils@2.0.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6902150Z [0m[32mInitialize[0m is-glob@4.0.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.6927909Z [0m[32mInitialize[0m import-fresh@3.3.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7081463Z [0m[32mInitialize[0m find-up@5.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7274784Z [0m[32mInitialize[0m espree@10.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7326049Z [0m[32mInitialize[0m @eslint/core@0.17.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7510084Z [0m[32mInitialize[0m fast-deep-equal@3.1.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7681909Z [0m[32mInitialize[0m term-size@2.2.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7699168Z [0m[32mInitialize[0m mri@1.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7823944Z [0m[32mInitialize[0m ci-info@3.9.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7856782Z [0m[32mInitialize[0m picocolors@1.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.7996538Z [0m[32mInitialize[0m globals@14.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.8081826Z [0m[32mInitialize[0m yargs-parser@21.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.8124531Z [0m[32mInitialize[0m links-notation@0.11.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.8178687Z [0m[32mInitialize[0m lino-env@0.2.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.8182164Z [0m[32mInitialize[0m natural-compare@1.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:30.8184221Z [0m[32mInitialize[0m p-limit@2.3.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.3590806Z [0m[32mInitialize[0m synckit@0.11.11
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.3779182Z [0m[32mInitialize[0m fast-json-stable-stringify@2.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.3783176Z [0m[32mInitialize[0m require-directory@2.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.3936371Z [0m[32mInitialize[0m eslint-plugin-prettier@5.5.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4047248Z [0m[32mInitialize[0m strip-json-comments@3.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4110464Z [0m[32mInitialize[0m string-argv@0.3.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4167612Z [0m[32mInitialize[0m eslint-visitor-keys@4.2.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4207826Z [0m[32mInitialize[0m cliui@8.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4254137Z [0m[32mInitialize[0m resolve-from@5.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4660545Z [0m[32mInitialize[0m @changesets/cli@2.29.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4664347Z [0m[32mInitialize[0m get-caller-file@2.0.5
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4688025Z [0m[32mInitialize[0m spawndamnit@3.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4729343Z [0m[32mInitialize[0m prettier-linter-helpers@1.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4735028Z [0m[32mInitialize[0m @types/estree@1.0.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4829987Z [0m[32mInitialize[0m y18n@5.0.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4907723Z [0m[32mInitialize[0m lint-staged@16.2.7
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.4997870Z [0m[32mInitialize[0m yargs@17.7.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5284909Z [0m[32mInitialize[0m levn@0.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5331981Z [0m[32mInitialize[0m js-yaml@4.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5333502Z [0m[32mInitialize[0m string-width@4.2.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5387566Z [0m[32mInitialize[0m debug@4.4.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5559077Z [0m[32mInitialize[0m fs-extra@7.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5659615Z [0m[32mInitialize[0m eslint-scope@8.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5661742Z [0m[32mInitialize[0m ms@2.1.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5690979Z [0m[32mInitialize[0m escalade@3.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5739330Z [0m[32mInitialize[0m pidtree@0.6.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5896189Z [0m[32mInitialize[0m nano-spawn@2.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5933434Z [0m[32mInitialize[0m @eslint/config-helpers@0.4.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.5950164Z [0m[32mInitialize[0m micromatch@4.0.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6214174Z [0m[32mInitialize[0m esquery@1.7.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6214661Z [0m[32mInitialize[0m ansi-styles@4.3.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6291523Z [0m[32mInitialize[0m package-manager-detector@0.2.11
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6309012Z [0m[32mInitialize[0m getenv@2.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6392444Z [0m[32mInitialize[0m ignore@5.3.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6394296Z [0m[32mInitialize[0m optionator@0.9.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6642899Z [0m[32mInitialize[0m @changesets/read@0.6.6
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6645868Z [0m[32mInitialize[0m minimatch@3.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6735127Z [0m[32mInitialize[0m semver@7.7.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.6978254Z [0m[32mInitialize[0m @changesets/get-release-plan@4.0.14
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7048826Z [0m[32mInitialize[0m eslint-visitor-keys@3.4.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7089886Z [0m[32mInitialize[0m cross-spawn@7.0.6
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7233496Z [0m[32mInitialize[0m json-schema-traverse@0.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7297450Z [0m[32mInitialize[0m type-check@0.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7359876Z [0m[32mInitialize[0m enquirer@2.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7450554Z [0m[32mInitialize[0m test-anywhere@0.6.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7659600Z [0m[32mInitialize[0m globby@11.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.7962606Z [0m[32mInitialize[0m which@2.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8029458Z [0m[32mInitialize[0m @changesets/changelog-git@0.2.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8031678Z [0m[32mInitialize[0m graceful-fs@4.2.11
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8080219Z [0m[32mInitialize[0m @changesets/config@3.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8174122Z [0m[32mInitialize[0m json-stable-stringify-without-jsonify@1.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8684078Z [0m[32mInitialize[0m @eslint-community/eslint-utils@4.9.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8738787Z [0m[32mInitialize[0m word-wrap@1.2.5
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8745662Z [0m[32mInitialize[0m @eslint-community/regexpp@4.12.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.8929392Z [0m[32mInitialize[0m @changesets/assemble-release-plan@6.0.9
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9038265Z [0m[32mInitialize[0m imurmurhash@0.1.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9039433Z [0m[32mInitialize[0m @changesets/errors@0.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9268124Z [0m[32mInitialize[0m @eslint/js@9.39.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9269157Z [0m[32mInitialize[0m brace-expansion@1.1.12
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9293015Z [0m[32mInitialize[0m @changesets/apply-release-plan@7.0.14
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9325341Z [0m[32mInitialize[0m prelude-ls@1.2.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9368699Z [0m[32mInitialize[0m listr2@9.0.5
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9447336Z [0m[32mInitialize[0m acorn-jsx@5.3.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9570018Z [0m[32mInitialize[0m @eslint/eslintrc@3.3.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9724291Z [0m[32mInitialize[0m deep-is@0.1.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:32.9806037Z [0m[32mInitialize[0m extendable-error@0.1.7
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.2637683Z [0m[32mInitialize[0m @humanfs/node@0.16.7
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.2648830Z [0m[32mInitialize[0m estraverse@5.3.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.2699649Z [0m[32mInitialize[0m shebang-command@2.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.2903703Z [0m[32mInitialize[0m @humanwhocodes/retry@0.4.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3021476Z [0m[32mInitialize[0m keyv@4.5.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3065657Z [0m[32mInitialize[0m @humanwhocodes/module-importer@1.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3066376Z [0m[32mInitialize[0m is-extglob@2.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3066928Z [0m[32mInitialize[0m p-filter@2.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3187831Z [0m[32mInitialize[0m uri-js@4.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3272056Z [0m[32mInitialize[0m @changesets/git@3.0.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3351702Z [0m[32mInitialize[0m flatted@3.3.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3621728Z [0m[32mInitialize[0m @changesets/logger@0.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3622286Z [0m[32mInitialize[0m log-update@6.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3750627Z [0m[32mInitialize[0m @eslint/config-array@0.21.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.3891791Z [0m[32mInitialize[0m commander@14.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4110619Z [0m[32mInitialize[0m @eslint/object-schema@2.1.7
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4112693Z [0m[32mInitialize[0m p-locate@5.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4115344Z [0m[32mInitialize[0m fast-diff@1.3.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4247371Z [0m[32mInitialize[0m ansi-colors@4.1.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4249160Z [0m[32mInitialize[0m is-fullwidth-code-point@3.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4362089Z [0m[32mInitialize[0m rfdc@1.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4590300Z [0m[32mInitialize[0m @changesets/write@0.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4607644Z [0m[32mInitialize[0m human-id@4.1.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4742426Z [0m[32mInitialize[0m @changesets/should-skip-package@0.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4765546Z [0m[32mInitialize[0m @changesets/get-dependents-graph@2.1.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4767059Z [0m[32mInitialize[0m punycode@2.3.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4768111Z [0m[32mInitialize[0m esrecurse@4.3.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4769926Z [0m[32mInitialize[0m parent-module@1.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.4986563Z [0m[32mInitialize[0m flat-cache@4.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5033524Z [0m[32mInitialize[0m resolve-from@4.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5034194Z [0m[32mInitialize[0m shebang-regex@3.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5196575Z [0m[32mInitialize[0m eventemitter3@5.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5197908Z [0m[32mInitialize[0m wrap-ansi@9.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5313137Z [0m[32mInitialize[0m colorette@2.0.20
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5841190Z [0m[32mInitialize[0m cli-truncate@5.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.5958856Z [0m[32mInitialize[0m color-convert@2.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.6256646Z [0m[32mInitialize[0m fast-levenshtein@2.0.6
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.7182981Z [0m[32mInitialize[0m strip-bom@3.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.8030999Z [0m[32mInitialize[0m strip-ansi@6.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.8090671Z [0m[32mInitialize[0m strip-ansi@7.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:33.9694509Z [0m[32mInitialize[0m @manypkg/get-packages@1.1.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.0114046Z [0m[32mInitialize[0m @eslint/plugin-kit@0.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.1735746Z [0m[32mInitialize[0m slash@3.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.2586000Z [0m[32mInitialize[0m emoji-regex@8.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.2888196Z [0m[32mInitialize[0m chalk@4.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3015400Z [0m[32mInitialize[0m p-try@2.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3015933Z [0m[32mInitialize[0m quansync@0.2.11
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3063538Z [0m[32mInitialize[0m @inquirer/external-editor@1.0.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3330960Z [0m[32mInitialize[0m @changesets/get-version-range-type@0.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3331475Z [0m[32mInitialize[0m locate-path@6.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3331820Z [0m[32mInitialize[0m find-up@4.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.3721418Z [0m[32mInitialize[0m ajv@6.12.6
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.7833686Z [0m[32mInitialize[0m eslint-config-prettier@10.1.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.7865079Z [0m[32mInitialize[0m fs-extra@8.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.7866009Z [0m[32mInitialize[0m wrap-ansi@7.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.7866528Z [0m[32mInitialize[0m fill-range@7.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.9157401Z [0m[32mInitialize[0m @changesets/types@6.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.9158104Z [0m[32mInitialize[0m @types/json-schema@7.0.15
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.9346952Z [0m[32mInitialize[0m path-exists@4.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:34.9382997Z [0m[32mInitialize[0m callsites@3.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.0648438Z [0m[32mInitialize[0m is-subdir@1.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.0879511Z [0m[32mInitialize[0m jsonfile@4.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.0917026Z [0m[32mInitialize[0m read-yaml-file@1.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.1245545Z [0m[32mInitialize[0m string-width@7.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.1712038Z [0m[32mInitialize[0m argparse@2.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.1713081Z [0m[32mInitialize[0m restore-cursor@5.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.1717484Z [0m[32mInitialize[0m better-path-resolve@1.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.1744528Z [0m[32mInitialize[0m has-flag@4.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2277394Z [0m[32mInitialize[0m path-type@4.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2282642Z [0m[32mInitialize[0m universalify@0.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2467041Z [0m[32mInitialize[0m json-buffer@3.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2580813Z [0m[32mInitialize[0m outdent@0.5.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2644953Z [0m[32mInitialize[0m @humanfs/core@0.19.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2646299Z [0m[32mInitialize[0m acorn@8.15.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2646994Z [0m[32mInitialize[0m color-name@1.1.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2648036Z [0m[32mInitialize[0m supports-color@7.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2648777Z [0m[32mInitialize[0m safer-buffer@2.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2785730Z [0m[32mInitialize[0m lodash.startcase@4.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.2944754Z [0m[32mInitialize[0m merge2@1.4.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.3014475Z [0m[32mInitialize[0m cli-cursor@5.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.3381722Z [0m[32mInitialize[0m get-east-asian-width@1.4.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.3468158Z [0m[32mInitialize[0m string-width@8.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.3655379Z [0m[32mInitialize[0m @changesets/parse@0.4.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4023822Z [0m[32mInitialize[0m picomatch@2.3.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4029362Z [0m[32mInitialize[0m locate-path@5.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4445804Z [0m[32mInitialize[0m isexe@2.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4462145Z [0m[32mInitialize[0m ansi-regex@6.2.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4464046Z [0m[32mInitialize[0m is-windows@1.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4713618Z [0m[32mInitialize[0m js-yaml@3.14.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4836681Z [0m[32mInitialize[0m @changesets/types@4.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4838744Z [0m[32mInitialize[0m p-map@2.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.4842262Z [0m[32mInitialize[0m @manypkg/find-root@1.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5404638Z [0m[32mInitialize[0m @changesets/pre@2.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5430796Z [0m[32mInitialize[0m is-fullwidth-code-point@5.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5431917Z [0m[32mInitialize[0m yocto-queue@0.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5434992Z [0m[32mInitialize[0m pify@4.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5451632Z [0m[32mInitialize[0m p-locate@4.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5551455Z [0m[32mInitialize[0m concat-map@0.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5555258Z [0m[32mInitialize[0m ansi-styles@6.2.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5797416Z [0m[32mInitialize[0m signal-exit@4.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5806131Z [0m[32mInitialize[0m is-number@7.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.5831360Z [0m[32mInitialize[0m path-key@3.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6008532Z [0m[32mInitialize[0m reusify@1.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6119388Z [0m[32mInitialize[0m sprintf-js@1.0.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6120372Z [0m[32mInitialize[0m array-union@2.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6281433Z [0m[32mInitialize[0m balanced-match@1.0.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6513085Z [0m[32mInitialize[0m braces@3.0.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6528906Z [0m[32mInitialize[0m ansi-escapes@7.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6759372Z [0m[32mInitialize[0m @pkgr/core@0.2.9
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6766742Z [0m[32mInitialize[0m slice-ansi@7.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6921911Z [0m[32mInitialize[0m fastq@1.20.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6923571Z [0m[32mInitialize[0m onetime@7.0.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.6954022Z [0m[32mInitialize[0m glob-parent@5.1.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.7110626Z [0m[32mInitialize[0m esprima@4.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.7112528Z [0m[32mInitialize[0m queue-microtask@1.2.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.7113168Z [0m[32mInitialize[0m dir-glob@3.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.7113631Z [0m[32mInitialize[0m emoji-regex@10.6.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:35.7357832Z [0m[32mInitialize[0m to-regex-range@5.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.6093068Z [0m[32mInitialize[0m chardet@2.1.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.6098982Z [0m[32mInitialize[0m detect-indent@6.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.6281861Z [0m[32mInitialize[0m fast-glob@3.3.3
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.6292168Z [0m[32mInitialize[0m run-parallel@1.2.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.6293256Z [0m[32mInitialize[0m p-limit@3.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.7179236Z [0m[32mInitialize[0m ansi-regex@5.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.8165228Z [0m[32mInitialize[0m environment@1.1.0
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:36.8181486Z [0m[32mInitialize[0m mimic-function@5.0.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:37.0404179Z [0m[32mInitialize[0m @nodelib/fs.scandir@2.1.5
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:37.0749695Z [0m[32mInitialize[0m @nodelib/fs.stat@2.0.5
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:37.1149577Z [0m[32mInitialize[0m @nodelib/fs.walk@1.2.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:37.1159955Z [0m[32mInitialize[0m argparse@1.0.10
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:38.2288218Z [0m[32mInitialize[0m @types/node@12.20.55
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:38.2448729Z [0m[32mInitialize[0m iconv-lite@0.7.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:38.2972739Z [0m[32mInitialize[0m prettier@2.8.8
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:38.3176015Z [0m[32mInitialize[0m prettier@3.7.4
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:38.3344833Z [0m[32mInitialize[0m yaml@2.8.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.0158077Z [0m[32mInitialize[0m @babel/runtime@7.28.6
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.1189332Z [0m[32mInitialize[0m eslint@9.39.2
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5690186Z [0m[38;5;245mrunning 58 tests from ./tests/index.test.js[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5700631Z should convert camelCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5702365Z should convert kebab-case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5704657Z should convert snake_case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5709203Z should convert PascalCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5711396Z should handle already UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5715228Z should convert kebab-case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5718513Z should convert UPPER_CASE to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5720372Z should convert snake_case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5722403Z should convert PascalCase to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5725634Z should handle already camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5729214Z should convert camelCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5731327Z should convert UPPER_CASE to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5734205Z should convert PascalCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5736437Z should handle already kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5739327Z should convert camelCase to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5742023Z should convert kebab-case to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5743827Z should convert UPPER_CASE to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5745345Z should handle already snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5748577Z should convert camelCase to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5751894Z should convert kebab-case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5753756Z should convert snake_case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5755427Z should handle already PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5763616Z should find variable in UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5767043Z should find variable in camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5770839Z should find variable in kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5773732Z should return default value when not found ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5777043Z should return empty string as default when not specified ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5780061Z should try original key first ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5925032Z should work with minimal configuration ... [0m[32mok[0m [0m[38;5;245m(14ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.5975820Z should use CLI arguments with highest priority ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6017647Z should convert kebab-case to camelCase in result ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6034066Z should load .lenv file by default ...
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6034794Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6035837Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6077493Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6078130Z should load .lenv file by default ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6087977Z should handle --configuration flag ...
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6088636Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6089601Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6108520Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6129871Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6130488Z should handle --configuration flag ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6137096Z should prioritize CLI over environment ...
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6138289Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6139069Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6168864Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6169832Z should prioritize CLI over environment ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6205264Z should handle missing .lenv file gracefully ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6211842Z should convert all keys to UPPER_CASE in process.env ...
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6212474Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6213039Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6240213Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6240915Z should convert all keys to UPPER_CASE in process.env ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6277608Z should find env vars in any case format via getenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6314878Z should support disabling lenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6350276Z should support enabling env/dotenvx (deprecated) ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6383474Z should support disabling getenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6408727Z should support configuration alias -c ...
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6409649Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6410831Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6432660Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6433614Z should support configuration alias -c ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6444973Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ...
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6445630Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6446206Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6474775Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6489449Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6506695Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6521126Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6543064Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6544333Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ... [0m[32mok[0m [0m[38;5;245m(10ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6579248Z should allow user-defined --version option by calling .version(false) ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6612892Z should allow user-defined --help option ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6647503Z should work with --version in strict mode ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6679882Z should handle --version with boolean type ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6710807Z should allow users to explicitly enable help ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6747033Z should work with multiple custom options including version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6782700Z should allow explicitly enabling built-in --version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6816105Z should allow explicitly enabling both --version and --help ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6856052Z should allow version with alias ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6892399Z should allow help with alias ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6926612Z should work with both built-in version/help and custom options ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6949088Z should parse simple links notation format ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6955007Z should parse arguments without parentheses ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6957876Z should handle empty input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6959813Z should handle null input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.6965640Z should filter out comments ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.7022495Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.7023200Z [0m[32mok[0m | 58 passed | 0 failed [0m[38;5;245m(133ms)[0m
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.7023509Z 
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:39.8470734Z Post job cleanup.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.0290217Z Caching is not enabled. Caching is skipped.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.0770752Z Post job cleanup.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.3305084Z Post job cleanup.
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.5944963Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.6261351Z git version 2.52.0.windows.1
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.6347771Z Temporarily overriding HOME='D:\a\_temp\a1a8dd66-e4c6-44ba-82eb-8cd9d7172c3c' before making global git config changes
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.6348909Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.6360275Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.6686321Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:40.7073191Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:41.2818274Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:41.3087602Z http.https://github.com/.extraheader
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:41.3146604Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:41.3504332Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:41.9489923Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:41.9814860Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (deno on windows-latest)	UNKNOWN STEP	2026-01-13T21:26:42.5254458Z Cleaning up orphan processes
+Release	UNKNOWN STEP	﻿2026-01-13T21:26:47.4374674Z Current runner version: '2.330.0'
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4398572Z ##[group]Runner Image Provisioner
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4399379Z Hosted Compute Agent
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4399911Z Version: 20251211.462
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4400570Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4401312Z Build Date: 2025-12-11T16:28:49Z
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4401911Z Worker ID: {be2ff6b2-85b3-4458-9491-c9aa50694d76}
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4402634Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4403153Z ##[group]Operating System
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4404153Z Ubuntu
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4405126Z 24.04.3
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4405548Z LTS
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4405987Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4406473Z ##[group]Runner Image
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4407041Z Image: ubuntu-24.04
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4407534Z Version: 20260105.202.1
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4408566Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4410088Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4411127Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4412239Z ##[group]GITHUB_TOKEN Permissions
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4414808Z Contents: write
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4415336Z Metadata: read
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4415832Z PullRequests: write
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4416282Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4418423Z Secret source: Actions
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4419399Z Prepare workflow directory
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4821050Z Prepare all required actions
+Release	UNKNOWN STEP	2026-01-13T21:26:47.4859146Z Getting action download info
+Release	UNKNOWN STEP	2026-01-13T21:26:47.8124118Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Release	UNKNOWN STEP	2026-01-13T21:26:47.9192543Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1132284Z Complete job name: Release
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1853593Z ##[group]Run actions/checkout@v4
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1854466Z with:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1854855Z   fetch-depth: 0
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1855334Z   repository: link-foundation/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1856060Z   token: ***
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1856444Z   ssh-strict: true
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1856840Z   ssh-user: git
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1857238Z   persist-credentials: true
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1857695Z   clean: true
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1858098Z   sparse-checkout-cone-mode: true
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1858598Z   fetch-tags: false
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1858999Z   show-progress: true
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1859412Z   lfs: false
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1859787Z   submodules: false
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1860199Z   set-safe-directory: true
+Release	UNKNOWN STEP	2026-01-13T21:26:48.1860852Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.2957208Z Syncing repository: link-foundation/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.2959010Z ##[group]Getting Git version info
+Release	UNKNOWN STEP	2026-01-13T21:26:48.2959895Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Release	UNKNOWN STEP	2026-01-13T21:26:48.2961046Z [command]/usr/bin/git version
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3026011Z git version 2.52.0
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3052186Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3075406Z Temporarily overriding HOME='/home/runner/work/_temp/77317bca-d711-482c-8f4c-b9da959f6553' before making global git config changes
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3078295Z Adding repository directory to the temporary git global config as a safe directory
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3080596Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3116861Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3120203Z ##[group]Initializing the repository
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3124209Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3217342Z hint: Using 'master' as the name for the initial branch. This default branch name
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3219152Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3220866Z hint: to use in all of your new repositories, which will suppress this warning,
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3222763Z hint: call:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3223498Z hint:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3224375Z hint: 	git config --global init.defaultBranch <name>
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3225354Z hint:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3226306Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3228029Z hint: 'development'. The just-created branch can be renamed via this command:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3229243Z hint:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3229886Z hint: 	git branch -m <name>
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3230612Z hint:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3231710Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3235150Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3238715Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3269452Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3270950Z ##[group]Disabling automatic garbage collection
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3274717Z [command]/usr/bin/git config --local gc.auto 0
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3302595Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3304085Z ##[group]Setting up auth
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3310307Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3340879Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3664907Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3694459Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3919852Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.3959646Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Release	UNKNOWN STEP	2026-01-13T21:26:48.4198555Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Release	UNKNOWN STEP	2026-01-13T21:26:48.4232460Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.4233924Z ##[group]Fetching the repository
+Release	UNKNOWN STEP	2026-01-13T21:26:48.4242049Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8225959Z From https://github.com/link-foundation/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8227980Z  * [new branch]      changeset-release/manual-19391025857 -> origin/changeset-release/manual-19391025857
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8229882Z  * [new branch]      claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj -> origin/claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8232033Z  * [new branch]      claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq -> origin/claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8233886Z  * [new branch]      issue-1-171e0c1cad4c  -> origin/issue-1-171e0c1cad4c
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8234839Z  * [new branch]      issue-10-89893ff89d82 -> origin/issue-10-89893ff89d82
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8235792Z  * [new branch]      issue-10-d4419a0e77c2 -> origin/issue-10-d4419a0e77c2
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8236736Z  * [new branch]      issue-13-167bb501b116 -> origin/issue-13-167bb501b116
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8237682Z  * [new branch]      issue-14-555e0cfd6e57 -> origin/issue-14-555e0cfd6e57
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8238629Z  * [new branch]      issue-17-aac47b45095f -> origin/issue-17-aac47b45095f
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8239569Z  * [new branch]      issue-19-c4402d419d95 -> origin/issue-19-c4402d419d95
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8240512Z  * [new branch]      issue-20-535e73c3f5df -> origin/issue-20-535e73c3f5df
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8241453Z  * [new branch]      issue-6-88ce301275b5  -> origin/issue-6-88ce301275b5
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8242397Z  * [new branch]      issue-6-ed79da598197  -> origin/issue-6-ed79da598197
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8243700Z  * [new branch]      issue-6-ef625c0a060f  -> origin/issue-6-ef625c0a060f
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8244493Z  * [new branch]      main                  -> origin/main
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8245120Z  * [new tag]         v0.2.5                -> v0.2.5
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8245709Z  * [new tag]         v0.2.7                -> v0.2.7
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8246313Z  * [new tag]         v0.2.8                -> v0.2.8
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8246902Z  * [new tag]         v0.3.0                -> v0.3.0
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8287778Z [command]/usr/bin/git branch --list --remote origin/main
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8313204Z   origin/main
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8321997Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8342652Z 119f5d34cdf0678aa4718f130756bde47d402052
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8353480Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +b73b5c079470a20edd496ca9ff7177e7cb3ef490:refs/remotes/origin/main
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8402716Z From https://github.com/link-foundation/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8405202Z  + 119f5d3...b73b5c0 b73b5c079470a20edd496ca9ff7177e7cb3ef490 -> origin/main  (forced update)
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8430071Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8430973Z ##[group]Determining the checkout info
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8431803Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8436794Z [command]/usr/bin/git sparse-checkout disable
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8476354Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8502008Z ##[group]Checking out the ref
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8506855Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8654949Z Switched to a new branch 'main'
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8657644Z branch 'main' set up to track 'origin/main'.
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8664686Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8698698Z [command]/usr/bin/git log -1 --format=%H
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8719706Z b73b5c079470a20edd496ca9ff7177e7cb3ef490
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8947382Z ##[group]Run actions/setup-node@v4
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8947897Z with:
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8948244Z   node-version: 20.x
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8948675Z   registry-url: https://registry.npmjs.org
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8949188Z   always-auth: false
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8949569Z   check-latest: false
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8950094Z   token: ***
+Release	UNKNOWN STEP	2026-01-13T21:26:48.8950441Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:49.0750876Z Found in cache @ /opt/hostedtoolcache/node/20.19.6/x64
+Release	UNKNOWN STEP	2026-01-13T21:26:49.0757557Z ##[group]Environment details
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4138561Z node: v20.19.6
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4139347Z npm: 10.8.2
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4140033Z yarn: 1.22.22
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4141554Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4277237Z ##[group]Run npm install
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4277755Z [36;1mnpm install[0m
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4327766Z shell: /usr/bin/bash -e {0}
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4328236Z env:
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4328674Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4329272Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+Release	UNKNOWN STEP	2026-01-13T21:26:49.4329740Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1116103Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1125038Z > lino-arguments@0.3.0 prepare
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1125850Z > husky || true
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1126163Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1541626Z .git can't be found
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1542584Z added 234 packages, and audited 235 packages in 3s
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1543152Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1543740Z 59 packages are looking for funding
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1544474Z   run `npm fund` for details
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1562823Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1564072Z 1 moderate severity vulnerability
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1565947Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1566399Z To address all issues, run:
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1567319Z   npm audit fix
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1567714Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1568087Z Run `npm audit` for details.
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1834698Z ##[group]Run node ../scripts/setup-npm.mjs
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1835152Z [36;1mnode ../scripts/setup-npm.mjs[0m
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1870544Z shell: /usr/bin/bash -e {0}
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1870859Z env:
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1871169Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1871597Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+Release	UNKNOWN STEP	2026-01-13T21:26:52.1871941Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:53.6252538Z 10.8.2
+Release	UNKNOWN STEP	2026-01-13T21:26:53.6301643Z Current npm version: 10.8.2
+Release	UNKNOWN STEP	2026-01-13T21:26:57.0892247Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:57.0893067Z removed 45 packages, and changed 107 packages in 3s
+Release	UNKNOWN STEP	2026-01-13T21:26:57.0896920Z 
+Release	UNKNOWN STEP	2026-01-13T21:26:57.0897238Z 16 packages are looking for funding
+Release	UNKNOWN STEP	2026-01-13T21:26:57.0897790Z   run `npm fund` for details
+Release	UNKNOWN STEP	2026-01-13T21:26:57.1991847Z npm warn Unknown user config "always-auth". This will stop working in the next major version of npm.
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2002812Z 11.7.0
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2048956Z Updated npm version: 11.7.0
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2137215Z ##[group]Run # Count changeset files (excluding README.md and config.json)
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2137862Z [36;1m# Count changeset files (excluding README.md and config.json)[0m
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2138470Z [36;1mCHANGESET_COUNT=$(find .changeset -name "*.md" ! -name "README.md" | wc -l)[0m
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2139004Z [36;1mecho "Found $CHANGESET_COUNT changeset file(s)"[0m
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2139600Z [36;1mecho "has_changesets=$([[ $CHANGESET_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT[0m
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2172441Z shell: /usr/bin/bash -e {0}
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2172710Z env:
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2172966Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2173525Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2173837Z ##[endgroup]
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2249764Z Found 0 changeset file(s)
+Release	UNKNOWN STEP	2026-01-13T21:26:57.2371400Z Post job cleanup.
+Release	UNKNOWN STEP	2026-01-13T21:26:57.4036923Z Post job cleanup.
+Release	UNKNOWN STEP	2026-01-13T21:26:57.4982416Z [command]/usr/bin/git version
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5019390Z git version 2.52.0
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5063838Z Temporarily overriding HOME='/home/runner/work/_temp/633f6721-f34b-4f52-8e9c-e360f9b7d270' before making global git config changes
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5065483Z Adding repository directory to the temporary git global config as a safe directory
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5077180Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5111234Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5144238Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5370200Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5392478Z http.https://github.com/.extraheader
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5405825Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5437019Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5657616Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Release	UNKNOWN STEP	2026-01-13T21:26:57.5689233Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Release	UNKNOWN STEP	2026-01-13T21:26:57.6020895Z Cleaning up orphan processes

--- a/docs/case-studies/issue-29/js-cicd-run-24263446026.txt
+++ b/docs/case-studies/issue-29/js-cicd-run-24263446026.txt
@@ -1,0 +1,6003 @@
+Detect Changes	Set up job	﻿2026-04-10T20:47:05.4892147Z Current runner version: '2.333.1'
+Detect Changes	Set up job	2026-04-10T20:47:05.4927977Z ##[group]Runner Image Provisioner
+Detect Changes	Set up job	2026-04-10T20:47:05.4929134Z Hosted Compute Agent
+Detect Changes	Set up job	2026-04-10T20:47:05.4930259Z Version: 20260213.493
+Detect Changes	Set up job	2026-04-10T20:47:05.4931274Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Detect Changes	Set up job	2026-04-10T20:47:05.4932804Z Build Date: 2026-02-13T00:28:41Z
+Detect Changes	Set up job	2026-04-10T20:47:05.4933945Z Worker ID: {78295fd6-4809-4a26-a33c-f332245ef47c}
+Detect Changes	Set up job	2026-04-10T20:47:05.4934995Z Azure Region: eastus
+Detect Changes	Set up job	2026-04-10T20:47:05.4935957Z ##[endgroup]
+Detect Changes	Set up job	2026-04-10T20:47:05.4938524Z ##[group]Operating System
+Detect Changes	Set up job	2026-04-10T20:47:05.4939481Z Ubuntu
+Detect Changes	Set up job	2026-04-10T20:47:05.4940323Z 24.04.4
+Detect Changes	Set up job	2026-04-10T20:47:05.4941010Z LTS
+Detect Changes	Set up job	2026-04-10T20:47:05.4941730Z ##[endgroup]
+Detect Changes	Set up job	2026-04-10T20:47:05.4942541Z ##[group]Runner Image
+Detect Changes	Set up job	2026-04-10T20:47:05.4943483Z Image: ubuntu-24.04
+Detect Changes	Set up job	2026-04-10T20:47:05.4944246Z Version: 20260406.80.1
+Detect Changes	Set up job	2026-04-10T20:47:05.4946055Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+Detect Changes	Set up job	2026-04-10T20:47:05.4949192Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+Detect Changes	Set up job	2026-04-10T20:47:05.4951024Z ##[endgroup]
+Detect Changes	Set up job	2026-04-10T20:47:05.4955706Z ##[group]GITHUB_TOKEN Permissions
+Detect Changes	Set up job	2026-04-10T20:47:05.4959251Z Actions: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4960082Z ArtifactMetadata: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4961093Z Attestations: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4961941Z Checks: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4962802Z Contents: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4963677Z Deployments: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4964563Z Discussions: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4965339Z Issues: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4966315Z Metadata: read
+Detect Changes	Set up job	2026-04-10T20:47:05.4967562Z Models: read
+Detect Changes	Set up job	2026-04-10T20:47:05.4968351Z Packages: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4969332Z Pages: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4970346Z PullRequests: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4971321Z RepositoryProjects: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4972470Z SecurityEvents: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4973484Z Statuses: write
+Detect Changes	Set up job	2026-04-10T20:47:05.4974330Z ##[endgroup]
+Detect Changes	Set up job	2026-04-10T20:47:05.4977650Z Secret source: Actions
+Detect Changes	Set up job	2026-04-10T20:47:05.4979128Z Prepare workflow directory
+Detect Changes	Set up job	2026-04-10T20:47:05.5573924Z Prepare all required actions
+Detect Changes	Set up job	2026-04-10T20:47:05.5633552Z Getting action download info
+Detect Changes	Set up job	2026-04-10T20:47:05.8270148Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Detect Changes	Set up job	2026-04-10T20:47:06.0006225Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Detect Changes	Set up job	2026-04-10T20:47:06.1821082Z Complete job name: Detect Changes
+Detect Changes	Run actions/checkout@v4	﻿2026-04-10T20:47:06.2543228Z ##[group]Run actions/checkout@v4
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2544106Z with:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2544511Z   fetch-depth: 0
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2544986Z   repository: link-foundation/lino-arguments
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2545712Z   token: ***
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2546107Z   ssh-strict: true
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2546725Z   ssh-user: git
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2547202Z   persist-credentials: true
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2547671Z   clean: true
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2548085Z   sparse-checkout-cone-mode: true
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2548608Z   fetch-tags: false
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2549017Z   show-progress: true
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2549423Z   lfs: false
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2549802Z   submodules: false
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2550207Z   set-safe-directory: true
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.2550931Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3650117Z Syncing repository: link-foundation/lino-arguments
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3651972Z ##[group]Getting Git version info
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3652776Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3653895Z [command]/usr/bin/git version
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3682549Z git version 2.53.0
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3710310Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3733528Z Temporarily overriding HOME='/home/runner/work/_temp/ee3354f5-f222-40c6-bbbd-c8e4b5f8954a' before making global git config changes
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3735938Z Adding repository directory to the temporary git global config as a safe directory
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3740546Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3773964Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3778791Z ##[group]Initializing the repository
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3783688Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3865622Z hint: Using 'master' as the name for the initial branch. This default branch name
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3867679Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3869398Z hint: to use in all of your new repositories, which will suppress this warning,
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3870674Z hint: call:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3871335Z hint:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3872151Z hint: 	git config --global init.defaultBranch <name>
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3873224Z hint:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3874191Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3875742Z hint: 'development'. The just-created branch can be renamed via this command:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3877279Z hint:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3878001Z hint: 	git branch -m <name>
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3878792Z hint:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3879832Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3881733Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3884488Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3910775Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3911976Z ##[group]Disabling automatic garbage collection
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3915801Z [command]/usr/bin/git config --local gc.auto 0
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3944317Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3945521Z ##[group]Setting up auth
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3952119Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.3982199Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4251322Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4281776Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4511811Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4553837Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4772790Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4806232Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4807377Z ##[group]Fetching the repository
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.4815262Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7368333Z From https://github.com/link-foundation/lino-arguments
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7370168Z  * [new branch]      changeset-release/manual-19391025857 -> origin/changeset-release/manual-19391025857
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7372673Z  * [new branch]      claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj -> origin/claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7375725Z  * [new branch]      claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq -> origin/claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7378343Z  * [new branch]      issue-1-171e0c1cad4c  -> origin/issue-1-171e0c1cad4c
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7379723Z  * [new branch]      issue-10-89893ff89d82 -> origin/issue-10-89893ff89d82
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7381116Z  * [new branch]      issue-10-d4419a0e77c2 -> origin/issue-10-d4419a0e77c2
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7382752Z  * [new branch]      issue-13-167bb501b116 -> origin/issue-13-167bb501b116
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7384125Z  * [new branch]      issue-14-555e0cfd6e57 -> origin/issue-14-555e0cfd6e57
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7385464Z  * [new branch]      issue-17-aac47b45095f -> origin/issue-17-aac47b45095f
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7387138Z  * [new branch]      issue-19-c4402d419d95 -> origin/issue-19-c4402d419d95
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7388565Z  * [new branch]      issue-20-535e73c3f5df -> origin/issue-20-535e73c3f5df
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7389955Z  * [new branch]      issue-23-139e66537421 -> origin/issue-23-139e66537421
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7391399Z  * [new branch]      issue-25-05c1d1b27224 -> origin/issue-25-05c1d1b27224
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7392812Z  * [new branch]      issue-27-88fb89a5de9c -> origin/issue-27-88fb89a5de9c
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7394191Z  * [new branch]      issue-6-88ce301275b5  -> origin/issue-6-88ce301275b5
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7395570Z  * [new branch]      issue-6-ed79da598197  -> origin/issue-6-ed79da598197
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7397281Z  * [new branch]      issue-6-ef625c0a060f  -> origin/issue-6-ef625c0a060f
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7398563Z  * [new branch]      main                  -> origin/main
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7399611Z  * [new tag]         v0.1.1                -> v0.1.1
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7400624Z  * [new tag]         v0.2.0                -> v0.2.0
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7401615Z  * [new tag]         v0.2.5                -> v0.2.5
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7402613Z  * [new tag]         v0.2.7                -> v0.2.7
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7403617Z  * [new tag]         v0.2.8                -> v0.2.8
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7404602Z  * [new tag]         v0.3.0                -> v0.3.0
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7438657Z [command]/usr/bin/git branch --list --remote origin/main
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7463151Z   origin/main
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7471425Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7490311Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7494768Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7495841Z ##[group]Determining the checkout info
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7497262Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7595356Z [command]/usr/bin/git sparse-checkout disable
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7598723Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7601729Z ##[group]Checking out the ref
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7603059Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7736943Z Switched to a new branch 'main'
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7738971Z branch 'main' set up to track 'origin/main'.
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7747349Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7792100Z [command]/usr/bin/git log -1 --format=%H
+Detect Changes	Run actions/checkout@v4	2026-04-10T20:47:06.7815942Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Detect Changes	Setup Node.js	﻿2026-04-10T20:47:06.8122153Z ##[group]Run actions/setup-node@v4
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.8123249Z with:
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.8123951Z   node-version: 20.x
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.8124757Z   always-auth: false
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.8125568Z   check-latest: false
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.8126938Z   token: ***
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.8127701Z ##[endgroup]
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.9908296Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+Detect Changes	Setup Node.js	2026-04-10T20:47:06.9911051Z ##[group]Environment details
+Detect Changes	Setup Node.js	2026-04-10T20:47:07.2637389Z node: v20.20.2
+Detect Changes	Setup Node.js	2026-04-10T20:47:07.2638404Z npm: 10.8.2
+Detect Changes	Setup Node.js	2026-04-10T20:47:07.2639028Z yarn: 1.22.22
+Detect Changes	Setup Node.js	2026-04-10T20:47:07.2640388Z ##[endgroup]
+Detect Changes	Detect changes	﻿2026-04-10T20:47:07.2792788Z ##[group]Run node scripts/detect-code-changes.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.2793929Z [36;1mnode scripts/detect-code-changes.mjs[0m
+Detect Changes	Detect changes	2026-04-10T20:47:07.2828761Z shell: /usr/bin/bash -e {0}
+Detect Changes	Detect changes	2026-04-10T20:47:07.2829425Z env:
+Detect Changes	Detect changes	2026-04-10T20:47:07.2829875Z   GITHUB_EVENT_NAME: push
+Detect Changes	Detect changes	2026-04-10T20:47:07.2830470Z   GITHUB_BASE_SHA: 
+Detect Changes	Detect changes	2026-04-10T20:47:07.2831005Z   GITHUB_HEAD_SHA: 
+Detect Changes	Detect changes	2026-04-10T20:47:07.2831512Z ##[endgroup]
+Detect Changes	Detect changes	2026-04-10T20:47:07.3213650Z Detecting file changes for CI/CD...
+Detect Changes	Detect changes	2026-04-10T20:47:07.3214858Z 
+Detect Changes	Detect changes	2026-04-10T20:47:07.3215358Z Comparing HEAD^ to HEAD
+Detect Changes	Detect changes	2026-04-10T20:47:07.3257041Z Changed files:
+Detect Changes	Detect changes	2026-04-10T20:47:07.3258400Z   .github/workflows/js.yml
+Detect Changes	Detect changes	2026-04-10T20:47:07.3259339Z   .github/workflows/rust.yml
+Detect Changes	Detect changes	2026-04-10T20:47:07.3260270Z   docs/case-studies/issue-27/case-study.md
+Detect Changes	Detect changes	2026-04-10T20:47:07.3261503Z   docs/case-studies/issue-27/issue-data.json
+Detect Changes	Detect changes	2026-04-10T20:47:07.3262582Z   rust/changelog.d/fix-duplicate-publish.md
+Detect Changes	Detect changes	2026-04-10T20:47:07.3263629Z   scripts/check-release-needed.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3264483Z   scripts/create-github-release.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3265253Z   scripts/format-github-release.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3266018Z   scripts/format-release-notes.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3267268Z   scripts/format-rust-release.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3268194Z   scripts/publish-crate.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3268859Z   scripts/publish-to-npm.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3269677Z   scripts/version-and-commit.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3270251Z 
+Detect Changes	Detect changes	2026-04-10T20:47:07.3270565Z rs-changed=false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3271224Z toml-changed=false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3271729Z js-changed=false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3272323Z package-changed=false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3273124Z mjs-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3273818Z docs-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3275088Z workflow-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3276341Z rust-workflow-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3277896Z js-workflow-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3278700Z 
+Detect Changes	Detect changes	2026-04-10T20:47:07.3279290Z Files considered as code changes:
+Detect Changes	Detect changes	2026-04-10T20:47:07.3280553Z   .github/workflows/js.yml
+Detect Changes	Detect changes	2026-04-10T20:47:07.3281676Z   .github/workflows/rust.yml
+Detect Changes	Detect changes	2026-04-10T20:47:07.3282921Z   scripts/check-release-needed.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3284311Z   scripts/create-github-release.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3285793Z   scripts/format-github-release.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3287473Z   scripts/format-release-notes.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3288848Z   scripts/format-rust-release.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3290107Z   scripts/publish-crate.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3291242Z   scripts/publish-to-npm.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3292464Z   scripts/version-and-commit.mjs
+Detect Changes	Detect changes	2026-04-10T20:47:07.3293294Z 
+Detect Changes	Detect changes	2026-04-10T20:47:07.3293747Z any-code-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3294782Z rust-code-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3295857Z js-code-changed=true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3297160Z rust-package-changed=false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3298240Z js-package-changed=false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3298834Z 
+Detect Changes	Detect changes	2026-04-10T20:47:07.3299308Z Language-specific detection:
+Detect Changes	Detect changes	2026-04-10T20:47:07.3300414Z   Rust-related changes: true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3301552Z   JS-related changes: true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3302701Z   Rust package code changes: false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3303957Z   JS package code changes: false
+Detect Changes	Detect changes	2026-04-10T20:47:07.3305282Z   Shared scripts changed: true
+Detect Changes	Detect changes	2026-04-10T20:47:07.3306131Z 
+Detect Changes	Detect changes	2026-04-10T20:47:07.3306849Z Change detection completed.
+Detect Changes	Post Setup Node.js	﻿2026-04-10T20:47:07.3535905Z Post job cleanup.
+Detect Changes	Post Run actions/checkout@v4	﻿2026-04-10T20:47:07.5281929Z Post job cleanup.
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6222761Z [command]/usr/bin/git version
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6259565Z git version 2.53.0
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6303981Z Temporarily overriding HOME='/home/runner/work/_temp/a03bb644-6d43-4131-b635-a1ba28bfde83' before making global git config changes
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6306250Z Adding repository directory to the temporary git global config as a safe directory
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6316038Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6351665Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6388533Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6639460Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6660183Z http.https://github.com/.extraheader
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6674254Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6705759Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6926059Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Detect Changes	Post Run actions/checkout@v4	2026-04-10T20:47:07.6958869Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Detect Changes	Complete job	﻿2026-04-10T20:47:07.7294218Z Evaluate and set job outputs
+Detect Changes	Complete job	2026-04-10T20:47:07.7303193Z Set output 'js-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7305617Z Set output 'package-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7306921Z Set output 'mjs-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7307588Z Set output 'docs-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7308272Z Set output 'js-workflow-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7308992Z Set output 'js-code-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7309677Z Set output 'js-package-changed'
+Detect Changes	Complete job	2026-04-10T20:47:07.7310844Z Cleaning up orphan processes
+Detect Changes	Complete job	2026-04-10T20:47:07.7669356Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Lint and Format Check	Set up job	﻿2026-04-10T20:47:12.5849877Z Current runner version: '2.333.1'
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5889617Z ##[group]Runner Image Provisioner
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5891065Z Hosted Compute Agent
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5891968Z Version: 20260213.493
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5893116Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5894331Z Build Date: 2026-02-13T00:28:41Z
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5895189Z Worker ID: {433adcfc-e537-4714-8f3e-7e381d83feb9}
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5895925Z Azure Region: westus3
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5896414Z ##[endgroup]
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5898358Z ##[group]Operating System
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5898977Z Ubuntu
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5899389Z 24.04.4
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5900229Z LTS
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5901058Z ##[endgroup]
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5901874Z ##[group]Runner Image
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5902790Z Image: ubuntu-24.04
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5903334Z Version: 20260406.80.1
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5904866Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5906641Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5907521Z ##[endgroup]
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5910296Z ##[group]GITHUB_TOKEN Permissions
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5913068Z Actions: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5914561Z ArtifactMetadata: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5915522Z Attestations: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5916437Z Checks: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5917272Z Contents: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5918052Z Deployments: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5918829Z Discussions: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5919583Z Issues: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5920411Z Metadata: read
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5921102Z Models: read
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5921876Z Packages: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5922816Z Pages: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5923719Z PullRequests: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5924589Z RepositoryProjects: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5925476Z SecurityEvents: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5926269Z Statuses: write
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5926973Z ##[endgroup]
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5930123Z Secret source: Actions
+Lint and Format Check	Set up job	2026-04-10T20:47:12.5931340Z Prepare workflow directory
+Lint and Format Check	Set up job	2026-04-10T20:47:12.6524716Z Prepare all required actions
+Lint and Format Check	Set up job	2026-04-10T20:47:12.6583801Z Getting action download info
+Lint and Format Check	Set up job	2026-04-10T20:47:13.1023439Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Lint and Format Check	Set up job	2026-04-10T20:47:13.2566485Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Lint and Format Check	Set up job	2026-04-10T20:47:13.4338494Z Complete job name: Lint and Format Check
+Lint and Format Check	Run actions/checkout@v4	﻿2026-04-10T20:47:13.5044658Z ##[group]Run actions/checkout@v4
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5045624Z with:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5046065Z   repository: link-foundation/lino-arguments
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5046808Z   token: ***
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5047188Z   ssh-strict: true
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5047572Z   ssh-user: git
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5047963Z   persist-credentials: true
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5048401Z   clean: true
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5048789Z   sparse-checkout-cone-mode: true
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5049271Z   fetch-depth: 1
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5049639Z   fetch-tags: false
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5050021Z   show-progress: true
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5050409Z   lfs: false
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5050757Z   submodules: false
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5051148Z   set-safe-directory: true
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.5051800Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6106229Z Syncing repository: link-foundation/lino-arguments
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6108705Z ##[group]Getting Git version info
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6109846Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6111251Z [command]/usr/bin/git version
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6163922Z git version 2.53.0
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6204259Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6230919Z Temporarily overriding HOME='/home/runner/work/_temp/38d6e94c-c0ad-436b-8b77-28c60c76fee4' before making global git config changes
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6232911Z Adding repository directory to the temporary git global config as a safe directory
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6238738Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6276097Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6280336Z ##[group]Initializing the repository
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6286512Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6379925Z hint: Using 'master' as the name for the initial branch. This default branch name
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6381890Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6383329Z hint: to use in all of your new repositories, which will suppress this warning,
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6384031Z hint: call:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6384380Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6384823Z hint: 	git config --global init.defaultBranch <name>
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6385382Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6385899Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6386746Z hint: 'development'. The just-created branch can be renamed via this command:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6387456Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6387982Z hint: 	git branch -m <name>
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6388407Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6388966Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6389978Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6395813Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6428084Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6428804Z ##[group]Disabling automatic garbage collection
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6433697Z [command]/usr/bin/git config --local gc.auto 0
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6464958Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6465633Z ##[group]Setting up auth
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6474826Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6508654Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6816222Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.6845910Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.7055418Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.7086991Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.7304481Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.7336978Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.7338210Z ##[group]Fetching the repository
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:13.7346776Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4439876Z From https://github.com/link-foundation/lino-arguments
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4441686Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4470489Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4472064Z ##[group]Determining the checkout info
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4474137Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4478705Z [command]/usr/bin/git sparse-checkout disable
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4517454Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4546552Z ##[group]Checking out the ref
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4549715Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4697458Z Switched to a new branch 'main'
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4698965Z branch 'main' set up to track 'origin/main'.
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4706008Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4737547Z [command]/usr/bin/git log -1 --format=%H
+Lint and Format Check	Run actions/checkout@v4	2026-04-10T20:47:14.4758903Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Lint and Format Check	Setup Node.js	﻿2026-04-10T20:47:14.5061482Z ##[group]Run actions/setup-node@v4
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.5062894Z with:
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.5063607Z   node-version: 20.x
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.5064416Z   always-auth: false
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.5065231Z   check-latest: false
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.5066327Z   token: ***
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.5067043Z ##[endgroup]
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.6813500Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.6819141Z ##[group]Environment details
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.9902629Z node: v20.20.2
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.9903221Z npm: 10.8.2
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.9903520Z yarn: 1.22.22
+Lint and Format Check	Setup Node.js	2026-04-10T20:47:14.9904674Z ##[endgroup]
+Lint and Format Check	Install dependencies	﻿2026-04-10T20:47:15.0019718Z ##[group]Run npm install
+Lint and Format Check	Install dependencies	2026-04-10T20:47:15.0020273Z [36;1mnpm install[0m
+Lint and Format Check	Install dependencies	2026-04-10T20:47:15.0064442Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Install dependencies	2026-04-10T20:47:15.0064960Z ##[endgroup]
+Lint and Format Check	Install dependencies	2026-04-10T20:47:17.9952819Z 
+Lint and Format Check	Install dependencies	2026-04-10T20:47:17.9960976Z > lino-arguments@0.3.0 prepare
+Lint and Format Check	Install dependencies	2026-04-10T20:47:17.9961606Z > husky || true
+Lint and Format Check	Install dependencies	2026-04-10T20:47:17.9961762Z 
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0389997Z .git can't be found
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0390815Z added 234 packages, and audited 235 packages in 3s
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0391301Z 
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0391630Z 59 packages are looking for funding
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0392163Z   run `npm fund` for details
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0489236Z 
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0489838Z 7 vulnerabilities (4 moderate, 3 high)
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0490117Z 
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0490372Z To address all issues, run:
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0490858Z   npm audit fix
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0491099Z 
+Lint and Format Check	Install dependencies	2026-04-10T20:47:18.0491376Z Run `npm audit` for details.
+Lint and Format Check	Run ESLint	﻿2026-04-10T20:47:18.0750151Z ##[group]Run npm run lint
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.0750674Z [36;1mnpm run lint[0m
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.0778747Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.0779002Z ##[endgroup]
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.1882986Z 
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.1883423Z > lino-arguments@0.3.0 lint
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.1883776Z > eslint .
+Lint and Format Check	Run ESLint	2026-04-10T20:47:18.1883926Z 
+Lint and Format Check	Check formatting	﻿2026-04-10T20:47:19.1844230Z ##[group]Run npm run format:check
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.1844696Z [36;1mnpm run format:check[0m
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.1872727Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.1873110Z ##[endgroup]
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.3013037Z 
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.3014100Z > lino-arguments@0.3.0 format:check
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.3014692Z > prettier --check .
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.3014944Z 
+Lint and Format Check	Check formatting	2026-04-10T20:47:19.3863969Z Checking formatting...
+Lint and Format Check	Check formatting	2026-04-10T20:47:20.0613976Z All matched files use Prettier code style!
+Lint and Format Check	Check file size limit	﻿2026-04-10T20:47:20.1061753Z ##[group]Run npm run check:file-size
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.1062066Z [36;1mnpm run check:file-size[0m
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.1083738Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.1083976Z ##[endgroup]
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2236089Z 
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2236926Z > lino-arguments@0.3.0 check:file-size
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2237693Z > node ../scripts/check-file-size.mjs
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2238131Z 
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2601897Z 
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2602826Z Checking JavaScript files for maximum 1500 lines...
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2603654Z 
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2660453Z ✓ All files are within the line limit
+Lint and Format Check	Check file size limit	2026-04-10T20:47:20.2661825Z 
+Lint and Format Check	Post Setup Node.js	﻿2026-04-10T20:47:20.2826437Z Post job cleanup.
+Lint and Format Check	Post Run actions/checkout@v4	﻿2026-04-10T20:47:20.4475999Z Post job cleanup.
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5399098Z [command]/usr/bin/git version
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5439235Z git version 2.53.0
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5486611Z Temporarily overriding HOME='/home/runner/work/_temp/34465d06-5b48-476f-be62-bcfc72df3d9a' before making global git config changes
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5488455Z Adding repository directory to the temporary git global config as a safe directory
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5494067Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5539143Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5573294Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5810446Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5831584Z http.https://github.com/.extraheader
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5845026Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.5876890Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.6100884Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and Format Check	Post Run actions/checkout@v4	2026-04-10T20:47:20.6132049Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and Format Check	Complete job	﻿2026-04-10T20:47:20.6465104Z Cleaning up orphan processes
+Lint and Format Check	Complete job	2026-04-10T20:47:20.6750270Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (node on ubuntu-latest)	Set up job	﻿2026-04-10T20:47:11.9815864Z Current runner version: '2.333.1'
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9842527Z ##[group]Runner Image Provisioner
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9843369Z Hosted Compute Agent
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9843901Z Version: 20260213.493
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9844649Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9845316Z Build Date: 2026-02-13T00:28:41Z
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9845977Z Worker ID: {246f563d-ea90-488a-b7f8-4d817594823d}
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9846660Z Azure Region: eastus
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9847246Z ##[endgroup]
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9848642Z ##[group]Operating System
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9849574Z Ubuntu
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9850084Z 24.04.4
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9850515Z LTS
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9851018Z ##[endgroup]
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9851505Z ##[group]Runner Image
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9852096Z Image: ubuntu-24.04
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9852708Z Version: 20260406.80.1
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9853787Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9855472Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9856391Z ##[endgroup]
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9859761Z ##[group]GITHUB_TOKEN Permissions
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9862266Z Actions: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9862989Z ArtifactMetadata: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9863575Z Attestations: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9864162Z Checks: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9864711Z Contents: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9865219Z Deployments: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9865813Z Discussions: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9866339Z Issues: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9866821Z Metadata: read
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9867381Z Models: read
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9867870Z Packages: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9868379Z Pages: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9869026Z PullRequests: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9869531Z RepositoryProjects: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9870112Z SecurityEvents: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9870628Z Statuses: write
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9871230Z ##[endgroup]
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9873919Z Secret source: Actions
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:11.9875048Z Prepare workflow directory
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0265778Z Prepare all required actions
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0303359Z Getting action download info
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:12.3448248Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:12.4710905Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:12.8649665Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:13.0617354Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (node on ubuntu-latest)	Set up job	2026-04-10T20:47:13.3728694Z Complete job name: Test (node on ubuntu-latest)
+Test (node on ubuntu-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:13.4512587Z ##[group]Run actions/checkout@v4
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4513581Z with:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4514068Z   repository: link-foundation/lino-arguments
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4515072Z   token: ***
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4515521Z   ssh-strict: true
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4515969Z   ssh-user: git
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4516425Z   persist-credentials: true
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4516980Z   clean: true
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4517435Z   sparse-checkout-cone-mode: true
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4518052Z   fetch-depth: 1
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4518492Z   fetch-tags: false
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4518963Z   show-progress: true
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4519456Z   lfs: false
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4519860Z   submodules: false
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4520359Z   set-safe-directory: true
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4521082Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5591574Z Syncing repository: link-foundation/lino-arguments
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5594240Z ##[group]Getting Git version info
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5595296Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5596779Z [command]/usr/bin/git version
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5638670Z git version 2.53.0
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5662977Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5686700Z Temporarily overriding HOME='/home/runner/work/_temp/af59f5cf-1a97-41c5-88ef-ad64f5261898' before making global git config changes
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5689245Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5692208Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5725903Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5729181Z ##[group]Initializing the repository
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5733780Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5791832Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5794666Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5796964Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5798679Z hint: call:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5799313Z hint:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5800187Z hint: 	git config --global init.defaultBranch <name>
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5801391Z hint:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5802685Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5804963Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5806704Z hint:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5807352Z hint: 	git branch -m <name>
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5808143Z hint:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5809384Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5812008Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5814845Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5838080Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5839419Z ##[group]Disabling automatic garbage collection
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5842901Z [command]/usr/bin/git config --local gc.auto 0
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5872166Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5873667Z ##[group]Setting up auth
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5879991Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5910795Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6200449Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6231770Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6460673Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6494315Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6726480Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6761333Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6762262Z ##[group]Fetching the repository
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6770011Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3226544Z From https://github.com/link-foundation/lino-arguments
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3227561Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3255766Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3256268Z ##[group]Determining the checkout info
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3258229Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3263666Z [command]/usr/bin/git sparse-checkout disable
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3300108Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3325991Z ##[group]Checking out the ref
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3329887Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3488779Z Switched to a new branch 'main'
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3490131Z branch 'main' set up to track 'origin/main'.
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3497450Z ##[endgroup]
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3535276Z [command]/usr/bin/git log -1 --format=%H
+Test (node on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3558949Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (node on ubuntu-latest)	Setup Node.js	﻿2026-04-10T20:47:14.3864741Z ##[group]Run actions/setup-node@v4
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.3865109Z with:
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.3865345Z   node-version: 20.x
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.3865603Z   always-auth: false
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.3865848Z   check-latest: false
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.3866248Z   token: ***
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.3866480Z ##[endgroup]
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.5613525Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.5620053Z ##[group]Environment details
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.8318394Z node: v20.20.2
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.8319042Z npm: 10.8.2
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.8319452Z yarn: 1.22.22
+Test (node on ubuntu-latest)	Setup Node.js	2026-04-10T20:47:14.8320557Z ##[endgroup]
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	﻿2026-04-10T20:47:14.8437717Z ##[group]Run npm install
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:14.8438135Z [36;1mnpm install[0m
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:14.8471756Z shell: /usr/bin/bash -e {0}
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:14.8472090Z ##[endgroup]
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.6882675Z 
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.6889308Z > lino-arguments@0.3.0 prepare
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.6889738Z > husky || true
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.6889877Z 
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7339969Z .git can't be found
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7340474Z added 234 packages, and audited 235 packages in 3s
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7340858Z 
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7342576Z 59 packages are looking for funding
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7343315Z   run `npm fund` for details
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7430497Z 
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7430987Z 7 vulnerabilities (4 moderate, 3 high)
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7431378Z 
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7431607Z To address all issues, run:
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7432033Z   npm audit fix
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7432248Z 
+Test (node on ubuntu-latest)	Install dependencies (Node.js)	2026-04-10T20:47:17.7432687Z Run `npm audit` for details.
+Test (node on ubuntu-latest)	Run tests (Node.js)	﻿2026-04-10T20:47:17.7647374Z ##[group]Run npm test
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.7647660Z [36;1mnpm test[0m
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.7670089Z shell: /usr/bin/bash -e {0}
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.7670388Z ##[endgroup]
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.8832991Z 
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.8833862Z > lino-arguments@0.3.0 test
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.8834422Z > node --test tests/
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.8834691Z 
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:17.9307497Z TAP version 13
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0314378Z # 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0324083Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0337072Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0351302Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0383794Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0488119Z # 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0502983Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0516556Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0535889Z # 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0545502Z # 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0552679Z # 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0840059Z # Subtest: Case Conversion Utilities
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0841187Z     # Subtest: toUpperCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0842112Z         # Subtest: should convert camelCase to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0852999Z         ok 1 - should convert camelCase to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0873562Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0902145Z           duration_ms: 1.136128
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0903228Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0904006Z         # Subtest: should convert kebab-case to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0904720Z         ok 2 - should convert kebab-case to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0905218Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0905662Z           duration_ms: 0.240695
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0906166Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0906658Z         # Subtest: should convert snake_case to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0907221Z         ok 3 - should convert snake_case to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0907675Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0908055Z           duration_ms: 0.157072
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0908441Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0908948Z         # Subtest: should convert PascalCase to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0909500Z         ok 4 - should convert PascalCase to UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0909968Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0910333Z           duration_ms: 0.145205
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0910714Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0911169Z         # Subtest: should handle already UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0911659Z         ok 5 - should handle already UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0912110Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0912792Z           duration_ms: 0.125315
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0913358Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0913905Z         1..5
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0914467Z     ok 1 - toUpperCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0915079Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0915635Z       duration_ms: 2.441595
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0916254Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0916836Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0917407Z     # Subtest: toCamelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0918181Z         # Subtest: should convert kebab-case to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0919134Z         ok 1 - should convert kebab-case to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0919876Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0920487Z           duration_ms: 0.33882
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0921608Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0922766Z         # Subtest: should convert UPPER_CASE to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0923748Z         ok 2 - should convert UPPER_CASE to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0924503Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0925146Z           duration_ms: 0.143732
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0925754Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0926421Z         # Subtest: should convert snake_case to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0927353Z         ok 3 - should convert snake_case to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0928093Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0928684Z           duration_ms: 0.175459
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0929314Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0929986Z         # Subtest: should convert PascalCase to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0930854Z         ok 4 - should convert PascalCase to camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0931587Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0932189Z           duration_ms: 0.218052
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0933324Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0935900Z         # Subtest: should handle already camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0936846Z         ok 5 - should handle already camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0937588Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0938160Z           duration_ms: 0.194778
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0938716Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0939204Z         1..5
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0939717Z     ok 2 - toCamelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0940234Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0940746Z       duration_ms: 1.411694
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0941373Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0941963Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0943369Z     # Subtest: toKebabCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0944464Z         # Subtest: should convert camelCase to kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0945576Z         ok 1 - should convert camelCase to kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0946272Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0946840Z           duration_ms: 0.316767
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.0951904Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1008444Z         # Subtest: should convert UPPER_CASE to kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1043100Z         ok 2 - should convert UPPER_CASE to kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1059245Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1088765Z           duration_ms: 0.226054
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1089568Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1090331Z         # Subtest: should convert PascalCase to kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1091363Z         ok 3 - should convert PascalCase to kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1092122Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1092966Z           duration_ms: 0.172835
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1093622Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1094301Z         # Subtest: should handle already kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1095121Z         ok 4 - should handle already kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1095780Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1096329Z           duration_ms: 0.119676
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1096887Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1097371Z         1..4
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1097875Z     ok 3 - toKebabCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1098468Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1098995Z       duration_ms: 1.058402
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1099557Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1100070Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1100530Z     # Subtest: toSnakeCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1101221Z         # Subtest: should convert camelCase to snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1102127Z         ok 1 - should convert camelCase to snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1103018Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1103562Z           duration_ms: 0.264711
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1104123Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1104800Z         # Subtest: should convert kebab-case to snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1105604Z         ok 2 - should convert kebab-case to snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1106257Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1106791Z           duration_ms: 0.132926
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1107379Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1108026Z         # Subtest: should convert UPPER_CASE to snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1108879Z         ok 3 - should convert UPPER_CASE to snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1109586Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1110463Z           duration_ms: 0.102691
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1111022Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1111652Z         # Subtest: should handle already snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1112572Z         ok 4 - should handle already snake_case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1113213Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1113736Z           duration_ms: 0.275727
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1114287Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1114724Z         1..4
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1115300Z     ok 4 - toSnakeCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1115873Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1116419Z       duration_ms: 0.950173
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1117031Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1117580Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1118093Z     # Subtest: toPascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1118861Z         # Subtest: should convert camelCase to PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1119830Z         ok 1 - should convert camelCase to PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1125644Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1152734Z           duration_ms: 0.239253
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1162954Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1183932Z         # Subtest: should convert kebab-case to PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1193188Z         ok 2 - should convert kebab-case to PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1206323Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1206988Z           duration_ms: 0.150151
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1207520Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1227017Z         # Subtest: should convert snake_case to PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1227764Z         ok 3 - should convert snake_case to PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1228235Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1228593Z           duration_ms: 0.115381
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1228945Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1229337Z         # Subtest: should handle already PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1229886Z         ok 4 - should handle already PascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1230301Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1230633Z           duration_ms: 0.091976
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1231010Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1231628Z         1..4
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1231946Z     ok 5 - toPascalCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1232271Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1232775Z       duration_ms: 1.452735
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1233140Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1233424Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1247116Z     1..5
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1247531Z ok 1 - Case Conversion Utilities
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1247942Z   ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1248240Z   duration_ms: 8.264813
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1248574Z   type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1248868Z   ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1249147Z # Subtest: getenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1249573Z     # Subtest: should find variable in UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1250124Z     ok 1 - should find variable in UPPER_CASE
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1250550Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1250839Z       duration_ms: 0.431617
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1251165Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1251541Z     # Subtest: should find variable in camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1252065Z     ok 2 - should find variable in camelCase
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1252823Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1253120Z       duration_ms: 0.171233
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1253451Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1253814Z     # Subtest: should find variable in kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1254510Z     ok 3 - should find variable in kebab-case
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1254919Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1255198Z       duration_ms: 0.216189
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1255517Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1255927Z     # Subtest: should return default value when not found
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1257041Z     ok 4 - should return default value when not found
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1257496Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1257775Z       duration_ms: 0.263409
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1258100Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1258602Z     # Subtest: should return empty string as default when not specified
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1259359Z     ok 5 - should return empty string as default when not specified
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1259861Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1260139Z       duration_ms: 0.223941
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1260464Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1261093Z     # Subtest: should try original key first
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1261577Z     ok 6 - should try original key first
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1261966Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1262245Z       duration_ms: 0.273153
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1262805Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1263065Z     1..6
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1263323Z ok 2 - getenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1263645Z   ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1263919Z   duration_ms: 1.838073
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1264247Z   type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1264532Z   ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1265306Z # Subtest: makeConfig
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1265704Z     # Subtest: Hero Example (defaults)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1266240Z         # Subtest: should work with minimal configuration
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1266864Z         ok 1 - should work with minimal configuration
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1267319Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1267645Z           duration_ms: 8.39185
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1268002Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1268479Z         # Subtest: should use CLI arguments with highest priority
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1269156Z         ok 2 - should use CLI arguments with highest priority
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1269640Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1269966Z           duration_ms: 2.399222
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1270303Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1285075Z         # Subtest: should convert kebab-case to camelCase in result
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1285850Z         ok 3 - should convert kebab-case to camelCase in result
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1286379Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1286742Z           duration_ms: 2.566108
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1287093Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1287364Z         1..3
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1287714Z     ok 1 - Hero Example (defaults)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1288081Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1288375Z       duration_ms: 13.506992
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1288724Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1289022Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1289381Z     # Subtest: Environment Loading Priority
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1290189Z         # Subtest: should load .lenv file by default
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1290799Z         ok 1 - should load .lenv file by default
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1291224Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1291567Z           duration_ms: 2.590044
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1291920Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1292312Z         # Subtest: should handle --configuration flag
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1293170Z         ok 2 - should handle --configuration flag
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1293612Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1293933Z           duration_ms: 2.902945
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1294283Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1294707Z         # Subtest: should prioritize CLI over environment
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1295323Z         ok 3 - should prioritize CLI over environment
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1295776Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1296097Z           duration_ms: 1.76788
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1296441Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1296865Z         # Subtest: should handle missing .lenv file gracefully
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1297490Z         ok 4 - should handle missing .lenv file gracefully
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1297969Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1298284Z           duration_ms: 1.348311
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1298632Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1298904Z         1..4
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1299251Z     ok 2 - Environment Loading Priority
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1299679Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1299968Z       duration_ms: 8.772111
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1300311Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1300602Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1300987Z     # Subtest: Case Conversion in Environment Loading
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1301681Z         # Subtest: should convert all keys to UPPER_CASE in process.env
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1302588Z         ok 1 - should convert all keys to UPPER_CASE in process.env
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1303080Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1303418Z           duration_ms: 1.736885
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1303771Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1304243Z         # Subtest: should find env vars in any case format via getenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1305177Z         ok 2 - should find env vars in any case format via getenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1305656Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1305986Z           duration_ms: 2.894643
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1306331Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1306593Z         1..2
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1306984Z     ok 3 - Case Conversion in Environment Loading
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1307417Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1307696Z       duration_ms: 4.761379
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1308050Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1308339Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1308689Z     # Subtest: Configuration Options
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1309184Z         # Subtest: should support disabling lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1309751Z         ok 1 - should support disabling lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1310167Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1310551Z           duration_ms: 1.935077
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1310942Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1311477Z         # Subtest: should support enabling env/dotenvx (deprecated)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1312232Z         ok 2 - should support enabling env/dotenvx (deprecated)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1312926Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1313311Z           duration_ms: 2.048484
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1313678Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1314093Z         # Subtest: should support disabling getenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1314672Z         ok 3 - should support disabling getenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1315146Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1315504Z           duration_ms: 1.012645
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1315880Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1316374Z         # Subtest: should support configuration alias -c
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1317026Z         ok 4 - should support configuration alias -c
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1317525Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1317897Z           duration_ms: 1.597698
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1318269Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1318598Z         1..4
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1318975Z     ok 4 - Configuration Options
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1319395Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1320070Z       duration_ms: 6.748273
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1320490Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1320843Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1321320Z     # Subtest: Complete Priority Chain
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1322328Z         # Subtest: should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1323791Z         ok 1 - should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1324599Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1325008Z           duration_ms: 7.381458
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1325442Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1325805Z         1..1
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1326201Z     ok 5 - Complete Priority Chain
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1326693Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1327027Z       duration_ms: 7.512581
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1327481Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1327833Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1328288Z     # Subtest: Built-in Flag Conflicts (Issue \#14)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1329250Z         # Subtest: should allow user-defined --version option by calling .version(false)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1330496Z         ok 1 - should allow user-defined --version option by calling .version(false)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1331386Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1331887Z           duration_ms: 2.316881
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1332336Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1332997Z         # Subtest: should allow user-defined --help option
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1333607Z         ok 2 - should allow user-defined --help option
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1334055Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1334375Z           duration_ms: 1.850532
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1334769Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1335185Z         # Subtest: should work with --version in strict mode
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1335820Z         ok 3 - should work with --version in strict mode
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1336317Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1336647Z           duration_ms: 1.824854
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1337000Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1337420Z         # Subtest: should handle --version with boolean type
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1338268Z         ok 4 - should handle --version with boolean type
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1338727Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1339044Z           duration_ms: 1.581745
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1339394Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1339826Z         # Subtest: should allow users to explicitly enable help
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1340469Z         ok 5 - should allow users to explicitly enable help
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1340941Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1341253Z           duration_ms: 1.842179
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1341589Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1342101Z         # Subtest: should work with multiple custom options including version
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1343161Z         ok 6 - should work with multiple custom options including version
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1343730Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1344065Z           duration_ms: 2.426472
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1344434Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1344712Z         1..6
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1345087Z     ok 6 - Built-in Flag Conflicts (Issue \#14)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1345539Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1345818Z       duration_ms: 12.169207
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1346174Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1346471Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1346904Z     # Subtest: Explicitly Enabling Built-in Version and Help
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1347618Z         # Subtest: should allow explicitly enabling built-in --version
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1348344Z         ok 1 - should allow explicitly enabling built-in --version
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1348837Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1349173Z           duration_ms: 1.851333
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1349521Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1350056Z         # Subtest: should allow explicitly enabling both --version and --help
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1350854Z         ok 2 - should allow explicitly enabling both --version and --help
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1351383Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1351761Z           duration_ms: 1.373047
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1352132Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1352937Z         # Subtest: should allow version with alias
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1353521Z         ok 3 - should allow version with alias
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1353808Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1354016Z           duration_ms: 1.258087
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1354251Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1354493Z         # Subtest: should allow help with alias
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1354818Z         ok 4 - should allow help with alias
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1355079Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1355284Z           duration_ms: 1.271037
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1355505Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1355839Z         # Subtest: should work with both built-in version/help and custom options
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1356396Z         ok 5 - should work with both built-in version/help and custom options
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1356749Z           ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1356950Z           duration_ms: 1.826026
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1357169Z           ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1357341Z         1..5
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1357613Z     ok 7 - Explicitly Enabling Built-in Version and Help
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1357934Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1358126Z       duration_ms: 7.778023
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1358364Z       type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1358561Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1358727Z     1..7
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1358920Z ok 3 - makeConfig
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1359150Z   ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1359354Z   duration_ms: 61.682188
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1359578Z   type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1359756Z   ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1360015Z # Subtest: parseLinoArguments (legacy)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1360380Z     # Subtest: should parse simple links notation format
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1360762Z     ok 1 - should parse simple links notation format
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1361047Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1361229Z       duration_ms: 1.783283
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1361440Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1361779Z     # Subtest: should parse arguments without parentheses
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1362157Z     ok 2 - should parse arguments without parentheses
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1362708Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1363070Z       duration_ms: 0.358228
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1363283Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1363499Z     # Subtest: should handle empty input
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1363796Z     ok 3 - should handle empty input
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1364040Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1364228Z       duration_ms: 0.192444
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1364437Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1364651Z     # Subtest: should handle null input
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1364944Z     ok 4 - should handle null input
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1365178Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1365362Z       duration_ms: 0.122521
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1365564Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1365777Z     # Subtest: should filter out comments
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1366079Z     ok 5 - should filter out comments
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1366316Z       ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1366489Z       duration_ms: 0.542841
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1366690Z       ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1366858Z     1..5
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1367095Z ok 4 - parseLinoArguments (legacy)
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1367340Z   ---
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1367520Z   duration_ms: 3.144873
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1367736Z   type: 'suite'
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1367915Z   ...
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1391589Z 1..4
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1391839Z # tests 58
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1392120Z # suites 16
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1392633Z # pass 58
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1392883Z # fail 0
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1393151Z # cancelled 0
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1393417Z # skipped 0
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1393677Z # todo 0
+Test (node on ubuntu-latest)	Run tests (Node.js)	2026-04-10T20:47:18.1397234Z # duration_ms 218.528924
+Test (node on ubuntu-latest)	Post Setup Node.js	﻿2026-04-10T20:47:18.1631960Z Post job cleanup.
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:18.3381933Z Post job cleanup.
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4317209Z [command]/usr/bin/git version
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4353703Z git version 2.53.0
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4394280Z Temporarily overriding HOME='/home/runner/work/_temp/5fce208a-eae7-40ce-97e8-40987c381848' before making global git config changes
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4395418Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4407759Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4443068Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4475644Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4713701Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4738435Z http.https://github.com/.extraheader
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4750209Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.4781276Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.5014410Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:18.5046056Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on ubuntu-latest)	Complete job	﻿2026-04-10T20:47:18.5389226Z Cleaning up orphan processes
+Test (node on ubuntu-latest)	Complete job	2026-04-10T20:47:18.5669664Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (deno on ubuntu-latest)	Set up job	﻿2026-04-10T20:47:11.9972894Z Current runner version: '2.333.1'
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0008171Z ##[group]Runner Image Provisioner
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0009502Z Hosted Compute Agent
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0010506Z Version: 20260213.493
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0012011Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0013256Z Build Date: 2026-02-13T00:28:41Z
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0014415Z Worker ID: {3ab58e40-77cf-468a-809e-18367cf37837}
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0015693Z Azure Region: eastus2
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0016695Z ##[endgroup]
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0019061Z ##[group]Operating System
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0020230Z Ubuntu
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0021278Z 24.04.4
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0022090Z LTS
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0022892Z ##[endgroup]
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0023840Z ##[group]Runner Image
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0024927Z Image: ubuntu-24.04
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0025800Z Version: 20260406.80.1
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0027736Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0030772Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0032693Z ##[endgroup]
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0037608Z ##[group]GITHUB_TOKEN Permissions
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0040403Z Actions: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0041648Z ArtifactMetadata: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0042669Z Attestations: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0043514Z Checks: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0044539Z Contents: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0045417Z Deployments: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0046329Z Discussions: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0047321Z Issues: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0048214Z Metadata: read
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0049029Z Models: read
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0050119Z Packages: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0051242Z Pages: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0052178Z PullRequests: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0053256Z RepositoryProjects: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0054211Z SecurityEvents: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0055310Z Statuses: write
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0056242Z ##[endgroup]
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0059300Z Secret source: Actions
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0060513Z Prepare workflow directory
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0651390Z Prepare all required actions
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0711124Z Getting action download info
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.3739928Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.5257873Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.6123578Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:12.8751591Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (deno on ubuntu-latest)	Set up job	2026-04-10T20:47:13.2639940Z Complete job name: Test (deno on ubuntu-latest)
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:13.3507054Z ##[group]Run actions/checkout@v4
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3508398Z with:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3509196Z   repository: link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3510499Z   token: ***
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3511542Z   ssh-strict: true
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3512329Z   ssh-user: git
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3513085Z   persist-credentials: true
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3513952Z   clean: true
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3514711Z   sparse-checkout-cone-mode: true
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3515630Z   fetch-depth: 1
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3516380Z   fetch-tags: false
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3517131Z   show-progress: true
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3517880Z   lfs: false
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3518570Z   submodules: false
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3519324Z   set-safe-directory: true
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3520420Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4611801Z Syncing repository: link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4614504Z ##[group]Getting Git version info
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4615929Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4618035Z [command]/usr/bin/git version
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4654118Z git version 2.53.0
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4681107Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4703713Z Temporarily overriding HOME='/home/runner/work/_temp/c3a94217-b254-4237-b6b1-07d4d3f8d522' before making global git config changes
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4707670Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4711397Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4741629Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4745494Z ##[group]Initializing the repository
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4749322Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4863056Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4865422Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4867222Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4868579Z hint: call:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4869634Z hint:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4870697Z hint: 	git config --global init.defaultBranch <name>
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4872222Z hint:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4873279Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4875111Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4876879Z hint:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4877590Z hint: 	git branch -m <name>
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4878410Z hint:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4879900Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4882311Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4885537Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4907564Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4908921Z ##[group]Disabling automatic garbage collection
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4911341Z [command]/usr/bin/git config --local gc.auto 0
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4939750Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4941196Z ##[group]Setting up auth
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4946370Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.4975912Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5271144Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5304054Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5522273Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5556494Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5782795Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5817407Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5819994Z ##[group]Fetching the repository
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5829286Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8417571Z From https://github.com/link-foundation/lino-arguments
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8421428Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8449613Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8452249Z ##[group]Determining the checkout info
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8454830Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8457084Z [command]/usr/bin/git sparse-checkout disable
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8503328Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8526052Z ##[group]Checking out the ref
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8530037Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8683522Z Switched to a new branch 'main'
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8686141Z branch 'main' set up to track 'origin/main'.
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8693324Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8728871Z [command]/usr/bin/git log -1 --format=%H
+Test (deno on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.8751525Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	﻿2026-04-10T20:47:13.9218464Z ##[group]Run actions/setup-node@v4
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.9219468Z with:
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.9220104Z   node-version: 20.x
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.9221030Z   always-auth: false
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.9221772Z   check-latest: false
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.9222754Z   token: ***
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.9223414Z ##[endgroup]
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.1224646Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.1231764Z ##[group]Environment details
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.4449736Z node: v20.20.2
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.4452028Z npm: 10.8.2
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.4452878Z yarn: 1.22.22
+Test (deno on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.4454254Z ##[endgroup]
+Test (deno on ubuntu-latest)	Setup Deno	﻿2026-04-10T20:47:14.4629016Z ##[group]Run denoland/setup-deno@v2
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:14.4629940Z with:
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:14.4630576Z   deno-version: v2.x
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:14.4631652Z   deno-binary-name: deno
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:14.4632437Z   cache: false
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:14.4633089Z ##[endgroup]
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:15.8978315Z Going to install stable version 2.7.12.
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:15.8985589Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.7.12/deno-x86_64-unknown-linux-gnu.zip.
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:16.2189741Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/56361cbd-45fa-4040-80fd-1db7a596c214
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:17.3191217Z Cached Deno to /opt/hostedtoolcache/deno/2.7.12/x64.
+Test (deno on ubuntu-latest)	Setup Deno	2026-04-10T20:47:17.3203868Z Installation complete.
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	﻿2026-04-10T20:47:17.3355443Z ##[group]Run npm install
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:17.3355765Z [36;1mnpm install[0m
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:17.4614135Z shell: /usr/bin/bash -e {0}
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:17.4614478Z ##[endgroup]
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9226126Z 
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9227093Z > lino-arguments@0.3.0 prepare
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9227731Z > husky || true
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9251758Z 
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9695082Z .git can't be found
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9695909Z added 234 packages, and audited 235 packages in 3s
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9696413Z 
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9696695Z 59 packages are looking for funding
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9697202Z   run `npm fund` for details
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9803162Z 
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9817963Z 7 vulnerabilities (4 moderate, 3 high)
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9818724Z 
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9819391Z To address all issues, run:
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9820014Z   npm audit fix
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9820398Z 
+Test (deno on ubuntu-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.9820749Z Run `npm audit` for details.
+Test (deno on ubuntu-latest)	Run tests (Deno)	﻿2026-04-10T20:47:21.0085185Z ##[group]Run deno test --allow-read --allow-env --allow-write
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0085680Z [36;1mdeno test --allow-read --allow-env --allow-write[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0107281Z shell: /usr/bin/bash -e {0}
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0107564Z ##[endgroup]
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0227316Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fcli
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0228555Z [0m[32mDownload[0m https://registry.npmjs.org/eslint
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0238468Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0239607Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0240600Z [0m[32mDownload[0m https://registry.npmjs.org/getenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0241744Z [0m[32mDownload[0m https://registry.npmjs.org/husky
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0242669Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0243592Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0244463Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0245381Z [0m[32mDownload[0m https://registry.npmjs.org/prettier
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0246229Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.0269903Z [0m[32mDownload[0m https://registry.npmjs.org/yargs
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3253347Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fapply-release-plan
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3256082Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fassemble-release-plan
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3258056Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fchangelog-git
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3259335Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fconfig
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3261130Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ferrors
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3262764Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-dependents-graph
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3264364Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-release-plan
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3265875Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fgit
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3267256Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2flogger
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3268621Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fpre
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3269868Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fread
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3271473Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fshould-skip-package
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3272927Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ftypes
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3274232Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fwrite
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3275547Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer%2fexternal-editor
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3276899Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2fget-packages
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3278292Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3279435Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3280495Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3281883Z [0m[32mDownload[0m https://registry.npmjs.org/mri
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3283264Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3284668Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3285975Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3287203Z [0m[32mDownload[0m https://registry.npmjs.org/semver
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3288431Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3289553Z [0m[32mDownload[0m https://registry.npmjs.org/term-size
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3291170Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2feslint-utils
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3292650Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2fregexpp
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3294436Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-array
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3295875Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-helpers
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3297207Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fcore
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3298469Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2feslintrc
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3299716Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fjs
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3301243Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fplugin-kit
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3302618Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fnode
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3304051Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fmodule-importer
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3305576Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fretry
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3306917Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2festree
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3308155Z [0m[32mDownload[0m https://registry.npmjs.org/ajv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3309298Z [0m[32mDownload[0m https://registry.npmjs.org/chalk
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3310429Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3312152Z [0m[32mDownload[0m https://registry.npmjs.org/debug
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3313409Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3314722Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3316034Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3317264Z [0m[32mDownload[0m https://registry.npmjs.org/espree
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3318423Z [0m[32mDownload[0m https://registry.npmjs.org/esquery
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3319509Z [0m[32mDownload[0m https://registry.npmjs.org/esutils
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3320659Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3322183Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3323360Z [0m[32mDownload[0m https://registry.npmjs.org/find-up
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3324477Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3325669Z [0m[32mDownload[0m https://registry.npmjs.org/ignore
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3326888Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3328113Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3329250Z [0m[32mDownload[0m https://registry.npmjs.org/jiti
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3330651Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3332323Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3333525Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3334732Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3335943Z [0m[32mDownload[0m https://registry.npmjs.org/optionator
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3337105Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2feslint
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3338370Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3339519Z [0m[32mDownload[0m https://registry.npmjs.org/synckit
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3340619Z [0m[32mDownload[0m https://registry.npmjs.org/commander
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3342031Z [0m[32mDownload[0m https://registry.npmjs.org/listr2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3343148Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3344262Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3345334Z [0m[32mDownload[0m https://registry.npmjs.org/tinyexec
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3346414Z [0m[32mDownload[0m https://registry.npmjs.org/yaml
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3347797Z [0m[32mDownload[0m https://registry.npmjs.org/cliui
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3348686Z [0m[32mDownload[0m https://registry.npmjs.org/escalade
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3349709Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3351484Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3352522Z [0m[32mDownload[0m https://registry.npmjs.org/string-width
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3353458Z [0m[32mDownload[0m https://registry.npmjs.org/y18n
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.3354363Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6015862Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-version-range-type
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6017088Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6018065Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6018939Z [0m[32mDownload[0m https://registry.npmjs.org/outdent
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6019782Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6020705Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6021921Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6022913Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fparse
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6023806Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6024970Z [0m[32mDownload[0m https://registry.npmjs.org/human-id
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6025866Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fnode
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6026713Z [0m[32mDownload[0m https://registry.npmjs.org/chardet
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6027542Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6028444Z [0m[32mDownload[0m https://registry.npmjs.org/@babel%2fruntime
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6029402Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2ffind-root
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6030274Z [0m[32mDownload[0m https://registry.npmjs.org/globby
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6031336Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6032210Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6033079Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6033900Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6034730Z [0m[32mDownload[0m https://registry.npmjs.org/universalify
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6035518Z [0m[32mDownload[0m https://registry.npmjs.org/quansync
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6036302Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6037247Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fobject-schema
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6038227Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fjson-schema
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6039172Z [0m[32mDownload[0m https://registry.npmjs.org/globals
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6040072Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6040598Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6041631Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6042626Z [0m[32mDownload[0m https://registry.npmjs.org/levn
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6043610Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fcore
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6044750Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6045934Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6046889Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6047836Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6048857Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6049820Z [0m[32mDownload[0m https://registry.npmjs.org/path-key
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6051144Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6052162Z [0m[32mDownload[0m https://registry.npmjs.org/which
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6052991Z [0m[32mDownload[0m https://registry.npmjs.org/ms
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6053855Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6055036Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6055879Z [0m[32mDownload[0m https://registry.npmjs.org/acorn
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6056765Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6057645Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6058517Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6059446Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6060335Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6061577Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6062501Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6063425Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6064396Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6065408Z [0m[32mDownload[0m https://registry.npmjs.org/type-check
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6066326Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6067266Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6068572Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr%2fcore
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6069537Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6070434Z [0m[32mDownload[0m https://registry.npmjs.org/colorette
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6071658Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6072573Z [0m[32mDownload[0m https://registry.npmjs.org/log-update
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6073439Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6074312Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6075219Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.6076251Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.7093570Z [0m[32mDownload[0m https://registry.npmjs.org/braces
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.7094511Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8183524Z [0m[32mDownload[0m https://registry.npmjs.org/p-map
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8184544Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8186700Z [0m[32mDownload[0m https://registry.npmjs.org/array-union
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8187643Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8188518Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8189343Z [0m[32mDownload[0m https://registry.npmjs.org/merge2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8190123Z [0m[32mDownload[0m https://registry.npmjs.org/slash
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8191138Z [0m[32mDownload[0m https://registry.npmjs.org/pify
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8191767Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8192340Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8192886Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8193429Z [0m[32mDownload[0m https://registry.npmjs.org/argparse
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8194064Z [0m[32mDownload[0m https://registry.npmjs.org/punycode
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8194593Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8195117Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8195635Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8196112Z [0m[32mDownload[0m https://registry.npmjs.org/isexe
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8196571Z [0m[32mDownload[0m https://registry.npmjs.org/flatted
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8197025Z [0m[32mDownload[0m https://registry.npmjs.org/keyv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8197481Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8197992Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8198763Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8199251Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8199755Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8200239Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8200716Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8201463Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8970384Z [0m[32mDownload[0m https://registry.npmjs.org/path-type
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8971657Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.stat
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8972637Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.walk
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.8973524Z [0m[32mDownload[0m https://registry.npmjs.org/esprima
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9248336Z [0m[32mDownload[0m https://registry.npmjs.org/callsites
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9269352Z [0m[32mDownload[0m https://registry.npmjs.org/color-name
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9270187Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9271228Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9272505Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9273450Z [0m[32mDownload[0m https://registry.npmjs.org/environment
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9274379Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9275317Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9615499Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.scandir
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9616114Z [0m[32mDownload[0m https://registry.npmjs.org/fastq
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9616744Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9696157Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9718341Z [0m[32mDownload[0m https://registry.npmjs.org/onetime
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:21.9720588Z [0m[32mDownload[0m https://registry.npmjs.org/is-number
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.0351366Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.0352111Z [0m[32mDownload[0m https://registry.npmjs.org/reusify
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.0547778Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.0548490Z [0m[32mDownload[0m https://registry.npmjs.org/p-try
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.0823647Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1541660Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1543449Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1545074Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1546685Z [0m[32mDownload[0m https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1548347Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/cli/-/cli-2.30.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1549868Z [0m[32mDownload[0m https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1551618Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1553196Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere/-/test-anywhere-0.6.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1554523Z [0m[32mDownload[0m https://registry.npmjs.org/husky/-/husky-9.1.7.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1555834Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1557147Z [0m[32mDownload[0m https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1558544Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1560060Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1561979Z [0m[32mDownload[0m https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1562881Z [0m[32mDownload[0m https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1564260Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1565512Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1566486Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1567580Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1568646Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1569565Z [0m[32mDownload[0m https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1570456Z [0m[32mDownload[0m https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1571611Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1572962Z [0m[32mDownload[0m https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1573874Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1574829Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1575832Z [0m[32mDownload[0m https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1576739Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1577647Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1578596Z [0m[32mDownload[0m https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1579606Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1580617Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1582048Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1583462Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1584828Z [0m[32mDownload[0m https://registry.npmjs.org/espree/-/espree-10.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1586052Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1587326Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1588422Z [0m[32mDownload[0m https://registry.npmjs.org/debug/-/debug-4.4.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1589783Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1591288Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1592606Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1593863Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1595187Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1596360Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1597528Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1598658Z [0m[32mDownload[0m https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1599855Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1601271Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1602886Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1604291Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.15.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1605660Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1607114Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1608453Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1609679Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1610577Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1611646Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1612448Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/config/-/config-3.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1613097Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1614074Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1614838Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1615488Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1616209Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1616798Z [0m[32mDownload[0m https://registry.npmjs.org/mri/-/mri-1.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1617472Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1618332Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1619101Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1619752Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1620417Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1621420Z [0m[32mDownload[0m https://registry.npmjs.org/semver/-/semver-7.7.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1622046Z [0m[32mDownload[0m https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1622769Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1623452Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1624092Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1624762Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1625417Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1626054Z [0m[32mDownload[0m https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1626636Z [0m[32mDownload[0m https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1627244Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1627890Z [0m[32mDownload[0m https://registry.npmjs.org/commander/-/commander-14.0.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1628499Z [0m[32mDownload[0m https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1629055Z [0m[32mDownload[0m https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1629676Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1630312Z [0m[32mDownload[0m https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1631495Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1632262Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1632925Z [0m[32mDownload[0m https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1633557Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1634217Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1634818Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1635424Z [0m[32mDownload[0m https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1636107Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1636739Z [0m[32mDownload[0m https://registry.npmjs.org/which/-/which-2.0.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1637445Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1638129Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1639070Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1639949Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1640716Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1641540Z [0m[32mDownload[0m https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1642177Z [0m[32mDownload[0m https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1642850Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1643550Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1644193Z [0m[32mDownload[0m https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1644831Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1645439Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1646061Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1646713Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1647403Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1648064Z [0m[32mDownload[0m https://registry.npmjs.org/globals/-/globals-14.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1648711Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1649465Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1650160Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1650973Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1651674Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1652266Z [0m[32mDownload[0m https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1652934Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1653551Z [0m[32mDownload[0m https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1654140Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1654784Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1655447Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1656953Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1658119Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1658944Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1659838Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1660724Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1661711Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1662337Z [0m[32mDownload[0m https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1663004Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1664429Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1665665Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1666997Z [0m[32mDownload[0m https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1667684Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1668359Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1669032Z [0m[32mDownload[0m https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1669720Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1670437Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1671305Z [0m[32mDownload[0m https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1671941Z [0m[32mDownload[0m https://registry.npmjs.org/globby/-/globby-11.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1672579Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1673214Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1673828Z [0m[32mDownload[0m https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1674450Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1675089Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1675754Z [0m[32mDownload[0m https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1676430Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1677066Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1677755Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1678470Z [0m[32mDownload[0m https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1679129Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1679791Z [0m[32mDownload[0m https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1680424Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1681214Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1681842Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1682454Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1683241Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1683990Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1684806Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1685417Z [0m[32mDownload[0m https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1686041Z [0m[32mDownload[0m https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1686722Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1687378Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1688046Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1688753Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1689419Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1690064Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1690882Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1691540Z [0m[32mDownload[0m https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1692250Z [0m[32mDownload[0m https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1692858Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1693482Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1694082Z [0m[32mDownload[0m https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1694797Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1695541Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1696201Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1696833Z [0m[32mDownload[0m https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1697442Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1698057Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1698662Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1699240Z [0m[32mDownload[0m https://registry.npmjs.org/pify/-/pify-4.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1699808Z [0m[32mDownload[0m https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1700429Z [0m[32mDownload[0m https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1701196Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1701816Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1702420Z [0m[32mDownload[0m https://registry.npmjs.org/slash/-/slash-3.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1702988Z [0m[32mDownload[0m https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1703590Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1704263Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1704920Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1705576Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1706242Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1706887Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1707531Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1708226Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1709034Z [0m[32mDownload[0m https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1709679Z [0m[32mDownload[0m https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1710351Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1711123Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1711749Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1712390Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1713045Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1713690Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1714304Z [0m[32mDownload[0m https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1714929Z [0m[32mDownload[0m https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1715578Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1716379Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1717040Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1717829Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1718692Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1719418Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1720069Z [0m[32mDownload[0m https://registry.npmjs.org/environment/-/environment-1.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1720898Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1721601Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1722269Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1722959Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1723609Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1724244Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1724935Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1725592Z [0m[32mDownload[0m https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1726183Z [0m[32mDownload[0m https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1726795Z [0m[32mDownload[0m https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1727408Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1728057Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1728703Z [0m[32mDownload[0m https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1729359Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1729989Z [0m[32mDownload[0m https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.1730660Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2000609Z [0m[32mInitialize[0m getenv@2.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2076739Z [0m[32mInitialize[0m chalk@4.1.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2081000Z [0m[32mInitialize[0m eslint-config-prettier@10.1.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2092021Z [0m[32mInitialize[0m lint-staged@16.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2103526Z [0m[32mInitialize[0m is-glob@4.0.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2138710Z [0m[32mInitialize[0m minimatch@3.1.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2140438Z [0m[32mInitialize[0m natural-compare@1.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2197898Z [0m[32mInitialize[0m links-notation@0.11.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2201211Z [0m[32mInitialize[0m eslint-visitor-keys@4.2.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2201746Z [0m[32mInitialize[0m prettier-linter-helpers@1.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2227709Z [0m[32mInitialize[0m eslint-plugin-prettier@5.5.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2231814Z [0m[32mInitialize[0m lodash.merge@4.6.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2316756Z [0m[32mInitialize[0m glob-parent@6.0.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2319173Z [0m[32mInitialize[0m esutils@2.0.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2329441Z [0m[32mInitialize[0m lino-env@0.2.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2331231Z [0m[32mInitialize[0m ignore@5.3.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2350661Z [0m[32mInitialize[0m find-up@5.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2371809Z [0m[32mInitialize[0m yargs@17.7.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2432279Z [0m[32mInitialize[0m husky@9.1.7
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2527074Z [0m[32mInitialize[0m enquirer@2.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2527773Z [0m[32mInitialize[0m picomatch@4.0.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2528334Z [0m[32mInitialize[0m fast-deep-equal@3.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2529245Z [0m[32mInitialize[0m spawndamnit@3.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2529874Z [0m[32mInitialize[0m @changesets/config@3.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2530406Z [0m[32mInitialize[0m json-stable-stringify-without-jsonify@1.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2577173Z [0m[32mInitialize[0m esquery@1.7.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2592289Z [0m[32mInitialize[0m synckit@0.11.12
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2593469Z [0m[32mInitialize[0m fast-json-stable-stringify@2.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2602977Z [0m[32mInitialize[0m eslint-scope@8.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2603477Z [0m[32mInitialize[0m y18n@5.0.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2604108Z [0m[32mInitialize[0m tinyexec@1.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2610607Z [0m[32mInitialize[0m escape-string-regexp@4.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2709781Z [0m[32mInitialize[0m @changesets/get-dependents-graph@2.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2728285Z [0m[32mInitialize[0m fast-diff@1.3.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2732715Z [0m[32mInitialize[0m cross-spawn@7.0.6
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2735116Z [0m[32mInitialize[0m file-entry-cache@8.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2735812Z [0m[32mInitialize[0m path-key@3.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2736702Z [0m[32mInitialize[0m @changesets/read@0.6.7
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2750773Z [0m[32mInitialize[0m ajv@6.14.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2751793Z [0m[32mInitialize[0m levn@0.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2754287Z [0m[32mInitialize[0m string-width@4.2.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2781548Z [0m[32mInitialize[0m which@2.0.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2787700Z [0m[32mInitialize[0m @changesets/get-release-plan@4.0.15
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2827202Z [0m[32mInitialize[0m import-fresh@3.3.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2828307Z [0m[32mInitialize[0m espree@10.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2834652Z [0m[32mInitialize[0m imurmurhash@0.1.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2838576Z [0m[32mInitialize[0m get-caller-file@2.0.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2855267Z [0m[32mInitialize[0m ansi-styles@4.3.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2895564Z [0m[32mInitialize[0m cliui@8.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2896189Z [0m[32mInitialize[0m js-yaml@4.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2896728Z [0m[32mInitialize[0m shebang-command@2.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2917509Z [0m[32mInitialize[0m string-argv@0.3.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2918570Z [0m[32mInitialize[0m fast-levenshtein@2.0.6
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2919459Z [0m[32mInitialize[0m type-check@0.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2963933Z [0m[32mInitialize[0m picocolors@1.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2990091Z [0m[32mInitialize[0m prelude-ls@1.2.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2991529Z [0m[32mInitialize[0m @changesets/should-skip-package@0.1.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2994016Z [0m[32mInitialize[0m fs-extra@7.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2995102Z [0m[32mInitialize[0m @inquirer/external-editor@1.0.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2996174Z [0m[32mInitialize[0m package-manager-detector@0.2.11
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2997411Z [0m[32mInitialize[0m supports-color@7.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2998400Z [0m[32mInitialize[0m eslint-visitor-keys@3.4.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.2999323Z [0m[32mInitialize[0m semver@7.7.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3000215Z [0m[32mInitialize[0m test-anywhere@0.6.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3017542Z [0m[32mInitialize[0m yargs-parser@21.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3024159Z [0m[32mInitialize[0m resolve-from@5.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3025769Z [0m[32mInitialize[0m @changesets/logger@0.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3026946Z [0m[32mInitialize[0m commander@14.0.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3027824Z [0m[32mInitialize[0m uri-js@4.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3028695Z [0m[32mInitialize[0m ansi-colors@4.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3103772Z [0m[32mInitialize[0m debug@4.4.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3109971Z [0m[32mInitialize[0m deep-is@0.1.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3111217Z [0m[32mInitialize[0m @eslint/eslintrc@3.3.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3112133Z [0m[32mInitialize[0m json-schema-traverse@0.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3123342Z [0m[32mInitialize[0m word-wrap@1.2.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3197232Z [0m[32mInitialize[0m @changesets/apply-release-plan@7.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3208715Z [0m[32mInitialize[0m @eslint/js@9.39.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3214050Z [0m[32mInitialize[0m estraverse@5.3.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3214943Z [0m[32mInitialize[0m @changesets/cli@2.30.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3215593Z [0m[32mInitialize[0m globals@14.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3216234Z [0m[32mInitialize[0m outdent@0.5.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3216912Z [0m[32mInitialize[0m @changesets/errors@0.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3285744Z [0m[32mInitialize[0m acorn-jsx@5.3.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3290207Z [0m[32mInitialize[0m flat-cache@4.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3295801Z [0m[32mInitialize[0m @changesets/git@3.0.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3317873Z [0m[32mInitialize[0m listr2@9.0.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3338785Z [0m[32mInitialize[0m @eslint/plugin-kit@0.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3343634Z [0m[32mInitialize[0m @eslint/config-helpers@0.4.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3392530Z [0m[32mInitialize[0m esrecurse@4.3.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3402855Z [0m[32mInitialize[0m escalade@3.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3403553Z [0m[32mInitialize[0m ms@2.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3404044Z [0m[32mInitialize[0m micromatch@4.0.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3420240Z [0m[32mInitialize[0m term-size@2.2.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3421414Z [0m[32mInitialize[0m @changesets/types@6.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3422144Z [0m[32mInitialize[0m signal-exit@4.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3433527Z [0m[32mInitialize[0m strip-json-comments@3.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3437928Z [0m[32mInitialize[0m @humanwhocodes/module-importer@1.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3438954Z [0m[32mInitialize[0m mri@1.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3440730Z [0m[32mInitialize[0m @eslint/config-array@0.21.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3467333Z [0m[32mInitialize[0m @changesets/write@0.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3468165Z [0m[32mInitialize[0m @changesets/assemble-release-plan@6.0.9
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3468658Z [0m[32mInitialize[0m @types/json-schema@7.0.15
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3534030Z [0m[32mInitialize[0m require-directory@2.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3539841Z [0m[32mInitialize[0m @eslint-community/eslint-utils@4.9.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3540646Z [0m[32mInitialize[0m acorn@8.16.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3544757Z [0m[32mInitialize[0m @humanwhocodes/retry@0.4.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3545501Z [0m[32mInitialize[0m argparse@2.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3546355Z [0m[32mInitialize[0m @changesets/get-version-range-type@0.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3554781Z [0m[32mInitialize[0m @humanfs/node@0.16.7
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3555725Z [0m[32mInitialize[0m extendable-error@0.1.7
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3621530Z [0m[32mInitialize[0m has-flag@4.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3622266Z [0m[32mInitialize[0m punycode@2.3.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3622658Z [0m[32mInitialize[0m yaml@2.8.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3623033Z [0m[32mInitialize[0m is-extglob@2.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3623418Z [0m[32mInitialize[0m colorette@2.0.20
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3639218Z [0m[32mInitialize[0m @eslint/object-schema@2.1.7
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3645828Z [0m[32mInitialize[0m eslint@9.39.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3651834Z [0m[32mInitialize[0m human-id@4.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3668064Z [0m[32mInitialize[0m @eslint-community/regexpp@4.12.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3684186Z [0m[32mInitialize[0m iconv-lite@0.7.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3718252Z [0m[32mInitialize[0m detect-indent@6.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3720120Z [0m[32mInitialize[0m path-exists@4.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3723199Z [0m[32mInitialize[0m log-update@6.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3728910Z [0m[32mInitialize[0m @types/estree@1.0.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3751970Z [0m[32mInitialize[0m @manypkg/get-packages@1.1.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3752748Z [0m[32mInitialize[0m emoji-regex@8.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3753391Z [0m[32mInitialize[0m p-filter@2.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3754000Z [0m[32mInitialize[0m fs-extra@8.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3792680Z [0m[32mInitialize[0m strip-bom@3.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3801103Z [0m[32mInitialize[0m p-locate@5.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3801697Z [0m[32mInitialize[0m eventemitter3@5.0.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3812768Z [0m[32mInitialize[0m globby@11.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3855562Z [0m[32mInitialize[0m strip-ansi@6.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3861264Z [0m[32mInitialize[0m @eslint/core@0.17.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3871381Z [0m[32mInitialize[0m @changesets/changelog-git@0.2.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3881553Z [0m[32mInitialize[0m keyv@4.5.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3882229Z [0m[32mInitialize[0m slash@3.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3882901Z [0m[32mInitialize[0m @changesets/parse@0.4.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3902549Z [0m[32mInitialize[0m slice-ansi@7.1.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3914849Z [0m[32mInitialize[0m string-width@8.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3931137Z [0m[32mInitialize[0m cli-truncate@5.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3932838Z [0m[32mInitialize[0m quansync@0.2.11
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3959902Z [0m[32mInitialize[0m pify@4.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3961905Z [0m[32mInitialize[0m graceful-fs@4.2.11
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3966223Z [0m[32mInitialize[0m merge2@1.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.3966929Z [0m[32mInitialize[0m locate-path@6.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4059246Z [0m[32mInitialize[0m ansi-escapes@7.3.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4059750Z [0m[32mInitialize[0m concat-map@0.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4060167Z [0m[32mInitialize[0m color-convert@2.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4060536Z [0m[32mInitialize[0m strip-ansi@7.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4061221Z [0m[32mInitialize[0m parent-module@1.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4061831Z [0m[32mInitialize[0m p-limit@3.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4074028Z [0m[32mInitialize[0m chardet@2.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4076962Z [0m[32mInitialize[0m js-yaml@3.14.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4088394Z [0m[32mInitialize[0m @manypkg/find-root@1.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4118424Z [0m[32mInitialize[0m flatted@3.4.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4118936Z [0m[32mInitialize[0m @changesets/pre@2.0.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4186847Z [0m[32mInitialize[0m read-yaml-file@1.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4187308Z [0m[32mInitialize[0m @types/node@12.20.55
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4187727Z [0m[32mInitialize[0m balanced-match@1.0.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4188089Z [0m[32mInitialize[0m locate-path@5.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4189895Z [0m[32mInitialize[0m @pkgr/core@0.2.9
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4191027Z [0m[32mInitialize[0m json-buffer@3.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4191764Z [0m[32mInitialize[0m safer-buffer@2.1.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4192509Z [0m[32mInitialize[0m @changesets/types@4.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4226709Z [0m[32mInitialize[0m is-subdir@1.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4228714Z [0m[32mInitialize[0m jsonfile@4.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4231208Z [0m[32mInitialize[0m p-map@2.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4234653Z [0m[32mInitialize[0m find-up@4.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4242437Z [0m[32mInitialize[0m is-windows@1.0.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4246513Z [0m[32mInitialize[0m isexe@2.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4247228Z [0m[32mInitialize[0m better-path-resolve@1.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4251551Z [0m[32mInitialize[0m resolve-from@4.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4268848Z [0m[32mInitialize[0m is-fullwidth-code-point@3.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4291186Z [0m[32mInitialize[0m picomatch@2.3.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4313319Z [0m[32mInitialize[0m wrap-ansi@9.0.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4358389Z [0m[32mInitialize[0m callsites@3.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4361209Z [0m[32mInitialize[0m cli-cursor@5.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4384313Z [0m[32mInitialize[0m @babel/runtime@7.29.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4394316Z [0m[32mInitialize[0m rfdc@1.4.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4401791Z [0m[32mInitialize[0m glob-parent@5.1.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4432240Z [0m[32mInitialize[0m universalify@0.1.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4451656Z [0m[32mInitialize[0m get-east-asian-width@1.5.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4488776Z [0m[32mInitialize[0m @humanfs/core@0.19.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4499026Z [0m[32mInitialize[0m is-fullwidth-code-point@5.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4501859Z [0m[32mInitialize[0m to-regex-range@5.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4503042Z [0m[32mInitialize[0m restore-cursor@5.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4506318Z [0m[32mInitialize[0m ansi-styles@6.2.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4520730Z [0m[32mInitialize[0m color-name@1.1.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4525077Z [0m[32mInitialize[0m brace-expansion@1.1.13
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4531328Z [0m[32mInitialize[0m braces@3.0.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4542008Z [0m[32mInitialize[0m reusify@1.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4569152Z [0m[32mInitialize[0m lodash.startcase@4.4.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4573322Z [0m[32mInitialize[0m ansi-regex@6.2.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4581137Z [0m[32mInitialize[0m shebang-regex@3.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4615857Z [0m[32mInitialize[0m p-limit@2.3.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4627002Z [0m[32mInitialize[0m wrap-ansi@7.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4633256Z [0m[32mInitialize[0m environment@1.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4642011Z [0m[32mInitialize[0m argparse@1.0.10
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4684322Z [0m[32mInitialize[0m emoji-regex@10.6.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4695368Z [0m[32mInitialize[0m path-type@4.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4699624Z [0m[32mInitialize[0m yocto-queue@0.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4779459Z [0m[32mInitialize[0m slice-ansi@8.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4780735Z [0m[32mInitialize[0m mimic-function@5.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4790352Z [0m[32mInitialize[0m array-union@2.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4803192Z [0m[32mInitialize[0m fast-glob@3.3.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4867193Z [0m[32mInitialize[0m dir-glob@3.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4868840Z [0m[32mInitialize[0m fill-range@7.1.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4911182Z [0m[32mInitialize[0m run-parallel@1.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4927797Z [0m[32mInitialize[0m optionator@0.9.4
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4951977Z [0m[32mInitialize[0m onetime@7.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4956502Z [0m[32mInitialize[0m ansi-regex@5.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4959454Z [0m[32mInitialize[0m @nodelib/fs.stat@2.0.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.4992135Z [0m[32mInitialize[0m esprima@4.0.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5004233Z [0m[32mInitialize[0m p-try@2.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5013128Z [0m[32mInitialize[0m string-width@7.2.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5074292Z [0m[32mInitialize[0m is-number@7.0.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5094837Z [0m[32mInitialize[0m p-locate@4.1.0
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5106123Z [0m[32mInitialize[0m prettier@3.8.2
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5273457Z [0m[32mInitialize[0m queue-microtask@1.2.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5297696Z [0m[32mInitialize[0m @nodelib/fs.walk@1.2.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5610358Z [0m[32mInitialize[0m sprintf-js@1.0.3
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5642106Z [0m[32mInitialize[0m prettier@2.8.8
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5909878Z [0m[32mInitialize[0m fastq@1.20.1
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.5940235Z [0m[32mInitialize[0m @nodelib/fs.scandir@2.1.5
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7045641Z [0m[38;5;245mrunning 58 tests from ./tests/index.test.js[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7054251Z should convert camelCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7057691Z should convert kebab-case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7060618Z should convert snake_case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7062645Z should convert PascalCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7064156Z should handle already UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7067803Z should convert kebab-case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7069488Z should convert UPPER_CASE to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7071365Z should convert snake_case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7073777Z should convert PascalCase to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7075256Z should handle already camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7077975Z should convert camelCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7079311Z should convert UPPER_CASE to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7081331Z should convert PascalCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7083093Z should handle already kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7084810Z should convert camelCase to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7091020Z should convert kebab-case to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7092678Z should convert UPPER_CASE to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7094004Z should handle already snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7096019Z should convert camelCase to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7097677Z should convert kebab-case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7099291Z should convert snake_case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7100410Z should handle already PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7104858Z should find variable in UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7110889Z should find variable in camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7114198Z should find variable in kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7120431Z should return default value when not found ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7122554Z should return empty string as default when not specified ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7125024Z should try original key first ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7252131Z should work with minimal configuration ... [0m[32mok[0m [0m[38;5;245m(12ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7332556Z should use CLI arguments with highest priority ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7357424Z should convert kebab-case to camelCase in result ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7419749Z should load .lenv file by default ...
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7420595Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7421744Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7612420Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7613685Z should load .lenv file by default ... [0m[32mok[0m [0m[38;5;245m(25ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7618714Z should handle --configuration flag ...
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7624128Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7625444Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7640081Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7663231Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7664920Z should handle --configuration flag ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7669295Z should prioritize CLI over environment ...
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7670064Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7671492Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7694920Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7695962Z should prioritize CLI over environment ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7722979Z should handle missing .lenv file gracefully ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7727002Z should convert all keys to UPPER_CASE in process.env ...
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7727531Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7728206Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7747647Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7748873Z should convert all keys to UPPER_CASE in process.env ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7773916Z should find env vars in any case format via getenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7800191Z should support disabling lenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7825035Z should support enabling env/dotenvx (deprecated) ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7848032Z should support disabling getenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7864129Z should support configuration alias -c ...
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7864931Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7866028Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7880616Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7881951Z should support configuration alias -c ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7886844Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ...
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7887852Z [0m[38;5;245m------- output -------[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7889032Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7911429Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7921143Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7934913Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7944970Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7960362Z [0m[38;5;245m----- output end -----[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7961489Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ... [0m[32mok[0m [0m[38;5;245m(7ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.7987223Z should allow user-defined --version option by calling .version(false) ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8012056Z should allow user-defined --help option ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8038071Z should work with --version in strict mode ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8067245Z should handle --version with boolean type ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8097427Z should allow users to explicitly enable help ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8137104Z should work with multiple custom options including version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8171740Z should allow explicitly enabling built-in --version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8209562Z should allow explicitly enabling both --version and --help ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8252075Z should allow version with alias ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8266188Z should allow help with alias ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8290618Z should work with both built-in version/help and custom options ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8315788Z should parse simple links notation format ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8321749Z should parse arguments without parentheses ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8325052Z should handle empty input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8326184Z should handle null input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8330645Z should filter out comments ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8352596Z 
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8356585Z [0m[32mok[0m | 58 passed | 0 failed [0m[38;5;245m(130ms)[0m
+Test (deno on ubuntu-latest)	Run tests (Deno)	2026-04-10T20:47:22.8356887Z 
+Test (deno on ubuntu-latest)	Post Setup Deno	﻿2026-04-10T20:47:22.8824207Z Post job cleanup.
+Test (deno on ubuntu-latest)	Post Setup Deno	2026-04-10T20:47:23.0169089Z Caching is not enabled. Caching is skipped.
+Test (deno on ubuntu-latest)	Post Setup Node.js (for npm install)	﻿2026-04-10T20:47:23.0299527Z Post job cleanup.
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:23.2052401Z Post job cleanup.
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3030339Z [command]/usr/bin/git version
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3066589Z git version 2.53.0
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3110551Z Temporarily overriding HOME='/home/runner/work/_temp/221e52d7-832f-43ef-b80d-d366faec4753' before making global git config changes
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3111856Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3116257Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3628898Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3668462Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3889510Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3909646Z http.https://github.com/.extraheader
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.3921609Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.4095421Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.4336879Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.4367813Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on ubuntu-latest)	Complete job	﻿2026-04-10T20:47:23.4707857Z Cleaning up orphan processes
+Test (deno on ubuntu-latest)	Complete job	2026-04-10T20:47:23.4982480Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (deno on macos-latest)	Set up job	﻿2026-04-10T20:47:13.0805140Z Current runner version: '2.333.1'
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0828380Z ##[group]Runner Image Provisioner
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0829050Z Hosted Compute Agent
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0829390Z Version: 20260213.493
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0829760Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0830200Z Build Date: 2026-02-13T00:28:41Z
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0830940Z Worker ID: {b15deb0c-2446-488d-bca2-d3b25432d789}
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0832330Z Azure Region: westus
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0832690Z ##[endgroup]
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0833950Z ##[group]Operating System
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0834300Z macOS
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0834580Z 15.7.4
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0834860Z 24G517
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0835140Z ##[endgroup]
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0835460Z ##[group]Runner Image
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0835790Z Image: macos-15-arm64
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0836090Z Version: 20260406.0256.1
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0836770Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260406.0256/images/macos/macos-15-arm64-Readme.md
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0837870Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260406.0256
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0838470Z ##[endgroup]
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0840260Z ##[group]GITHUB_TOKEN Permissions
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0841830Z Actions: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0842140Z ArtifactMetadata: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0842470Z Attestations: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0842780Z Checks: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0843090Z Contents: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0843420Z Deployments: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0843740Z Discussions: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0844050Z Issues: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0844350Z Metadata: read
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0844670Z Models: read
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0844980Z Packages: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0845290Z Pages: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0845670Z PullRequests: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0846010Z RepositoryProjects: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0846360Z SecurityEvents: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0846820Z Statuses: write
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0847150Z ##[endgroup]
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0849260Z Secret source: Actions
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.0850580Z Prepare workflow directory
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.1265060Z Prepare all required actions
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.1297940Z Getting action download info
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:13.7483980Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:14.2375670Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:14.3706090Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:15.0709120Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (deno on macos-latest)	Set up job	2026-04-10T20:47:15.7262920Z Complete job name: Test (deno on macos-latest)
+Test (deno on macos-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:15.7889940Z ##[group]Run actions/checkout@v4
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7890560Z with:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7890880Z   repository: link-foundation/lino-arguments
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7891540Z   token: ***
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7891840Z   ssh-strict: true
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7892120Z   ssh-user: git
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7892400Z   persist-credentials: true
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7892710Z   clean: true
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7892990Z   sparse-checkout-cone-mode: true
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7893620Z   fetch-depth: 1
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7894510Z   fetch-tags: false
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7894860Z   show-progress: true
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7895170Z   lfs: false
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7895460Z   submodules: false
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7895760Z   set-safe-directory: true
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.7898200Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1349100Z Syncing repository: link-foundation/lino-arguments
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1351090Z ##[group]Getting Git version info
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1351880Z Working directory is '/Users/runner/work/lino-arguments/lino-arguments'
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1353100Z [command]/opt/homebrew/bin/git version
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2149940Z git version 2.53.0
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2175620Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2186590Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/728c4e25-67bf-47e6-9549-e8a25c09bdaa/.gitconfig'
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2194330Z Temporarily overriding HOME='/Users/runner/work/_temp/728c4e25-67bf-47e6-9549-e8a25c09bdaa' before making global git config changes
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2196590Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2198670Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2288670Z Deleting the contents of '/Users/runner/work/lino-arguments/lino-arguments'
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2292290Z ##[group]Initializing the repository
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2296480Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-arguments/lino-arguments
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2494860Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2497010Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2498790Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2500140Z hint: call:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2500820Z hint:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2501640Z hint: 	git config --global init.defaultBranch <name>
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2502710Z hint:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2503790Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2505420Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2506720Z hint:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2507410Z hint: 	git branch -m <name>
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2508410Z hint:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2509540Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2511480Z Initialized empty Git repository in /Users/runner/work/lino-arguments/lino-arguments/.git/
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2515130Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2574850Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2576390Z ##[group]Disabling automatic garbage collection
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2577790Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2664840Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2666160Z ##[group]Setting up auth
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2667760Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2717200Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.3605580Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.3667220Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.4435640Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.4502000Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.5295350Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.5360490Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.5361660Z ##[group]Fetching the repository
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.5365940Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0713800Z From https://github.com/link-foundation/lino-arguments
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0716410Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0791990Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0793300Z ##[group]Determining the checkout info
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0794960Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0795750Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0859430Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0911580Z ##[group]Checking out the ref
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.0913900Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.1110340Z Switched to a new branch 'main'
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.1114440Z branch 'main' set up to track 'origin/main'.
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.1119410Z ##[endgroup]
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.1189440Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (deno on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.1243290Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (deno on macos-latest)	Setup Node.js (for npm install)	﻿2026-04-10T20:47:17.1546640Z ##[group]Run actions/setup-node@v4
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1547310Z with:
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1547760Z   node-version: 20.x
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1548270Z   always-auth: false
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1548790Z   check-latest: false
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1549500Z   token: ***
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1549960Z ##[endgroup]
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.2909900Z Found in cache @ /Users/runner/hostedtoolcache/node/20.20.2/arm64
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.2913360Z ##[group]Environment details
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.8876060Z node: v20.20.2
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.8906510Z npm: 10.8.2
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.8907860Z yarn: 1.22.22
+Test (deno on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.8910360Z ##[endgroup]
+Test (deno on macos-latest)	Setup Deno	﻿2026-04-10T20:47:17.9068540Z ##[group]Run denoland/setup-deno@v2
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:17.9069270Z with:
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:17.9069730Z   deno-version: v2.x
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:17.9070250Z   deno-binary-name: deno
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:17.9070780Z   cache: false
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:17.9071260Z ##[endgroup]
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:18.5109180Z Going to install stable version 2.7.12.
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:18.5116370Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.7.12/deno-aarch64-apple-darwin.zip.
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:18.9815930Z [command]/usr/bin/unzip -o -q /Users/runner/work/_temp/cab0eb36-0d3b-4c23-851b-24d52bbe67d4
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:20.0041240Z Cached Deno to /Users/runner/hostedtoolcache/deno/2.7.12/arm64.
+Test (deno on macos-latest)	Setup Deno	2026-04-10T20:47:20.0056570Z Installation complete.
+Test (deno on macos-latest)	Install dependencies (Deno)	﻿2026-04-10T20:47:20.0331680Z ##[group]Run npm install
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.0332040Z [36;1mnpm install[0m
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.0387570Z shell: /bin/bash -e {0}
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:20.0387910Z ##[endgroup]
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.1151460Z 
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.1202970Z > lino-arguments@0.3.0 prepare
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.1206100Z > husky || true
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.1224910Z 
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2015770Z .git can't be found
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2016690Z added 234 packages, and audited 235 packages in 3s
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2075560Z 
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2097480Z 59 packages are looking for funding
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2130660Z   run `npm fund` for details
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2159560Z 
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2173510Z 7 vulnerabilities (4 moderate, 3 high)
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2229960Z 
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2243430Z To address all issues, run:
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2244730Z   npm audit fix
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2255960Z 
+Test (deno on macos-latest)	Install dependencies (Deno)	2026-04-10T20:47:23.2256860Z Run `npm audit` for details.
+Test (deno on macos-latest)	Run tests (Deno)	﻿2026-04-10T20:47:23.2300860Z ##[group]Run deno test --allow-read --allow-env --allow-write
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.2301300Z [36;1mdeno test --allow-read --allow-env --allow-write[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.2337530Z shell: /bin/bash -e {0}
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.2337750Z ##[endgroup]
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3724510Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fcli
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3731830Z [0m[32mDownload[0m https://registry.npmjs.org/eslint
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3734100Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3735570Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3736240Z [0m[32mDownload[0m https://registry.npmjs.org/getenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3736930Z [0m[32mDownload[0m https://registry.npmjs.org/husky
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3737640Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3776210Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3776940Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3777590Z [0m[32mDownload[0m https://registry.npmjs.org/prettier
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3778150Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.3778660Z [0m[32mDownload[0m https://registry.npmjs.org/yargs
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5501430Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fapply-release-plan
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5502560Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fassemble-release-plan
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5503490Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fchangelog-git
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5504240Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fconfig
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5504910Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ferrors
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5505600Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-dependents-graph
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5506470Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-release-plan
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5507190Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fgit
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5507860Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2flogger
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5508640Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fpre
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5509460Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fread
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5510440Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fshould-skip-package
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5511190Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ftypes
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5511810Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fwrite
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5512560Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer%2fexternal-editor
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5513220Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2fget-packages
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5513880Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5514490Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5515000Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5515630Z [0m[32mDownload[0m https://registry.npmjs.org/mri
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5516200Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5516900Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5517510Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5518090Z [0m[32mDownload[0m https://registry.npmjs.org/semver
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5519240Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5519760Z [0m[32mDownload[0m https://registry.npmjs.org/term-size
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5520390Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2feslint-utils
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5520970Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2fregexpp
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5522070Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-array
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5522580Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-helpers
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5523080Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fcore
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5523560Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2feslintrc
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5524130Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fjs
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5524630Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fplugin-kit
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5525150Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fnode
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5525720Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fmodule-importer
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5526280Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fretry
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5526800Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2festree
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5527540Z [0m[32mDownload[0m https://registry.npmjs.org/ajv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5528050Z [0m[32mDownload[0m https://registry.npmjs.org/chalk
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5528470Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5528890Z [0m[32mDownload[0m https://registry.npmjs.org/debug
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5529440Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5529950Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5530520Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5530990Z [0m[32mDownload[0m https://registry.npmjs.org/espree
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5531390Z [0m[32mDownload[0m https://registry.npmjs.org/esquery
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5531860Z [0m[32mDownload[0m https://registry.npmjs.org/esutils
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5532320Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5532800Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5533280Z [0m[32mDownload[0m https://registry.npmjs.org/find-up
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5533720Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5534220Z [0m[32mDownload[0m https://registry.npmjs.org/ignore
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5534720Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5535240Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5535640Z [0m[32mDownload[0m https://registry.npmjs.org/jiti
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5536200Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5536720Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5537150Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5537590Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5538030Z [0m[32mDownload[0m https://registry.npmjs.org/optionator
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5538580Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2feslint
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5539150Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5539590Z [0m[32mDownload[0m https://registry.npmjs.org/synckit
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5540020Z [0m[32mDownload[0m https://registry.npmjs.org/commander
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5540490Z [0m[32mDownload[0m https://registry.npmjs.org/listr2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5540910Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5541350Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5541760Z [0m[32mDownload[0m https://registry.npmjs.org/tinyexec
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5542150Z [0m[32mDownload[0m https://registry.npmjs.org/yaml
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5542550Z [0m[32mDownload[0m https://registry.npmjs.org/cliui
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5542950Z [0m[32mDownload[0m https://registry.npmjs.org/escalade
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5543390Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5544050Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5544510Z [0m[32mDownload[0m https://registry.npmjs.org/string-width
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5544910Z [0m[32mDownload[0m https://registry.npmjs.org/y18n
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.5545430Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6308780Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-version-range-type
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6309620Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6310340Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6310900Z [0m[32mDownload[0m https://registry.npmjs.org/outdent
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6311710Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6312760Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6313740Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6314410Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fparse
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6315080Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6315570Z [0m[32mDownload[0m https://registry.npmjs.org/human-id
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6316190Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fnode
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6316680Z [0m[32mDownload[0m https://registry.npmjs.org/chardet
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6317180Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6317770Z [0m[32mDownload[0m https://registry.npmjs.org/@babel%2fruntime
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6318340Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2ffind-root
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6318950Z [0m[32mDownload[0m https://registry.npmjs.org/globby
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6319460Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6319970Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6320570Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6321070Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6321550Z [0m[32mDownload[0m https://registry.npmjs.org/universalify
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6322040Z [0m[32mDownload[0m https://registry.npmjs.org/quansync
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6322530Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6323190Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fobject-schema
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6323780Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fjson-schema
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6324370Z [0m[32mDownload[0m https://registry.npmjs.org/globals
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6324860Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6325330Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6325930Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6326430Z [0m[32mDownload[0m https://registry.npmjs.org/levn
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6326930Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fcore
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6327510Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6328040Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6328620Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6329250Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6329700Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6330240Z [0m[32mDownload[0m https://registry.npmjs.org/path-key
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6330760Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6331230Z [0m[32mDownload[0m https://registry.npmjs.org/which
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6331640Z [0m[32mDownload[0m https://registry.npmjs.org/ms
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6332070Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6332920Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6333380Z [0m[32mDownload[0m https://registry.npmjs.org/acorn
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6333800Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6334290Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6334970Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6335680Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6336890Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6337430Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6337920Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6338370Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6339100Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6339540Z [0m[32mDownload[0m https://registry.npmjs.org/type-check
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6339980Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6340410Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6340930Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr%2fcore
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6766190Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6815430Z [0m[32mDownload[0m https://registry.npmjs.org/colorette
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6847590Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6848330Z [0m[32mDownload[0m https://registry.npmjs.org/log-update
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6862670Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6863360Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6864010Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6864680Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6886170Z [0m[32mDownload[0m https://registry.npmjs.org/braces
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6926590Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.6938870Z [0m[32mDownload[0m https://registry.npmjs.org/p-map
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7360670Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7366780Z [0m[32mDownload[0m https://registry.npmjs.org/array-union
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7367410Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7367920Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7368520Z [0m[32mDownload[0m https://registry.npmjs.org/merge2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7369110Z [0m[32mDownload[0m https://registry.npmjs.org/slash
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7369630Z [0m[32mDownload[0m https://registry.npmjs.org/pify
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7370310Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7370920Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7371570Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7372180Z [0m[32mDownload[0m https://registry.npmjs.org/argparse
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7372750Z [0m[32mDownload[0m https://registry.npmjs.org/punycode
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7373360Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7373890Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7374470Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7375070Z [0m[32mDownload[0m https://registry.npmjs.org/isexe
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7375530Z [0m[32mDownload[0m https://registry.npmjs.org/flatted
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7375980Z [0m[32mDownload[0m https://registry.npmjs.org/keyv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7376550Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7377120Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7378060Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7378700Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7379280Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7379870Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7380490Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7381070Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7664720Z [0m[32mDownload[0m https://registry.npmjs.org/path-type
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7665710Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.stat
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7666210Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.walk
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7666660Z [0m[32mDownload[0m https://registry.npmjs.org/esprima
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7667470Z [0m[32mDownload[0m https://registry.npmjs.org/callsites
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7776650Z [0m[32mDownload[0m https://registry.npmjs.org/color-name
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7780530Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7781290Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7782000Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7782490Z [0m[32mDownload[0m https://registry.npmjs.org/environment
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7782970Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7824850Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7997440Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.scandir
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7998010Z [0m[32mDownload[0m https://registry.npmjs.org/fastq
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.7998520Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8009430Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8068660Z [0m[32mDownload[0m https://registry.npmjs.org/onetime
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8069300Z [0m[32mDownload[0m https://registry.npmjs.org/is-number
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8302970Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8303820Z [0m[32mDownload[0m https://registry.npmjs.org/reusify
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8304290Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8304760Z [0m[32mDownload[0m https://registry.npmjs.org/p-try
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8473280Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8787450Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8802010Z [0m[32mDownload[0m https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8810010Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/cli/-/cli-2.30.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8812290Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere/-/test-anywhere-0.6.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8829760Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8831000Z [0m[32mDownload[0m https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8831690Z [0m[32mDownload[0m https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8832300Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8833080Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8833810Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8834430Z [0m[32mDownload[0m https://registry.npmjs.org/husky/-/husky-9.1.7.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8835030Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8835790Z [0m[32mDownload[0m https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8837030Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8837750Z [0m[32mDownload[0m https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8838520Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8839160Z [0m[32mDownload[0m https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8839800Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8840520Z [0m[32mDownload[0m https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8841150Z [0m[32mDownload[0m https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8841830Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8842760Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8843550Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8844310Z [0m[32mDownload[0m https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8844980Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8845710Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8846450Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8847190Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8847990Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8848700Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8849710Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8850590Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8851400Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8852090Z [0m[32mDownload[0m https://registry.npmjs.org/espree/-/espree-10.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8852710Z [0m[32mDownload[0m https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8864650Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8865370Z [0m[32mDownload[0m https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8866090Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8866750Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8867490Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8868160Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8868780Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8869380Z [0m[32mDownload[0m https://registry.npmjs.org/debug/-/debug-4.4.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8870000Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8870670Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8871320Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8872030Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8872790Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8873840Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8874700Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.15.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8875410Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8876160Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8876900Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8877610Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8878330Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8879250Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8879950Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8880570Z [0m[32mDownload[0m https://registry.npmjs.org/mri/-/mri-1.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8881150Z [0m[32mDownload[0m https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8881760Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8882530Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8883250Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8890020Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8890850Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8891500Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8892230Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8892890Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8893510Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8894280Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8894950Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/config/-/config-3.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8895740Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8896490Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8897110Z [0m[32mDownload[0m https://registry.npmjs.org/semver/-/semver-7.7.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8897760Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8898440Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8899120Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8899730Z [0m[32mDownload[0m https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8900310Z [0m[32mDownload[0m https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8901010Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8901730Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8902380Z [0m[32mDownload[0m https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8902940Z [0m[32mDownload[0m https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8903500Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8904360Z [0m[32mDownload[0m https://registry.npmjs.org/commander/-/commander-14.0.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8904950Z [0m[32mDownload[0m https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8905640Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8906250Z [0m[32mDownload[0m https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8906840Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8907440Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8908170Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8908830Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8909650Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8910330Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8911060Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8911690Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8912390Z [0m[32mDownload[0m https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8912990Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8913550Z [0m[32mDownload[0m https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8914120Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8914820Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8915780Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8916570Z [0m[32mDownload[0m https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8917220Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8917830Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8918450Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8919100Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8919750Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8920380Z [0m[32mDownload[0m https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8921040Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8921680Z [0m[32mDownload[0m https://registry.npmjs.org/which/-/which-2.0.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8922350Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8922970Z [0m[32mDownload[0m https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8923560Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8924260Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8924960Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8925580Z [0m[32mDownload[0m https://registry.npmjs.org/globals/-/globals-14.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8926160Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8926870Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8927490Z [0m[32mDownload[0m https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8928230Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8928910Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8929570Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8930190Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8930780Z [0m[32mDownload[0m https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8931630Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8932450Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8933190Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8934040Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8934640Z [0m[32mDownload[0m https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8935330Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8935990Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8936630Z [0m[32mDownload[0m https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8937330Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8938050Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8938780Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8939460Z [0m[32mDownload[0m https://registry.npmjs.org/globby/-/globby-11.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8940080Z [0m[32mDownload[0m https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8940700Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8941410Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8942040Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8942670Z [0m[32mDownload[0m https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8943310Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8943970Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8944640Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8945290Z [0m[32mDownload[0m https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8945940Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8946710Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8947420Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8948040Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8948800Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8949410Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8950030Z [0m[32mDownload[0m https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8950640Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8951280Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8951930Z [0m[32mDownload[0m https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8952760Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8953420Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8954100Z [0m[32mDownload[0m https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8954660Z [0m[32mDownload[0m https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8955240Z [0m[32mDownload[0m https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8955830Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8956510Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8957160Z [0m[32mDownload[0m https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8958000Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8958710Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8959390Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8960100Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8960740Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8961320Z [0m[32mDownload[0m https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8961920Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8962630Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8963310Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8963920Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8964470Z [0m[32mDownload[0m https://registry.npmjs.org/pify/-/pify-4.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8965060Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8965720Z [0m[32mDownload[0m https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8966330Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8966950Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8967610Z [0m[32mDownload[0m https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8968210Z [0m[32mDownload[0m https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8968800Z [0m[32mDownload[0m https://registry.npmjs.org/slash/-/slash-3.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8969400Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8970050Z [0m[32mDownload[0m https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8970670Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8971330Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8972000Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8972640Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8973310Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8973960Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8974610Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8975290Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8975940Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8976810Z [0m[32mDownload[0m https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8977510Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8978180Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8978800Z [0m[32mDownload[0m https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8979470Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8980090Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8980690Z [0m[32mDownload[0m https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8981280Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8982080Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8982720Z [0m[32mDownload[0m https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8983390Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8984110Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8984850Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8985750Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8986730Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8987520Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8988260Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8989020Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8989700Z [0m[32mDownload[0m https://registry.npmjs.org/environment/-/environment-1.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8990360Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8991070Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8991720Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8992320Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8992930Z [0m[32mDownload[0m https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8993590Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8994260Z [0m[32mDownload[0m https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8994860Z [0m[32mDownload[0m https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8995440Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8996030Z [0m[32mDownload[0m https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.8998990Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9001030Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9002780Z [0m[32mDownload[0m https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9004880Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9137900Z [0m[32mInitialize[0m eslint-plugin-prettier@5.5.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9464580Z [0m[32mInitialize[0m getenv@2.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9478620Z [0m[32mInitialize[0m eslint-config-prettier@10.1.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9516520Z [0m[32mInitialize[0m test-anywhere@0.6.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9853130Z [0m[32mInitialize[0m synckit@0.11.12
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9876070Z [0m[32mInitialize[0m links-notation@0.11.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9886710Z [0m[32mInitialize[0m yargs@17.7.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9894230Z [0m[32mInitialize[0m lint-staged@16.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9919050Z [0m[32mInitialize[0m prettier-linter-helpers@1.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9954450Z [0m[32mInitialize[0m chalk@4.1.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9987030Z [0m[32mInitialize[0m file-entry-cache@8.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9988600Z [0m[32mInitialize[0m ignore@5.3.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:23.9993170Z [0m[32mInitialize[0m imurmurhash@0.1.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0023600Z [0m[32mInitialize[0m optionator@0.9.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0083380Z [0m[32mInitialize[0m is-glob@4.0.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0098160Z [0m[32mInitialize[0m fast-deep-equal@3.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0099620Z [0m[32mInitialize[0m lino-env@0.2.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0116050Z [0m[32mInitialize[0m find-up@5.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0120360Z [0m[32mInitialize[0m husky@9.1.7
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0125090Z [0m[32mInitialize[0m esutils@2.0.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0148150Z [0m[32mInitialize[0m minimatch@3.1.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0160270Z [0m[32mInitialize[0m glob-parent@6.0.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0161460Z [0m[32mInitialize[0m escape-string-regexp@4.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0705950Z [0m[32mInitialize[0m natural-compare@1.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0881760Z [0m[32mInitialize[0m mri@1.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0916730Z [0m[32mInitialize[0m json-stable-stringify-without-jsonify@1.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.0934680Z [0m[32mInitialize[0m eslint-visitor-keys@4.2.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1271070Z [0m[32mInitialize[0m espree@10.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1408660Z [0m[32mInitialize[0m yargs-parser@21.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1409570Z [0m[32mInitialize[0m esquery@1.7.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1410170Z [0m[32mInitialize[0m ajv@6.14.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1748180Z [0m[32mInitialize[0m get-caller-file@2.0.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1780080Z [0m[32mInitialize[0m term-size@2.2.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1782060Z [0m[32mInitialize[0m eslint@9.39.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1789280Z [0m[32mInitialize[0m picocolors@1.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1791190Z [0m[32mInitialize[0m eslint-scope@8.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1805990Z [0m[32mInitialize[0m debug@4.4.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1843700Z [0m[32mInitialize[0m tinyexec@1.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1844350Z [0m[32mInitialize[0m @eslint/core@0.17.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1890230Z [0m[32mInitialize[0m y18n@5.0.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1894290Z [0m[32mInitialize[0m @eslint-community/regexpp@4.12.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1902590Z [0m[32mInitialize[0m word-wrap@1.2.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1910840Z [0m[32mInitialize[0m @changesets/get-dependents-graph@2.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1911310Z [0m[32mInitialize[0m @types/estree@1.0.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1911650Z [0m[32mInitialize[0m semver@7.7.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1912040Z [0m[32mInitialize[0m levn@0.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.1914220Z [0m[32mInitialize[0m @eslint/eslintrc@3.3.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2204000Z [0m[32mInitialize[0m resolve-from@5.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2334080Z [0m[32mInitialize[0m lodash.merge@4.6.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2352900Z [0m[32mInitialize[0m deep-is@0.1.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2353490Z [0m[32mInitialize[0m package-manager-detector@0.2.11
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2354480Z [0m[32mInitialize[0m require-directory@2.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2675150Z [0m[32mInitialize[0m @eslint/plugin-kit@0.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2747910Z [0m[32mInitialize[0m string-width@4.2.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2797210Z [0m[32mInitialize[0m fast-diff@1.3.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2814370Z [0m[32mInitialize[0m commander@14.0.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2824080Z [0m[32mInitialize[0m yaml@2.8.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2866090Z [0m[32mInitialize[0m picomatch@4.0.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2970760Z [0m[32mInitialize[0m fast-levenshtein@2.0.6
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2987000Z [0m[32mInitialize[0m ansi-colors@4.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2995370Z [0m[32mInitialize[0m @changesets/cli@2.30.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2999000Z [0m[32mInitialize[0m @humanwhocodes/module-importer@1.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.2999540Z [0m[32mInitialize[0m type-check@0.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3003300Z [0m[32mInitialize[0m @eslint-community/eslint-utils@4.9.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3004860Z [0m[32mInitialize[0m supports-color@7.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3005320Z [0m[32mInitialize[0m prelude-ls@1.2.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3006410Z [0m[32mInitialize[0m enquirer@2.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3309250Z [0m[32mInitialize[0m spawndamnit@3.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3332250Z [0m[32mInitialize[0m @eslint/js@9.39.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3337110Z [0m[32mInitialize[0m @eslint/config-helpers@0.4.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3338590Z [0m[32mInitialize[0m escalade@3.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3384520Z [0m[32mInitialize[0m ansi-styles@4.3.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3402410Z [0m[32mInitialize[0m fs-extra@7.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3410400Z [0m[32mInitialize[0m @changesets/get-release-plan@4.0.15
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3424380Z [0m[32mInitialize[0m @eslint/config-array@0.21.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3425400Z [0m[32mInitialize[0m json-schema-traverse@0.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3425870Z [0m[32mInitialize[0m cliui@8.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3426370Z [0m[32mInitialize[0m string-argv@0.3.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3426770Z [0m[32mInitialize[0m estraverse@5.3.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3427320Z [0m[32mInitialize[0m listr2@9.0.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3713090Z [0m[32mInitialize[0m is-extglob@2.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3765580Z [0m[32mInitialize[0m @humanfs/node@0.16.7
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3775440Z [0m[32mInitialize[0m uri-js@4.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3803140Z [0m[32mInitialize[0m flat-cache@4.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3807700Z [0m[32mInitialize[0m acorn@8.16.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3837020Z [0m[32mInitialize[0m prettier@3.8.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3842600Z [0m[32mInitialize[0m fast-json-stable-stringify@2.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3856880Z [0m[32mInitialize[0m ms@2.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3857450Z [0m[32mInitialize[0m @changesets/apply-release-plan@7.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3857860Z [0m[32mInitialize[0m path-exists@4.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3863630Z [0m[32mInitialize[0m which@2.0.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3863950Z [0m[32mInitialize[0m cross-spawn@7.0.6
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3864310Z [0m[32mInitialize[0m @humanwhocodes/retry@0.4.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3864670Z [0m[32mInitialize[0m shebang-command@2.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3865010Z [0m[32mInitialize[0m brace-expansion@1.1.13
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3865320Z [0m[32mInitialize[0m esrecurse@4.3.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3865640Z [0m[32mInitialize[0m @changesets/errors@0.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.3865990Z [0m[32mInitialize[0m @manypkg/get-packages@1.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4055700Z [0m[32mInitialize[0m @inquirer/external-editor@1.0.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4221260Z [0m[32mInitialize[0m @types/json-schema@7.0.15
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4237690Z [0m[32mInitialize[0m acorn-jsx@5.3.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4264100Z [0m[32mInitialize[0m @changesets/git@3.0.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4269850Z [0m[32mInitialize[0m @changesets/logger@0.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4311180Z [0m[32mInitialize[0m @changesets/read@0.6.7
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4311680Z [0m[32mInitialize[0m @pkgr/core@0.2.9
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4347330Z [0m[32mInitialize[0m @changesets/should-skip-package@0.1.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4347910Z [0m[32mInitialize[0m strip-json-comments@3.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4348280Z [0m[32mInitialize[0m eslint-visitor-keys@3.4.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4348750Z [0m[32mInitialize[0m @changesets/types@6.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4349090Z [0m[32mInitialize[0m @changesets/write@0.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4349420Z [0m[32mInitialize[0m locate-path@6.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4349720Z [0m[32mInitialize[0m globals@14.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4349990Z [0m[32mInitialize[0m path-key@3.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4350300Z [0m[32mInitialize[0m @changesets/config@3.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4629240Z [0m[32mInitialize[0m @changesets/pre@2.0.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4641820Z [0m[32mInitialize[0m lodash.startcase@4.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4941870Z [0m[32mInitialize[0m @changesets/changelog-git@0.2.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4989260Z [0m[32mInitialize[0m js-yaml@4.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.4990060Z [0m[32mInitialize[0m outdent@0.5.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5013090Z [0m[32mInitialize[0m @changesets/assemble-release-plan@6.0.9
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5041240Z [0m[32mInitialize[0m p-filter@2.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5042170Z [0m[32mInitialize[0m detect-indent@6.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5045490Z [0m[32mInitialize[0m fs-extra@8.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5049660Z [0m[32mInitialize[0m micromatch@4.0.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5050020Z [0m[32mInitialize[0m @humanfs/core@0.19.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5050360Z [0m[32mInitialize[0m globby@11.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5050700Z [0m[32mInitialize[0m graceful-fs@4.2.11
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5051000Z [0m[32mInitialize[0m jsonfile@4.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5051840Z [0m[32mInitialize[0m strip-ansi@6.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5052130Z [0m[32mInitialize[0m colorette@2.0.20
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5052420Z [0m[32mInitialize[0m emoji-regex@8.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5052710Z [0m[32mInitialize[0m signal-exit@4.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5359200Z [0m[32mInitialize[0m flatted@3.4.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5363950Z [0m[32mInitialize[0m wrap-ansi@7.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5369430Z [0m[32mInitialize[0m universalify@0.1.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5402460Z [0m[32mInitialize[0m is-subdir@1.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5409420Z [0m[32mInitialize[0m read-yaml-file@1.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5421570Z [0m[32mInitialize[0m punycode@2.3.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5459270Z [0m[32mInitialize[0m strip-bom@3.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5475150Z [0m[32mInitialize[0m concat-map@0.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5475700Z [0m[32mInitialize[0m cli-truncate@5.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5478620Z [0m[32mInitialize[0m rfdc@1.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5479180Z [0m[32mInitialize[0m braces@3.0.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5479530Z [0m[32mInitialize[0m human-id@4.1.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5479820Z [0m[32mInitialize[0m chardet@2.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5480550Z [0m[32mInitialize[0m extendable-error@0.1.7
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5480910Z [0m[32mInitialize[0m parent-module@1.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5481210Z [0m[32mInitialize[0m p-locate@5.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5481490Z [0m[32mInitialize[0m quansync@0.2.11
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5481770Z [0m[32mInitialize[0m argparse@2.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5482060Z [0m[32mInitialize[0m iconv-lite@0.7.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5482380Z [0m[32mInitialize[0m better-path-resolve@1.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5903840Z [0m[32mInitialize[0m eventemitter3@5.0.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5973350Z [0m[32mInitialize[0m @eslint/object-schema@2.1.7
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.5984540Z [0m[32mInitialize[0m @changesets/get-version-range-type@0.4.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6007290Z [0m[32mInitialize[0m isexe@2.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6012360Z [0m[32mInitialize[0m log-update@6.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6046320Z [0m[32mInitialize[0m find-up@4.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6056510Z [0m[32mInitialize[0m has-flag@4.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6098110Z [0m[32mInitialize[0m wrap-ansi@9.0.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6109680Z [0m[32mInitialize[0m is-fullwidth-code-point@3.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6122900Z [0m[32mInitialize[0m keyv@4.5.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6127900Z [0m[32mInitialize[0m @changesets/types@4.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6144210Z [0m[32mInitialize[0m p-limit@3.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6488560Z [0m[32mInitialize[0m slice-ansi@7.1.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6508900Z [0m[32mInitialize[0m ansi-styles@6.2.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6556360Z [0m[32mInitialize[0m color-convert@2.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6556810Z [0m[32mInitialize[0m js-yaml@3.14.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6563420Z [0m[32mInitialize[0m safer-buffer@2.1.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6564110Z [0m[32mInitialize[0m resolve-from@4.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6564460Z [0m[32mInitialize[0m glob-parent@5.1.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6565700Z [0m[32mInitialize[0m dir-glob@3.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6566220Z [0m[32mInitialize[0m strip-ansi@7.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6566860Z [0m[32mInitialize[0m fill-range@7.1.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6569740Z [0m[32mInitialize[0m pify@4.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6591470Z [0m[32mInitialize[0m picomatch@2.3.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6591900Z [0m[32mInitialize[0m ansi-regex@5.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6599100Z [0m[32mInitialize[0m @babel/runtime@7.29.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6604120Z [0m[32mInitialize[0m slice-ansi@8.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6605220Z [0m[32mInitialize[0m @manypkg/find-root@1.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6605830Z [0m[32mInitialize[0m shebang-regex@3.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6906760Z [0m[32mInitialize[0m merge2@1.4.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6926040Z [0m[32mInitialize[0m array-union@2.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6932060Z [0m[32mInitialize[0m callsites@3.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6934950Z [0m[32mInitialize[0m sprintf-js@1.0.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6951190Z [0m[32mInitialize[0m environment@1.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6974760Z [0m[32mInitialize[0m color-name@1.1.4
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.6991520Z [0m[32mInitialize[0m slash@3.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7013070Z [0m[32mInitialize[0m locate-path@5.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7015350Z [0m[32mInitialize[0m balanced-match@1.0.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7022900Z [0m[32mInitialize[0m p-map@2.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7023540Z [0m[32mInitialize[0m to-regex-range@5.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7024130Z [0m[32mInitialize[0m cli-cursor@5.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7024440Z [0m[32mInitialize[0m @types/node@12.20.55
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7024750Z [0m[32mInitialize[0m argparse@1.0.10
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7025030Z [0m[32mInitialize[0m p-locate@4.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7025330Z [0m[32mInitialize[0m string-width@7.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7025620Z [0m[32mInitialize[0m run-parallel@1.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7025900Z [0m[32mInitialize[0m path-type@4.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7026190Z [0m[32mInitialize[0m json-buffer@3.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7026530Z [0m[32mInitialize[0m string-width@8.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7026850Z [0m[32mInitialize[0m ansi-regex@6.2.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7445610Z [0m[32mInitialize[0m get-east-asian-width@1.5.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7453770Z [0m[32mInitialize[0m @changesets/parse@0.4.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7457500Z [0m[32mInitialize[0m @nodelib/fs.walk@1.2.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7462000Z [0m[32mInitialize[0m reusify@1.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7465250Z [0m[32mInitialize[0m fast-glob@3.3.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7500920Z [0m[32mInitialize[0m esprima@4.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7501410Z [0m[32mInitialize[0m onetime@7.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7512720Z [0m[32mInitialize[0m ansi-escapes@7.3.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7513700Z [0m[32mInitialize[0m is-fullwidth-code-point@5.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7514080Z [0m[32mInitialize[0m p-limit@2.3.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7514460Z [0m[32mInitialize[0m p-try@2.2.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7527170Z [0m[32mInitialize[0m mimic-function@5.0.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7536930Z [0m[32mInitialize[0m is-number@7.0.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7602480Z [0m[32mInitialize[0m is-windows@1.0.2
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7603780Z [0m[32mInitialize[0m queue-microtask@1.2.3
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7627250Z [0m[32mInitialize[0m @nodelib/fs.stat@2.0.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7627930Z [0m[32mInitialize[0m yocto-queue@0.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7628250Z [0m[32mInitialize[0m restore-cursor@5.1.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7628570Z [0m[32mInitialize[0m fastq@1.20.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7957220Z [0m[32mInitialize[0m import-fresh@3.3.1
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7961260Z [0m[32mInitialize[0m emoji-regex@10.6.0
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.7977110Z [0m[32mInitialize[0m @nodelib/fs.scandir@2.1.5
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:24.8008020Z [0m[32mInitialize[0m prettier@2.8.8
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0045120Z [0m[38;5;245mrunning 58 tests from ./tests/index.test.js[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0067740Z should convert camelCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0068620Z should convert kebab-case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0071990Z should convert snake_case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0073130Z should convert PascalCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0073900Z should handle already UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0075430Z should convert kebab-case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0076720Z should convert UPPER_CASE to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0077740Z should convert snake_case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0078610Z should convert PascalCase to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0080610Z should handle already camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0082070Z should convert camelCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0083080Z should convert UPPER_CASE to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0083670Z should convert PascalCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0084230Z should handle already kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0085160Z should convert camelCase to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0085790Z should convert kebab-case to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0086520Z should convert UPPER_CASE to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0087080Z should handle already snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0088000Z should convert camelCase to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0088720Z should convert kebab-case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0089530Z should convert snake_case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0090090Z should handle already PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0092950Z should find variable in UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0093920Z should find variable in camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0096400Z should find variable in kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0097480Z should return default value when not found ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0098260Z should return empty string as default when not specified ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0098960Z should try original key first ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0201920Z should work with minimal configuration ... [0m[32mok[0m [0m[38;5;245m(10ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0235550Z should use CLI arguments with highest priority ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0256020Z should convert kebab-case to camelCase in result ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0270980Z should load .lenv file by default ...
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0271480Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0272190Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0293370Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0293910Z should load .lenv file by default ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0297310Z should handle --configuration flag ...
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0297740Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0298380Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0305900Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0316170Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0317030Z should handle --configuration flag ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0318430Z should prioritize CLI over environment ...
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0318990Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0319590Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0333580Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0334120Z should prioritize CLI over environment ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0356060Z should handle missing .lenv file gracefully ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0360880Z should convert all keys to UPPER_CASE in process.env ...
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0361300Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0361870Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0378420Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0379020Z should convert all keys to UPPER_CASE in process.env ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0399400Z should find env vars in any case format via getenv ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0423820Z should support disabling lenv ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0447110Z should support enabling env/dotenvx (deprecated) ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0464750Z should support disabling getenv ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0479390Z should support configuration alias -c ...
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0480490Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0481440Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0492650Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0493400Z should support configuration alias -c ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0498800Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ...
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0499290Z [0m[38;5;245m------- output -------[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0499850Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0515670Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0522440Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0530740Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0537470Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0550000Z [0m[38;5;245m----- output end -----[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0550690Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0570520Z should allow user-defined --version option by calling .version(false) ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0593050Z should allow user-defined --help option ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0613900Z should work with --version in strict mode ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0630970Z should handle --version with boolean type ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0645440Z should allow users to explicitly enable help ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0666680Z should work with multiple custom options including version ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0685350Z should allow explicitly enabling built-in --version ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0713020Z should allow explicitly enabling both --version and --help ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0778840Z should allow version with alias ... [0m[32mok[0m [0m[38;5;245m(6ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0821160Z should allow help with alias ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0849490Z should work with both built-in version/help and custom options ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0869550Z should parse simple links notation format ... [0m[32mok[0m [0m[38;5;245m(1ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0871220Z should parse arguments without parentheses ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0873200Z should handle empty input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0874670Z should handle null input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0876380Z should filter out comments ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0937210Z 
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0940270Z [0m[32mok[0m | 58 passed | 0 failed [0m[38;5;245m(89ms)[0m
+Test (deno on macos-latest)	Run tests (Deno)	2026-04-10T20:47:25.0942040Z 
+Test (deno on macos-latest)	Post Setup Deno	﻿2026-04-10T20:47:25.1077060Z Post job cleanup.
+Test (deno on macos-latest)	Post Setup Deno	2026-04-10T20:47:25.2406230Z Caching is not enabled. Caching is skipped.
+Test (deno on macos-latest)	Post Setup Node.js (for npm install)	﻿2026-04-10T20:47:25.2497340Z Post job cleanup.
+Test (deno on macos-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:25.4345670Z Post job cleanup.
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5288920Z [command]/opt/homebrew/bin/git version
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5357560Z git version 2.53.0
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5380190Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/41a29776-e61f-48aa-803d-9b19d2f298f2/.gitconfig'
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5387430Z Temporarily overriding HOME='/Users/runner/work/_temp/41a29776-e61f-48aa-803d-9b19d2f298f2' before making global git config changes
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5388160Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5395010Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5456670Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.5518290Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.6195200Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.6236520Z http.https://github.com/.extraheader
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.6244210Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.6294850Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.7165620Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:25.7246060Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (deno on macos-latest)	Complete job	﻿2026-04-10T20:47:25.8009320Z Cleaning up orphan processes
+Test (deno on macos-latest)	Complete job	2026-04-10T20:47:26.2123120Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (bun on ubuntu-latest)	Set up job	﻿2026-04-10T20:47:12.0308546Z Current runner version: '2.333.1'
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0343981Z ##[group]Runner Image Provisioner
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0345509Z Hosted Compute Agent
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0346517Z Version: 20260213.493
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0347544Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0349221Z Build Date: 2026-02-13T00:28:41Z
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0350390Z Worker ID: {4dfccb55-4921-441a-8e1d-c89a5f1f198a}
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0351655Z Azure Region: eastus
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0352724Z ##[endgroup]
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0355105Z ##[group]Operating System
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0356276Z Ubuntu
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0357126Z 24.04.4
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0358010Z LTS
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0359172Z ##[endgroup]
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0360175Z ##[group]Runner Image
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0361051Z Image: ubuntu-24.04
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0362030Z Version: 20260406.80.1
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0363779Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0366744Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0368407Z ##[endgroup]
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0373573Z ##[group]GITHUB_TOKEN Permissions
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0376388Z Actions: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0377481Z ArtifactMetadata: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0378450Z Attestations: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0379695Z Checks: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0380585Z Contents: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0381494Z Deployments: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0382402Z Discussions: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0383364Z Issues: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0384332Z Metadata: read
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0385218Z Models: read
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0386283Z Packages: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0387101Z Pages: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0388117Z PullRequests: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0389430Z RepositoryProjects: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0390424Z SecurityEvents: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0391342Z Statuses: write
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0392347Z ##[endgroup]
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0395338Z Secret source: Actions
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0396486Z Prepare workflow directory
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.0980939Z Prepare all required actions
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.1037467Z Getting action download info
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.3851137Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.5175493Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.6046447Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:12.7819711Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (bun on ubuntu-latest)	Set up job	2026-04-10T20:47:13.0856142Z Complete job name: Test (bun on ubuntu-latest)
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:13.1606141Z ##[group]Run actions/checkout@v4
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1607043Z with:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1607515Z   repository: link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1608246Z   token: ***
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1608661Z   ssh-strict: true
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1609566Z   ssh-user: git
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1610084Z   persist-credentials: true
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1610681Z   clean: true
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1611103Z   sparse-checkout-cone-mode: true
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1611591Z   fetch-depth: 1
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1611991Z   fetch-tags: false
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1612409Z   show-progress: true
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1612838Z   lfs: false
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1613217Z   submodules: false
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1613681Z   set-safe-directory: true
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.1614478Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2709026Z Syncing repository: link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2711135Z ##[group]Getting Git version info
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2711949Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2713139Z [command]/usr/bin/git version
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2780367Z git version 2.53.0
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2806939Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2822806Z Temporarily overriding HOME='/home/runner/work/_temp/1a532d42-4ff4-4c28-b7f5-4081a9e2bf06' before making global git config changes
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2825641Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2837146Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2869253Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2872975Z ##[group]Initializing the repository
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2877889Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2964058Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2965918Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2967692Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2969283Z hint: call:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2970026Z hint:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2970936Z hint: 	git config --global init.defaultBranch <name>
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2972107Z hint:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2973115Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2974678Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2975998Z hint:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2976759Z hint: 	git branch -m <name>
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2977609Z hint:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2979063Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2981011Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.2983963Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3009192Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3010593Z ##[group]Disabling automatic garbage collection
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3014004Z [command]/usr/bin/git config --local gc.auto 0
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3042216Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3043418Z ##[group]Setting up auth
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3048521Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3077020Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3368105Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3398144Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3612283Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3650658Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3866983Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3900658Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3902141Z ##[group]Fetching the repository
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3908737Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5925207Z From https://github.com/link-foundation/lino-arguments
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5926976Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5954262Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5957798Z ##[group]Determining the checkout info
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5960133Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5961951Z [command]/usr/bin/git sparse-checkout disable
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5996399Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6023126Z ##[group]Checking out the ref
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6025681Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6170714Z Switched to a new branch 'main'
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6173018Z branch 'main' set up to track 'origin/main'.
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6181840Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6214164Z [command]/usr/bin/git log -1 --format=%H
+Test (bun on ubuntu-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6235689Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	﻿2026-04-10T20:47:13.6665632Z ##[group]Run actions/setup-node@v4
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.6666660Z with:
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.6667325Z   node-version: 20.x
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.6668108Z   always-auth: false
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.6669203Z   check-latest: false
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.6670349Z   token: ***
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.6671017Z ##[endgroup]
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.8428458Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:13.8434289Z ##[group]Environment details
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.1825015Z node: v20.20.2
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.1826177Z npm: 10.8.2
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.1827094Z yarn: 1.22.22
+Test (bun on ubuntu-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:14.1829020Z ##[endgroup]
+Test (bun on ubuntu-latest)	Setup Bun	﻿2026-04-10T20:47:14.2036889Z ##[group]Run oven-sh/setup-bun@v2
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.2037842Z with:
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.2038475Z   bun-version: latest
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.2039398Z   no-cache: false
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.2040353Z   token: ***
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.2041005Z ##[endgroup]
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.5970286Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-linux-x64.zip
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:14.8240796Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/8ae319a8-cae9-442f-a3e0-8b74a2badc3c.zip
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:15.5404333Z [command]/home/runner/.bun/bin/bun --revision
+Test (bun on ubuntu-latest)	Setup Bun	2026-04-10T20:47:15.5447852Z 1.3.12+700fc117a
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	﻿2026-04-10T20:47:15.5595453Z ##[group]Run npm install
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:15.5595770Z [36;1mnpm install[0m
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:15.5627903Z shell: /usr/bin/bash -e {0}
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:15.5628180Z ##[endgroup]
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.4951660Z 
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.4952579Z > lino-arguments@0.3.0 prepare
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.4953115Z > husky || true
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.4953311Z 
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5393028Z .git can't be found
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5393786Z added 234 packages, and audited 235 packages in 3s
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5394341Z 
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5396424Z 59 packages are looking for funding
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5397096Z   run `npm fund` for details
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5494629Z 
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5495311Z 7 vulnerabilities (4 moderate, 3 high)
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5496022Z 
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5496550Z To address all issues, run:
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5497372Z   npm audit fix
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5497840Z 
+Test (bun on ubuntu-latest)	Install dependencies (Bun)	2026-04-10T20:47:18.5498293Z Run `npm audit` for details.
+Test (bun on ubuntu-latest)	Run tests (Bun)	﻿2026-04-10T20:47:18.5705597Z ##[group]Run bun test
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.5705880Z [36;1mbun test[0m
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.5731271Z shell: /usr/bin/bash -e {0}
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.5731521Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.5788803Z bun test v1.3.12 (700fc117)
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.5828344Z 
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.5829256Z ##[group]tests/index.test.js:
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6204062Z (pass) Case Conversion Utilities > toUpperCase > should convert camelCase to UPPER_CASE
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6205521Z (pass) Case Conversion Utilities > toUpperCase > should convert kebab-case to UPPER_CASE
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6206820Z (pass) Case Conversion Utilities > toUpperCase > should convert snake_case to UPPER_CASE
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6208150Z (pass) Case Conversion Utilities > toUpperCase > should convert PascalCase to UPPER_CASE
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6209652Z (pass) Case Conversion Utilities > toUpperCase > should handle already UPPER_CASE
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6210949Z (pass) Case Conversion Utilities > toCamelCase > should convert kebab-case to camelCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6212301Z (pass) Case Conversion Utilities > toCamelCase > should convert UPPER_CASE to camelCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6213576Z (pass) Case Conversion Utilities > toCamelCase > should convert snake_case to camelCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6214968Z (pass) Case Conversion Utilities > toCamelCase > should convert PascalCase to camelCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6216678Z (pass) Case Conversion Utilities > toCamelCase > should handle already camelCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6217946Z (pass) Case Conversion Utilities > toKebabCase > should convert camelCase to kebab-case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6219490Z (pass) Case Conversion Utilities > toKebabCase > should convert UPPER_CASE to kebab-case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6220901Z (pass) Case Conversion Utilities > toKebabCase > should convert PascalCase to kebab-case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6223074Z (pass) Case Conversion Utilities > toKebabCase > should handle already kebab-case [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6230564Z (pass) Case Conversion Utilities > toSnakeCase > should convert camelCase to snake_case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6232282Z (pass) Case Conversion Utilities > toSnakeCase > should convert kebab-case to snake_case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6234018Z (pass) Case Conversion Utilities > toSnakeCase > should convert UPPER_CASE to snake_case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6235630Z (pass) Case Conversion Utilities > toSnakeCase > should handle already snake_case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6237358Z (pass) Case Conversion Utilities > toPascalCase > should convert camelCase to PascalCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6239298Z (pass) Case Conversion Utilities > toPascalCase > should convert kebab-case to PascalCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6241104Z (pass) Case Conversion Utilities > toPascalCase > should convert snake_case to PascalCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6242794Z (pass) Case Conversion Utilities > toPascalCase > should handle already PascalCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6244194Z (pass) getenv > should find variable in UPPER_CASE
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6245246Z (pass) getenv > should find variable in camelCase
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6246421Z (pass) getenv > should find variable in kebab-case
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6247555Z (pass) getenv > should return default value when not found
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6249305Z (pass) getenv > should return empty string as default when not specified [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6250579Z (pass) getenv > should try original key first
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6320485Z (pass) makeConfig > Hero Example (defaults) > should work with minimal configuration [9.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6345506Z (pass) makeConfig > Hero Example (defaults) > should use CLI arguments with highest priority [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6364645Z (pass) makeConfig > Hero Example (defaults) > should convert kebab-case to camelCase in result [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6367616Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6386912Z (pass) makeConfig > Environment Loading Priority > should load .lenv file by default [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6388644Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6395159Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6404008Z (pass) makeConfig > Environment Loading Priority > should handle --configuration flag [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6405796Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6415868Z (pass) makeConfig > Environment Loading Priority > should prioritize CLI over environment [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6424477Z (pass) makeConfig > Environment Loading Priority > should handle missing .lenv file gracefully [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6426257Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6435651Z (pass) makeConfig > Case Conversion in Environment Loading > should convert all keys to UPPER_CASE in process.env [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6452750Z (pass) makeConfig > Case Conversion in Environment Loading > should find env vars in any case format via getenv [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6464366Z (pass) makeConfig > Configuration Options > should support disabling lenv [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6476370Z (pass) makeConfig > Configuration Options > should support enabling env/dotenvx (deprecated) [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6486677Z (pass) makeConfig > Configuration Options > should support disabling getenv [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6494267Z 📝 Loaded 1 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6501977Z (pass) makeConfig > Configuration Options > should support configuration alias -c [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6503486Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6514457Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6519852Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6527086Z 📝 Loaded 3 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6532003Z 📝 Loaded 2 variables from /home/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6540820Z (pass) makeConfig > Complete Priority Chain > should demonstrate full priority: CLI > getenv > --configuration > .lenv [4.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6563272Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --version option by calling .version(false) [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6578414Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --help option [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6588988Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with --version in strict mode [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6597021Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should handle --version with boolean type [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6620521Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow users to explicitly enable help [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6625490Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with multiple custom options including version [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6632404Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling built-in --version [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6643679Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling both --version and --help [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6654718Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow version with alias [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6664713Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow help with alias [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6673366Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should work with both built-in version/help and custom options [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6695889Z (pass) parseLinoArguments (legacy) > should parse simple links notation format [2.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6700970Z (pass) parseLinoArguments (legacy) > should parse arguments without parentheses [1.00ms]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6703406Z (pass) parseLinoArguments (legacy) > should handle empty input
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6704433Z (pass) parseLinoArguments (legacy) > should handle null input
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6708377Z (pass) parseLinoArguments (legacy) > should filter out comments
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6709056Z 
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6709588Z ##[endgroup]
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6709791Z 
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6709941Z  58 pass
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6710223Z  0 fail
+Test (bun on ubuntu-latest)	Run tests (Bun)	2026-04-10T20:47:18.6710534Z Ran 58 tests across 1 file. [92.00ms]
+Test (bun on ubuntu-latest)	Post Setup Bun	﻿2026-04-10T20:47:18.6828011Z Post job cleanup.
+Test (bun on ubuntu-latest)	Post Setup Node.js (for npm install)	﻿2026-04-10T20:47:18.8558406Z Post job cleanup.
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:19.0265472Z Post job cleanup.
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1424154Z [command]/usr/bin/git version
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1461417Z git version 2.53.0
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1503882Z Temporarily overriding HOME='/home/runner/work/_temp/547c5ae8-5dac-4afa-8439-ce3ac80741b9' before making global git config changes
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1505051Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1518123Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1552612Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1585239Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1804447Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1824205Z http.https://github.com/.extraheader
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1836432Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.1865882Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.2075379Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on ubuntu-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:19.2104378Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on ubuntu-latest)	Complete job	﻿2026-04-10T20:47:19.2452760Z Cleaning up orphan processes
+Test (bun on ubuntu-latest)	Complete job	2026-04-10T20:47:19.2723641Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (bun on windows-latest)	Set up job	﻿2026-04-10T20:47:20.4960272Z Current runner version: '2.333.1'
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5068870Z ##[group]Runner Image Provisioner
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5070048Z Hosted Compute Agent
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5070956Z Version: 20260213.493
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5071738Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5072743Z Build Date: 2026-02-13T00:28:41Z
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5073702Z Worker ID: {724fa802-aa53-4846-a9ac-af8be4d4044a}
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5074655Z Azure Region: northcentralus
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5075554Z ##[endgroup]
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5077632Z ##[group]Operating System
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5078559Z Microsoft Windows Server 2025
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5079330Z 10.0.26100
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5080373Z Datacenter
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5080981Z ##[endgroup]
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5081661Z ##[group]Runner Image
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5082413Z Image: windows-2025
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5083542Z Version: 20260405.77.1
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5084968Z Included Software: https://github.com/actions/runner-images/blob/win25/20260405.77/images/windows/Windows2025-Readme.md
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5087692Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20260405.77
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5089036Z ##[endgroup]
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5093441Z ##[group]GITHUB_TOKEN Permissions
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5096830Z Actions: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5097637Z ArtifactMetadata: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5098467Z Attestations: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5099195Z Checks: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5099917Z Contents: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5100652Z Deployments: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5101393Z Discussions: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5102035Z Issues: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5102748Z Metadata: read
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5103791Z Models: read
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5104487Z Packages: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5105214Z Pages: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5105994Z PullRequests: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5106767Z RepositoryProjects: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5107569Z SecurityEvents: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5108271Z Statuses: write
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5108940Z ##[endgroup]
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5112513Z Secret source: Actions
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5113564Z Prepare workflow directory
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5631815Z Prepare all required actions
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.5673507Z Getting action download info
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:20.8857760Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:21.0190493Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:21.1797385Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:21.6015928Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (bun on windows-latest)	Set up job	2026-04-10T20:47:22.1336565Z Complete job name: Test (bun on windows-latest)
+Test (bun on windows-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:22.3241259Z ##[group]Run actions/checkout@v4
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3243254Z with:
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3243898Z   repository: link-foundation/lino-arguments
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3245121Z   token: ***
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3245661Z   ssh-strict: true
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3246218Z   ssh-user: git
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3246779Z   persist-credentials: true
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3247428Z   clean: true
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3247993Z   sparse-checkout-cone-mode: true
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3248702Z   fetch-depth: 1
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3249245Z   fetch-tags: false
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3249821Z   show-progress: true
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3250407Z   lfs: false
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3250915Z   submodules: false
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3251529Z   set-safe-directory: true
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.3252485Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.5154035Z Syncing repository: link-foundation/lino-arguments
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.5158543Z ##[group]Getting Git version info
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.5160440Z Working directory is 'D:\a\lino-arguments\lino-arguments'
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:22.6212222Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.3003555Z git version 2.53.0.windows.2
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.3066024Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.3151943Z Temporarily overriding HOME='D:\a\_temp\c805f190-ed40-425a-aded-ee1ab59ce644' before making global git config changes
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.3152946Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.3165765Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.4070826Z Deleting the contents of 'D:\a\lino-arguments\lino-arguments'
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.4077051Z ##[group]Initializing the repository
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.4088375Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-arguments\lino-arguments
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.5651603Z Initialized empty Git repository in D:/a/lino-arguments/lino-arguments/.git/
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.5721394Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-arguments
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.6443816Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.6455625Z ##[group]Disabling automatic garbage collection
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.6456284Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.6778632Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.6794904Z ##[group]Setting up auth
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.6795536Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:23.7125859Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:25.8879933Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:25.9269422Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:26.5487977Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:26.5823464Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:27.1509842Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:27.1891293Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:27.1891755Z ##[group]Fetching the repository
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:27.1907179Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.3497927Z From https://github.com/link-foundation/lino-arguments
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.3501129Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.3950797Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.3951333Z ##[group]Determining the checkout info
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.3954654Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.3972051Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.4668121Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.5012542Z ##[group]Checking out the ref
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.5024613Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.6198807Z Switched to a new branch 'main'
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.6317083Z branch 'main' set up to track 'origin/main'.
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.6376174Z ##[endgroup]
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.6973616Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (bun on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:28.7282342Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (bun on windows-latest)	Setup Node.js (for npm install)	﻿2026-04-10T20:47:28.8162707Z ##[group]Run actions/setup-node@v4
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:28.8164371Z with:
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:28.8164595Z   node-version: 20.x
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:28.8164840Z   always-auth: false
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:28.8165053Z   check-latest: false
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:28.8165604Z   token: ***
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:28.8165786Z ##[endgroup]
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:29.0791668Z Found in cache @ C:\hostedtoolcache\windows\node\20.20.2\x64
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:29.0804384Z ##[group]Environment details
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:34.6784932Z node: v20.20.2
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:34.6785344Z npm: 10.8.2
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:34.6785554Z yarn: 1.22.22
+Test (bun on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:34.6787322Z ##[endgroup]
+Test (bun on windows-latest)	Setup Bun	﻿2026-04-10T20:47:34.7111104Z ##[group]Run oven-sh/setup-bun@v2
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:34.7111621Z with:
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:34.7112077Z   bun-version: latest
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:34.7112327Z   no-cache: false
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:34.7112804Z   token: ***
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:34.7112997Z ##[endgroup]
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:35.2189063Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-x64.zip
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:35.8115348Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\7c1bb29a-35f5-41ae-a608-02b254a54ea2.zip', 'D:\a\_temp\d51a66f4-86d6-4f9e-9f58-4c01a5c39900', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\7c1bb29a-35f5-41ae-a608-02b254a54ea2.zip' -DestinationPath 'D:\a\_temp\d51a66f4-86d6-4f9e-9f58-4c01a5c39900' -Force } else { throw $_ } } ;"
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:46.3486010Z [command]C:\Users\runneradmin\.bun\bin\bun.exe --revision
+Test (bun on windows-latest)	Setup Bun	2026-04-10T20:47:46.9904851Z 1.3.12+700fc117a
+Test (bun on windows-latest)	Install dependencies (Bun)	﻿2026-04-10T20:47:47.0320747Z ##[group]Run npm install
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:47:47.0321417Z [36;1mnpm install[0m
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:47:47.0388961Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:47:47.0389353Z ##[endgroup]
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.4273437Z 
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.4275146Z > lino-arguments@0.3.0 prepare
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.4275700Z > husky || true
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.4275818Z 
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5339904Z .git can't be found
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5340607Z added 234 packages, and audited 235 packages in 14s
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5341202Z 
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5341584Z 59 packages are looking for funding
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5341997Z   run `npm fund` for details
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5443554Z 
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5444470Z 7 vulnerabilities (4 moderate, 3 high)
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5444839Z 
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5445052Z To address all issues, run:
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5445456Z   npm audit fix
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5445958Z 
+Test (bun on windows-latest)	Install dependencies (Bun)	2026-04-10T20:48:01.5446327Z Run `npm audit` for details.
+Test (bun on windows-latest)	Run tests (Bun)	﻿2026-04-10T20:48:01.8663991Z ##[group]Run bun test
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:01.8664329Z [36;1mbun test[0m
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:01.8732622Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:01.8732968Z ##[endgroup]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.1682852Z bun test v1.3.12 (700fc117)
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.1994839Z 
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.1995584Z ##[group]tests\index.test.js:
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2792362Z (pass) Case Conversion Utilities > toUpperCase > should convert camelCase to UPPER_CASE
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2793372Z (pass) Case Conversion Utilities > toUpperCase > should convert kebab-case to UPPER_CASE
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2793950Z (pass) Case Conversion Utilities > toUpperCase > should convert snake_case to UPPER_CASE
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2794758Z (pass) Case Conversion Utilities > toUpperCase > should convert PascalCase to UPPER_CASE
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2795574Z (pass) Case Conversion Utilities > toUpperCase > should handle already UPPER_CASE
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2796491Z (pass) Case Conversion Utilities > toCamelCase > should convert kebab-case to camelCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2797993Z (pass) Case Conversion Utilities > toCamelCase > should convert UPPER_CASE to camelCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2798939Z (pass) Case Conversion Utilities > toCamelCase > should convert snake_case to camelCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2799842Z (pass) Case Conversion Utilities > toCamelCase > should convert PascalCase to camelCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2800778Z (pass) Case Conversion Utilities > toCamelCase > should handle already camelCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2801745Z (pass) Case Conversion Utilities > toKebabCase > should convert camelCase to kebab-case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2802787Z (pass) Case Conversion Utilities > toKebabCase > should convert UPPER_CASE to kebab-case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2803762Z (pass) Case Conversion Utilities > toKebabCase > should convert PascalCase to kebab-case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2811584Z (pass) Case Conversion Utilities > toKebabCase > should handle already kebab-case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2812715Z (pass) Case Conversion Utilities > toSnakeCase > should convert camelCase to snake_case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2813627Z (pass) Case Conversion Utilities > toSnakeCase > should convert kebab-case to snake_case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2815254Z (pass) Case Conversion Utilities > toSnakeCase > should convert UPPER_CASE to snake_case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2816131Z (pass) Case Conversion Utilities > toSnakeCase > should handle already snake_case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2817160Z (pass) Case Conversion Utilities > toPascalCase > should convert camelCase to PascalCase [16.00ms]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2818126Z (pass) Case Conversion Utilities > toPascalCase > should convert kebab-case to PascalCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2819052Z (pass) Case Conversion Utilities > toPascalCase > should convert snake_case to PascalCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2820060Z (pass) Case Conversion Utilities > toPascalCase > should handle already PascalCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2826407Z (pass) getenv > should find variable in UPPER_CASE
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2827654Z (pass) getenv > should find variable in camelCase
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2828863Z (pass) getenv > should find variable in kebab-case
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2830091Z (pass) getenv > should return default value when not found
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2831414Z (pass) getenv > should return empty string as default when not specified
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2832536Z (pass) getenv > should try original key first
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.2982766Z (pass) makeConfig > Hero Example (defaults) > should work with minimal configuration [15.00ms]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3018574Z (pass) makeConfig > Hero Example (defaults) > should use CLI arguments with highest priority
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3049671Z (pass) makeConfig > Hero Example (defaults) > should convert kebab-case to camelCase in result
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3056644Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3082603Z (pass) makeConfig > Environment Loading Priority > should load .lenv file by default
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3087381Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3101316Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3120221Z (pass) makeConfig > Environment Loading Priority > should handle --configuration flag [16.00ms]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3125065Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3145072Z (pass) makeConfig > Environment Loading Priority > should prioritize CLI over environment
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3161823Z (pass) makeConfig > Environment Loading Priority > should handle missing .lenv file gracefully
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3166892Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3182824Z (pass) makeConfig > Case Conversion in Environment Loading > should convert all keys to UPPER_CASE in process.env
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3209544Z (pass) makeConfig > Case Conversion in Environment Loading > should find env vars in any case format via getenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3229407Z (pass) makeConfig > Configuration Options > should support disabling lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3251409Z (pass) makeConfig > Configuration Options > should support enabling env/dotenvx (deprecated)
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3268815Z (pass) makeConfig > Configuration Options > should support disabling getenv [16.00ms]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3284049Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3295255Z (pass) makeConfig > Configuration Options > should support configuration alias -c
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3301300Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3319110Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3326831Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3339884Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3350470Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3370071Z (pass) makeConfig > Complete Priority Chain > should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3414706Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --version option by calling .version(false)
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3442985Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --help option [15.00ms]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3462319Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with --version in strict mode
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3477736Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should handle --version with boolean type
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3498517Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow users to explicitly enable help
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3528780Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with multiple custom options including version
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3550967Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling built-in --version
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3569154Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling both --version and --help
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3586659Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow version with alias [16.00ms]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3604712Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow help with alias
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3621387Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should work with both built-in version/help and custom options
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3649941Z (pass) parseLinoArguments (legacy) > should parse simple links notation format
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3657021Z (pass) parseLinoArguments (legacy) > should parse arguments without parentheses
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3661136Z (pass) parseLinoArguments (legacy) > should handle empty input
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3661883Z (pass) parseLinoArguments (legacy) > should handle null input
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3668278Z (pass) parseLinoArguments (legacy) > should filter out comments
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3668711Z 
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3669163Z ##[endgroup]
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3669460Z 
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3669820Z  58 pass
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3670091Z  0 fail
+Test (bun on windows-latest)	Run tests (Bun)	2026-04-10T20:48:02.3670416Z Ran 58 tests across 1 file. [200.00ms]
+Test (bun on windows-latest)	Post Setup Bun	﻿2026-04-10T20:48:02.5397462Z Post job cleanup.
+Test (bun on windows-latest)	Post Setup Node.js (for npm install)	﻿2026-04-10T20:48:02.7750572Z Post job cleanup.
+Test (bun on windows-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:48:03.0207037Z Post job cleanup.
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.2429016Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.2782130Z git version 2.53.0.windows.2
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.2878322Z Temporarily overriding HOME='D:\a\_temp\f92b33f5-552d-4955-ad1e-9e0080cec9fe' before making global git config changes
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.2879669Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.2891537Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.3306037Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.3724828Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:03.9883748Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:04.0203662Z http.https://github.com/.extraheader
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:04.0258645Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:04.0602197Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:04.6269061Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:48:04.6592688Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (bun on windows-latest)	Complete job	﻿2026-04-10T20:48:05.2567615Z Cleaning up orphan processes
+Test (bun on windows-latest)	Complete job	2026-04-10T20:48:05.2607399Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (bun on macos-latest)	Set up job	﻿2026-04-10T20:47:12.2835280Z Current runner version: '2.333.1'
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2853270Z ##[group]Runner Image Provisioner
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2853830Z Hosted Compute Agent
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2854800Z Version: 20260213.493
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2855530Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2855970Z Build Date: 2026-02-13T00:28:41Z
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2856380Z Worker ID: {8aa738aa-1edf-4662-81e1-ae966592d01a}
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2856800Z Azure Region: westus
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2857120Z ##[endgroup]
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2858070Z ##[group]Operating System
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2858430Z macOS
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2858710Z 15.7.4
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2858980Z 24G517
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2859250Z ##[endgroup]
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2859540Z ##[group]Runner Image
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2859860Z Image: macos-15-arm64
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2860170Z Version: 20260406.0256.1
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2860840Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260406.0256/images/macos/macos-15-arm64-Readme.md
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2861900Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260406.0256
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2862490Z ##[endgroup]
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2866440Z ##[group]GITHUB_TOKEN Permissions
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2868060Z Actions: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2868370Z ArtifactMetadata: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2868680Z Attestations: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2868980Z Checks: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2869310Z Contents: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2869630Z Deployments: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2870760Z Discussions: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2871960Z Issues: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2872360Z Metadata: read
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2872700Z Models: read
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2873010Z Packages: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2873360Z Pages: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2873800Z PullRequests: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2874130Z RepositoryProjects: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2874500Z SecurityEvents: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2874820Z Statuses: write
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2875130Z ##[endgroup]
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2876920Z Secret source: Actions
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.2877370Z Prepare workflow directory
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.3226960Z Prepare all required actions
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.3286180Z Getting action download info
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:12.8338070Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:13.1500110Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:13.2755470Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:13.8496360Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (bun on macos-latest)	Set up job	2026-04-10T20:47:14.5280140Z Complete job name: Test (bun on macos-latest)
+Test (bun on macos-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:14.5901160Z ##[group]Run actions/checkout@v4
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5902000Z with:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5902550Z   repository: link-foundation/lino-arguments
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5903490Z   token: ***
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5903990Z   ssh-strict: true
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5904900Z   ssh-user: git
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5905430Z   persist-credentials: true
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5906000Z   clean: true
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5906520Z   sparse-checkout-cone-mode: true
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5907140Z   fetch-depth: 1
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5907660Z   fetch-tags: false
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5908160Z   show-progress: true
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5908680Z   lfs: false
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5909150Z   submodules: false
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5909660Z   set-safe-directory: true
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.5910370Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.9852180Z Syncing repository: link-foundation/lino-arguments
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.9855020Z ##[group]Getting Git version info
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.9856440Z Working directory is '/Users/runner/work/lino-arguments/lino-arguments'
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.9859690Z [command]/opt/homebrew/bin/git version
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0529870Z git version 2.53.0
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0560110Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0571920Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/35fa3f90-f2e8-4e97-b7c1-0f9069ee3fd4/.gitconfig'
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0580110Z Temporarily overriding HOME='/Users/runner/work/_temp/35fa3f90-f2e8-4e97-b7c1-0f9069ee3fd4' before making global git config changes
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0581970Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0584890Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0731130Z Deleting the contents of '/Users/runner/work/lino-arguments/lino-arguments'
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0735510Z ##[group]Initializing the repository
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.0743380Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-arguments/lino-arguments
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1042270Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1043790Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1045060Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1046010Z hint: call:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1046540Z hint:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1047120Z hint: 	git config --global init.defaultBranch <name>
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1047840Z hint:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1048510Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1049610Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1050500Z hint:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1050980Z hint: 	git branch -m <name>
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1051520Z hint:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1052240Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1053540Z Initialized empty Git repository in /Users/runner/work/lino-arguments/lino-arguments/.git/
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1058030Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1154470Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1155450Z ##[group]Disabling automatic garbage collection
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1156860Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1241450Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1242400Z ##[group]Setting up auth
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1243350Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.1313500Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.2363270Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.2423750Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.3191980Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.3259170Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.4118670Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.4195650Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.4196900Z ##[group]Fetching the repository
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.4206360Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0334080Z From https://github.com/link-foundation/lino-arguments
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0364450Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0494320Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0495620Z ##[group]Determining the checkout info
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0498610Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0499420Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0603110Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0713190Z ##[group]Checking out the ref
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0728570Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1240000Z Switched to a new branch 'main'
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1250330Z branch 'main' set up to track 'origin/main'.
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1256030Z ##[endgroup]
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1349760Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (bun on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1418870Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (bun on macos-latest)	Setup Node.js (for npm install)	﻿2026-04-10T20:47:16.1720080Z ##[group]Run actions/setup-node@v4
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.1720760Z with:
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.1721210Z   node-version: 20.x
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.1721710Z   always-auth: false
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.1722200Z   check-latest: false
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.1722940Z   token: ***
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.1723390Z ##[endgroup]
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.3593840Z Found in cache @ /Users/runner/hostedtoolcache/node/20.20.2/arm64
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:16.3598160Z ##[group]Environment details
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1553640Z node: v20.20.2
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1572410Z npm: 10.8.2
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1575370Z yarn: 1.22.22
+Test (bun on macos-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:17.1583910Z ##[endgroup]
+Test (bun on macos-latest)	Setup Bun	﻿2026-04-10T20:47:17.1720060Z ##[group]Run oven-sh/setup-bun@v2
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:17.1720470Z with:
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:17.1720650Z   bun-version: latest
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:17.1720840Z   no-cache: false
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:17.1721230Z   token: ***
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:17.1721390Z ##[endgroup]
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:18.1290580Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-darwin-aarch64.zip
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:18.6728900Z [command]/usr/bin/unzip -o -q /Users/runner/work/_temp/f9fe4dda-b84e-4224-b4e8-760753bd162f.zip
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:19.2539760Z [command]/Users/runner/.bun/bin/bun --revision
+Test (bun on macos-latest)	Setup Bun	2026-04-10T20:47:19.2724350Z 1.3.12+700fc117a
+Test (bun on macos-latest)	Install dependencies (Bun)	﻿2026-04-10T20:47:19.3043350Z ##[group]Run npm install
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:19.3043840Z [36;1mnpm install[0m
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:19.3097170Z shell: /bin/bash -e {0}
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:19.3097550Z ##[endgroup]
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.6839620Z 
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.6844200Z > lino-arguments@0.3.0 prepare
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.6881710Z > husky || true
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.6898070Z 
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8163990Z .git can't be found
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8202680Z added 234 packages, and audited 235 packages in 3s
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8224180Z 
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8225170Z 59 packages are looking for funding
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8225710Z   run `npm fund` for details
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8226160Z 
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8226520Z 7 vulnerabilities (4 moderate, 3 high)
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8226770Z 
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8227020Z To address all issues, run:
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8228440Z   npm audit fix
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8228790Z 
+Test (bun on macos-latest)	Install dependencies (Bun)	2026-04-10T20:47:22.8228990Z Run `npm audit` for details.
+Test (bun on macos-latest)	Run tests (Bun)	﻿2026-04-10T20:47:22.8720360Z ##[group]Run bun test
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:22.8720660Z [36;1mbun test[0m
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:22.8755930Z shell: /bin/bash -e {0}
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:22.8756190Z ##[endgroup]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:22.9481630Z bun test v1.3.12 (700fc117)
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:22.9634710Z 
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:22.9649880Z ##[group]tests/index.test.js:
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0111850Z (pass) Case Conversion Utilities > toUpperCase > should convert camelCase to UPPER_CASE
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0113250Z (pass) Case Conversion Utilities > toUpperCase > should convert kebab-case to UPPER_CASE
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0114030Z (pass) Case Conversion Utilities > toUpperCase > should convert snake_case to UPPER_CASE
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0114710Z (pass) Case Conversion Utilities > toUpperCase > should convert PascalCase to UPPER_CASE
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0115500Z (pass) Case Conversion Utilities > toUpperCase > should handle already UPPER_CASE
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0117950Z (pass) Case Conversion Utilities > toCamelCase > should convert kebab-case to camelCase [0.15ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0125630Z (pass) Case Conversion Utilities > toCamelCase > should convert UPPER_CASE to camelCase
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0126440Z (pass) Case Conversion Utilities > toCamelCase > should convert snake_case to camelCase [0.07ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0127210Z (pass) Case Conversion Utilities > toCamelCase > should convert PascalCase to camelCase [0.02ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0127890Z (pass) Case Conversion Utilities > toCamelCase > should handle already camelCase [0.04ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0128720Z (pass) Case Conversion Utilities > toKebabCase > should convert camelCase to kebab-case [0.05ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0129410Z (pass) Case Conversion Utilities > toKebabCase > should convert UPPER_CASE to kebab-case [0.03ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0130120Z (pass) Case Conversion Utilities > toKebabCase > should convert PascalCase to kebab-case [0.01ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0130860Z (pass) Case Conversion Utilities > toKebabCase > should handle already kebab-case [0.01ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0131580Z (pass) Case Conversion Utilities > toSnakeCase > should convert camelCase to snake_case [0.03ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0132280Z (pass) Case Conversion Utilities > toSnakeCase > should convert kebab-case to snake_case [0.02ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0133100Z (pass) Case Conversion Utilities > toSnakeCase > should convert UPPER_CASE to snake_case
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0133700Z (pass) Case Conversion Utilities > toSnakeCase > should handle already snake_case
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0136160Z (pass) Case Conversion Utilities > toPascalCase > should convert camelCase to PascalCase
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0138150Z (pass) Case Conversion Utilities > toPascalCase > should convert kebab-case to PascalCase [0.06ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0139510Z (pass) Case Conversion Utilities > toPascalCase > should convert snake_case to PascalCase
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0140140Z (pass) Case Conversion Utilities > toPascalCase > should handle already PascalCase [0.03ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0140700Z (pass) getenv > should find variable in UPPER_CASE
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0141060Z (pass) getenv > should find variable in camelCase
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0141380Z (pass) getenv > should find variable in kebab-case
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0141750Z (pass) getenv > should return default value when not found
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0142190Z (pass) getenv > should return empty string as default when not specified
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0142640Z (pass) getenv > should try original key first
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0234390Z (pass) makeConfig > Hero Example (defaults) > should work with minimal configuration [10.60ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0255840Z (pass) makeConfig > Hero Example (defaults) > should use CLI arguments with highest priority [3.12ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0282730Z (pass) makeConfig > Hero Example (defaults) > should convert kebab-case to camelCase in result [2.12ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0294740Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0312610Z (pass) makeConfig > Environment Loading Priority > should load .lenv file by default [3.42ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0318900Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0328250Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0344480Z (pass) makeConfig > Environment Loading Priority > should handle --configuration flag [2.58ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0351960Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0371820Z (pass) makeConfig > Environment Loading Priority > should prioritize CLI over environment [2.97ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0378880Z (pass) makeConfig > Environment Loading Priority > should handle missing .lenv file gracefully [1.12ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0381480Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0391190Z (pass) makeConfig > Case Conversion in Environment Loading > should convert all keys to UPPER_CASE in process.env [1.22ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0400330Z (pass) makeConfig > Case Conversion in Environment Loading > should find env vars in any case format via getenv [1.15ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0410620Z (pass) makeConfig > Configuration Options > should support disabling lenv [0.53ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0443990Z (pass) makeConfig > Configuration Options > should support enabling env/dotenvx (deprecated) [1.95ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0445200Z (pass) makeConfig > Configuration Options > should support disabling getenv [1.25ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0457870Z 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0460420Z (pass) makeConfig > Configuration Options > should support configuration alias -c [1.87ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0471380Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0489480Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0490880Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0492800Z 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0502970Z 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0510030Z (pass) makeConfig > Complete Priority Chain > should demonstrate full priority: CLI > getenv > --configuration > .lenv [4.00ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0529740Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --version option by calling .version(false) [1.52ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0531000Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow user-defined --help option [1.53ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0562690Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with --version in strict mode [3.44ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0582470Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should handle --version with boolean type [0.51ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0607240Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should allow users to explicitly enable help [2.16ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0640520Z (pass) makeConfig > Built-in Flag Conflicts (Issue #14) > should work with multiple custom options including version
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0645610Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling built-in --version [2.36ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0648080Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow explicitly enabling both --version and --help
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0649170Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow version with alias
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0653500Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should allow help with alias [1.32ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0655740Z (pass) makeConfig > Explicitly Enabling Built-in Version and Help > should work with both built-in version/help and custom options [1.56ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0682600Z (pass) parseLinoArguments (legacy) > should parse simple links notation format [3.10ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0684030Z (pass) parseLinoArguments (legacy) > should parse arguments without parentheses [0.89ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0684900Z (pass) parseLinoArguments (legacy) > should handle empty input [0.29ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0685910Z (pass) parseLinoArguments (legacy) > should handle null input
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0691260Z (pass) parseLinoArguments (legacy) > should filter out comments [0.42ms]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0699290Z 
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0700320Z ##[endgroup]
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0700580Z 
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0701020Z  58 pass
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0701470Z  0 fail
+Test (bun on macos-latest)	Run tests (Bun)	2026-04-10T20:47:23.0709840Z Ran 58 tests across 1 file. [121.00ms]
+Test (bun on macos-latest)	Post Setup Bun	﻿2026-04-10T20:47:23.0800000Z Post job cleanup.
+Test (bun on macos-latest)	Post Setup Node.js (for npm install)	﻿2026-04-10T20:47:23.4028770Z Post job cleanup.
+Test (bun on macos-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:23.6592470Z Post job cleanup.
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.7983110Z [command]/opt/homebrew/bin/git version
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8070220Z git version 2.53.0
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8116390Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/a69d0a5e-b5ec-4ad1-a5b2-ef358066978a/.gitconfig'
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8125450Z Temporarily overriding HOME='/Users/runner/work/_temp/a69d0a5e-b5ec-4ad1-a5b2-ef358066978a' before making global git config changes
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8126240Z Adding repository directory to the temporary git global config as a safe directory
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8136690Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8214050Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.8320450Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.9562970Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.9626790Z http.https://github.com/.extraheader
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.9641130Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.9777020Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:24.1389340Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (bun on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:24.1701930Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (bun on macos-latest)	Complete job	﻿2026-04-10T20:47:24.3305610Z Cleaning up orphan processes
+Test (bun on macos-latest)	Complete job	2026-04-10T20:47:24.4265640Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (deno on windows-latest)	Set up job	﻿2026-04-10T20:47:12.0890772Z Current runner version: '2.333.1'
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1009508Z ##[group]Runner Image Provisioner
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1010744Z Hosted Compute Agent
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1011645Z Version: 20260213.493
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1012638Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1013754Z Build Date: 2026-02-13T00:28:41Z
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1014827Z Worker ID: {ef1a7e8c-acd0-477c-8a75-514ccfc8c180}
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1016041Z Azure Region: centralus
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1016874Z ##[endgroup]
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1018833Z ##[group]Operating System
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1019774Z Microsoft Windows Server 2025
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1020983Z 10.0.26100
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1021743Z Datacenter
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1022471Z ##[endgroup]
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1023146Z ##[group]Runner Image
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1024094Z Image: windows-2025
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1024813Z Version: 20260405.77.1
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1026426Z Included Software: https://github.com/actions/runner-images/blob/win25/20260405.77/images/windows/Windows2025-Readme.md
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1029862Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20260405.77
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1031399Z ##[endgroup]
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1036134Z ##[group]GITHUB_TOKEN Permissions
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1039091Z Actions: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1040010Z ArtifactMetadata: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1040757Z Attestations: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1041490Z Checks: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1042176Z Contents: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1042913Z Deployments: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1043590Z Discussions: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1044314Z Issues: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1044967Z Metadata: read
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1045712Z Models: read
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1046344Z Packages: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1047067Z Pages: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1048529Z PullRequests: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1049363Z RepositoryProjects: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1050225Z SecurityEvents: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1050968Z Statuses: write
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1051754Z ##[endgroup]
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1054694Z Secret source: Actions
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1055793Z Prepare workflow directory
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1503201Z Prepare all required actions
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.1559931Z Getting action download info
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.4908855Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.6106432Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:12.7697604Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:13.2316019Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (deno on windows-latest)	Set up job	2026-04-10T20:47:13.8866783Z Complete job name: Test (deno on windows-latest)
+Test (deno on windows-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:14.0209618Z ##[group]Run actions/checkout@v4
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0210990Z with:
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0211761Z   repository: link-foundation/lino-arguments
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0213025Z   token: ***
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0213703Z   ssh-strict: true
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0214402Z   ssh-user: git
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0215110Z   persist-credentials: true
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0215927Z   clean: true
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0216635Z   sparse-checkout-cone-mode: true
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0217500Z   fetch-depth: 1
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0218195Z   fetch-tags: false
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0218904Z   show-progress: true
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0219623Z   lfs: false
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0220291Z   submodules: false
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0221031Z   set-safe-directory: true
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0222028Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.1910625Z Syncing repository: link-foundation/lino-arguments
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.1913112Z ##[group]Getting Git version info
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.1914292Z Working directory is 'D:\a\lino-arguments\lino-arguments'
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2859713Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.6491482Z git version 2.53.0.windows.2
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.6549918Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.6571063Z Temporarily overriding HOME='D:\a\_temp\8b8614d7-5aab-4915-8284-80649419fb90' before making global git config changes
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.6573275Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.6581900Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.7131983Z Deleting the contents of 'D:\a\lino-arguments\lino-arguments'
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.7138633Z ##[group]Initializing the repository
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.7148800Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-arguments\lino-arguments
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.7968804Z Initialized empty Git repository in D:/a/lino-arguments/lino-arguments/.git/
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8018817Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-arguments
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8553831Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8555228Z ##[group]Disabling automatic garbage collection
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8570827Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8927861Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8929107Z ##[group]Setting up auth
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.8951863Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.9273958Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2824690Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.3133835Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.8482303Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.8809302Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.4078828Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.4376325Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.4377210Z ##[group]Fetching the repository
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.4389758Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.5871790Z From https://github.com/link-foundation/lino-arguments
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.5874891Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.6248232Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.6248917Z ##[group]Determining the checkout info
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.6251667Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.6263428Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.6715125Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.7008685Z ##[group]Checking out the ref
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.7017700Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.7815933Z Switched to a new branch 'main'
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.7871326Z branch 'main' set up to track 'origin/main'.
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.7922231Z ##[endgroup]
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.8341113Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (deno on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:18.8669112Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (deno on windows-latest)	Setup Node.js (for npm install)	﻿2026-04-10T20:47:18.9232345Z ##[group]Run actions/setup-node@v4
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:18.9233404Z with:
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:18.9233575Z   node-version: 20.x
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:18.9233792Z   always-auth: false
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:18.9233978Z   check-latest: false
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:18.9234309Z   token: ***
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:18.9234481Z ##[endgroup]
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:19.1770296Z Found in cache @ C:\hostedtoolcache\windows\node\20.20.2\x64
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:19.1785207Z ##[group]Environment details
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:23.5766680Z node: v20.20.2
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:23.5767242Z npm: 10.8.2
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:23.5767463Z yarn: 1.22.22
+Test (deno on windows-latest)	Setup Node.js (for npm install)	2026-04-10T20:47:23.5769209Z ##[endgroup]
+Test (deno on windows-latest)	Setup Deno	﻿2026-04-10T20:47:23.6051616Z ##[group]Run denoland/setup-deno@v2
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.6051938Z with:
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.6052107Z   deno-version: v2.x
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.6052305Z   deno-binary-name: deno
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.6052489Z   cache: false
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.6052654Z ##[endgroup]
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.9191310Z Going to install stable version 2.7.12.
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:23.9205477Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.7.12/deno-x86_64-pc-windows-msvc.zip.
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:24.7464675Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\3bc59186-b5d7-4899-aa23-3eb62ac125e8', 'D:\a\_temp\444823de-39ab-433d-9fa6-6a43f1a01852', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\3bc59186-b5d7-4899-aa23-3eb62ac125e8' -DestinationPath 'D:\a\_temp\444823de-39ab-433d-9fa6-6a43f1a01852' -Force } else { throw $_ } } ;"
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:30.6657968Z Cached Deno to C:\hostedtoolcache\windows\deno\2.7.12\x64.
+Test (deno on windows-latest)	Setup Deno	2026-04-10T20:47:30.6672127Z Installation complete.
+Test (deno on windows-latest)	Install dependencies (Deno)	﻿2026-04-10T20:47:30.6941095Z ##[group]Run npm install
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:30.6941448Z [36;1mnpm install[0m
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:30.7002444Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:30.7002794Z ##[endgroup]
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.4146796Z 
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.4147451Z > lino-arguments@0.3.0 prepare
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.4148220Z > husky || true
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.4148478Z 
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5112643Z .git can't be found
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5113343Z added 234 packages, and audited 235 packages in 7s
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5113801Z 
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5114256Z 59 packages are looking for funding
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5114763Z   run `npm fund` for details
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5209460Z 
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5210026Z 7 vulnerabilities (4 moderate, 3 high)
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5210497Z 
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5210839Z To address all issues, run:
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5211356Z   npm audit fix
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5211698Z 
+Test (deno on windows-latest)	Install dependencies (Deno)	2026-04-10T20:47:38.5212064Z Run `npm audit` for details.
+Test (deno on windows-latest)	Run tests (Deno)	﻿2026-04-10T20:47:38.7964250Z ##[group]Run deno test --allow-read --allow-env --allow-write
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:38.7964838Z [36;1mdeno test --allow-read --allow-env --allow-write[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:38.8032726Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:38.8033192Z ##[endgroup]
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1408971Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fcli
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1420493Z [0m[32mDownload[0m https://registry.npmjs.org/eslint
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1421498Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1422142Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1680129Z [0m[32mDownload[0m https://registry.npmjs.org/getenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1685210Z [0m[32mDownload[0m https://registry.npmjs.org/husky
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1686207Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1687505Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1688906Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1689630Z [0m[32mDownload[0m https://registry.npmjs.org/prettier
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.1850464Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.2014865Z [0m[32mDownload[0m https://registry.npmjs.org/yargs
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4654089Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fapply-release-plan
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4655188Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fassemble-release-plan
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4656469Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fchangelog-git
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4658005Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fconfig
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4659787Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ferrors
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4661017Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-dependents-graph
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4662356Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-release-plan
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4663462Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fgit
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4664499Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2flogger
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4666024Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fpre
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4667339Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fread
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4668550Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fshould-skip-package
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4669689Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2ftypes
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4670732Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fwrite
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4671839Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer%2fexternal-editor
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4672945Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2fget-packages
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4673943Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4674781Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4675587Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4676430Z [0m[32mDownload[0m https://registry.npmjs.org/mri
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4677390Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4678405Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4679346Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4680197Z [0m[32mDownload[0m https://registry.npmjs.org/semver
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4681074Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4681966Z [0m[32mDownload[0m https://registry.npmjs.org/term-size
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4683001Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2feslint-utils
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4686648Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community%2fregexpp
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4688090Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-array
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4689265Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fconfig-helpers
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4690291Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fcore
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4691281Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2feslintrc
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4692235Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fjs
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4693222Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fplugin-kit
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4694225Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fnode
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4695318Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fmodule-importer
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4696437Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes%2fretry
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4697711Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2festree
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4698625Z [0m[32mDownload[0m https://registry.npmjs.org/ajv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4699461Z [0m[32mDownload[0m https://registry.npmjs.org/chalk
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4700325Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4701178Z [0m[32mDownload[0m https://registry.npmjs.org/debug
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4702112Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4703059Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4704025Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4704946Z [0m[32mDownload[0m https://registry.npmjs.org/espree
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4705761Z [0m[32mDownload[0m https://registry.npmjs.org/esquery
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4706586Z [0m[32mDownload[0m https://registry.npmjs.org/esutils
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4707810Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4708831Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4709747Z [0m[32mDownload[0m https://registry.npmjs.org/find-up
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4710635Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4711482Z [0m[32mDownload[0m https://registry.npmjs.org/ignore
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4712343Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4713196Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4714002Z [0m[32mDownload[0m https://registry.npmjs.org/jiti
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4715099Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4716198Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4717091Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4718032Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4718966Z [0m[32mDownload[0m https://registry.npmjs.org/optionator
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4719886Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2feslint
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4720923Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4721856Z [0m[32mDownload[0m https://registry.npmjs.org/synckit
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4722673Z [0m[32mDownload[0m https://registry.npmjs.org/commander
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4723556Z [0m[32mDownload[0m https://registry.npmjs.org/listr2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4724409Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4725274Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4726151Z [0m[32mDownload[0m https://registry.npmjs.org/tinyexec
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4726964Z [0m[32mDownload[0m https://registry.npmjs.org/yaml
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4728140Z [0m[32mDownload[0m https://registry.npmjs.org/cliui
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4730541Z [0m[32mDownload[0m https://registry.npmjs.org/escalade
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4731487Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4732497Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4733462Z [0m[32mDownload[0m https://registry.npmjs.org/string-width
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4734334Z [0m[32mDownload[0m https://registry.npmjs.org/y18n
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.4735223Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6529090Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fget-version-range-type
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6530046Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6530638Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6532399Z [0m[32mDownload[0m https://registry.npmjs.org/outdent
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6533494Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6536297Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6537349Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6538335Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets%2fparse
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6539273Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6540102Z [0m[32mDownload[0m https://registry.npmjs.org/human-id
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6541378Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fnode
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6542495Z [0m[32mDownload[0m https://registry.npmjs.org/chardet
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6543324Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6544638Z [0m[32mDownload[0m https://registry.npmjs.org/@babel%2fruntime
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6545741Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg%2ffind-root
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6546704Z [0m[32mDownload[0m https://registry.npmjs.org/globby
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6547616Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6548553Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6549434Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6550295Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6551182Z [0m[32mDownload[0m https://registry.npmjs.org/universalify
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6552062Z [0m[32mDownload[0m https://registry.npmjs.org/quansync
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6552903Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6553888Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint%2fobject-schema
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6554911Z [0m[32mDownload[0m https://registry.npmjs.org/@types%2fjson-schema
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6555818Z [0m[32mDownload[0m https://registry.npmjs.org/globals
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6556678Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6557538Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6558437Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6559347Z [0m[32mDownload[0m https://registry.npmjs.org/levn
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6560203Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs%2fcore
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6561216Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6562777Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6563747Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6564616Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6565550Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6566389Z [0m[32mDownload[0m https://registry.npmjs.org/path-key
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6567323Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6568210Z [0m[32mDownload[0m https://registry.npmjs.org/which
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6569341Z [0m[32mDownload[0m https://registry.npmjs.org/ms
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6570164Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6571039Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6571865Z [0m[32mDownload[0m https://registry.npmjs.org/acorn
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6572688Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6573537Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6574388Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6575272Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6576140Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6577045Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6577919Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6579026Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6579942Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6580804Z [0m[32mDownload[0m https://registry.npmjs.org/type-check
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6581673Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6582834Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6583746Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr%2fcore
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6584655Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6585545Z [0m[32mDownload[0m https://registry.npmjs.org/colorette
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6586434Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6587259Z [0m[32mDownload[0m https://registry.npmjs.org/log-update
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6588022Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6588792Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6589582Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.6590483Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.7519483Z [0m[32mDownload[0m https://registry.npmjs.org/braces
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.7557061Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.7765280Z [0m[32mDownload[0m https://registry.npmjs.org/p-map
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8248248Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8249712Z [0m[32mDownload[0m https://registry.npmjs.org/array-union
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8251094Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8252000Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8252885Z [0m[32mDownload[0m https://registry.npmjs.org/merge2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8253742Z [0m[32mDownload[0m https://registry.npmjs.org/slash
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8254547Z [0m[32mDownload[0m https://registry.npmjs.org/pify
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8255430Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8256344Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8257231Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8258091Z [0m[32mDownload[0m https://registry.npmjs.org/argparse
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8258903Z [0m[32mDownload[0m https://registry.npmjs.org/punycode
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8259770Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8260620Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8261795Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8262689Z [0m[32mDownload[0m https://registry.npmjs.org/isexe
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8263507Z [0m[32mDownload[0m https://registry.npmjs.org/flatted
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8264628Z [0m[32mDownload[0m https://registry.npmjs.org/keyv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8265813Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8266683Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8267513Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8268306Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8269068Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8269858Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8270588Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8271299Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8786951Z [0m[32mDownload[0m https://registry.npmjs.org/path-type
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8790071Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.stat
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8791453Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.walk
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8792344Z [0m[32mDownload[0m https://registry.npmjs.org/esprima
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8793210Z [0m[32mDownload[0m https://registry.npmjs.org/callsites
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8794844Z [0m[32mDownload[0m https://registry.npmjs.org/color-name
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8796071Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8797365Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8798178Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8798738Z [0m[32mDownload[0m https://registry.npmjs.org/environment
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8799256Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.8799760Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9255856Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib%2ffs.scandir
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9257286Z [0m[32mDownload[0m https://registry.npmjs.org/fastq
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9258624Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9476596Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9477368Z [0m[32mDownload[0m https://registry.npmjs.org/onetime
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9478702Z [0m[32mDownload[0m https://registry.npmjs.org/is-number
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9675676Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9676305Z [0m[32mDownload[0m https://registry.npmjs.org/reusify
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9804765Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:39.9805576Z [0m[32mDownload[0m https://registry.npmjs.org/p-try
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0022637Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0527281Z [0m[32mDownload[0m https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0528724Z [0m[32mDownload[0m https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0529873Z [0m[32mDownload[0m https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0531103Z [0m[32mDownload[0m https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0532852Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0534347Z [0m[32mDownload[0m https://registry.npmjs.org/lino-env/-/lino-env-0.2.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0535303Z [0m[32mDownload[0m https://registry.npmjs.org/husky/-/husky-9.1.7.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0536295Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/cli/-/cli-2.30.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0537264Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0539296Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0540713Z [0m[32mDownload[0m https://registry.npmjs.org/test-anywhere/-/test-anywhere-0.6.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0543467Z [0m[32mDownload[0m https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0544414Z [0m[32mDownload[0m https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0545573Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0546684Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0547521Z [0m[32mDownload[0m https://registry.npmjs.org/espree/-/espree-10.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0548406Z [0m[32mDownload[0m https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0549286Z [0m[32mDownload[0m https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0550444Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0551684Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0552987Z [0m[32mDownload[0m https://registry.npmjs.org/debug/-/debug-4.4.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0553716Z [0m[32mDownload[0m https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0554779Z [0m[32mDownload[0m https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0555808Z [0m[32mDownload[0m https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0556888Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0557735Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0558905Z [0m[32mDownload[0m https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0560306Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0561525Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0562481Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0563644Z [0m[32mDownload[0m https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0564806Z [0m[32mDownload[0m https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0565931Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0566925Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0567670Z [0m[32mDownload[0m https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0568551Z [0m[32mDownload[0m https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0569580Z [0m[32mDownload[0m https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0571035Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0572153Z [0m[32mDownload[0m https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0573164Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0573955Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0575213Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0576619Z [0m[32mDownload[0m https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0577834Z [0m[32mDownload[0m https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0578784Z [0m[32mDownload[0m https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0580017Z [0m[32mDownload[0m https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0581934Z [0m[32mDownload[0m https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0583070Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0584399Z [0m[32mDownload[0m https://registry.npmjs.org/commander/-/commander-14.0.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0585209Z [0m[32mDownload[0m https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0586159Z [0m[32mDownload[0m https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0587173Z [0m[32mDownload[0m https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0588205Z [0m[32mDownload[0m https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0589362Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/config/-/config-3.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0591315Z [0m[32mDownload[0m https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0592442Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0593917Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0595109Z [0m[32mDownload[0m https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0596098Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0596971Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0598051Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0599209Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0600137Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0601119Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0602131Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0603375Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0605158Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0606139Z [0m[32mDownload[0m https://registry.npmjs.org/mri/-/mri-1.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0606977Z [0m[32mDownload[0m https://registry.npmjs.org/semver/-/semver-7.7.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0607785Z [0m[32mDownload[0m https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0608521Z [0m[32mDownload[0m https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0609838Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.15.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0611305Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0612193Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0613341Z [0m[32mDownload[0m https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0614982Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0616120Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0617057Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0618246Z [0m[32mDownload[0m https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0619512Z [0m[32mDownload[0m https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0620647Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0621535Z [0m[32mDownload[0m https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0622452Z [0m[32mDownload[0m https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0623563Z [0m[32mDownload[0m https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0624713Z [0m[32mDownload[0m https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0625642Z [0m[32mDownload[0m https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0626854Z [0m[32mDownload[0m https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0627999Z [0m[32mDownload[0m https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0629197Z [0m[32mDownload[0m https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0630692Z [0m[32mDownload[0m https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0631902Z [0m[32mDownload[0m https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0633086Z [0m[32mDownload[0m https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0634175Z [0m[32mDownload[0m https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0635025Z [0m[32mDownload[0m https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0635806Z [0m[32mDownload[0m https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0637031Z [0m[32mDownload[0m https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0638110Z [0m[32mDownload[0m https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0639143Z [0m[32mDownload[0m https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0640060Z [0m[32mDownload[0m https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0641211Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0642406Z [0m[32mDownload[0m https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0643324Z [0m[32mDownload[0m https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0644551Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0645663Z [0m[32mDownload[0m https://registry.npmjs.org/which/-/which-2.0.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0646692Z [0m[32mDownload[0m https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0647850Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0648894Z [0m[32mDownload[0m https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0649506Z [0m[32mDownload[0m https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0650548Z [0m[32mDownload[0m https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0651649Z [0m[32mDownload[0m https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0652583Z [0m[32mDownload[0m https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0653384Z [0m[32mDownload[0m https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0654236Z [0m[32mDownload[0m https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0655521Z [0m[32mDownload[0m https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0656622Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0657600Z [0m[32mDownload[0m https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0659030Z [0m[32mDownload[0m https://registry.npmjs.org/globals/-/globals-14.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0660279Z [0m[32mDownload[0m https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0661352Z [0m[32mDownload[0m https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0662271Z [0m[32mDownload[0m https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0663339Z [0m[32mDownload[0m https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0664687Z [0m[32mDownload[0m https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0665635Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0666454Z [0m[32mDownload[0m https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0667864Z [0m[32mDownload[0m https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0668960Z [0m[32mDownload[0m https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0669894Z [0m[32mDownload[0m https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0670804Z [0m[32mDownload[0m https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0671902Z [0m[32mDownload[0m https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0672986Z [0m[32mDownload[0m https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0673902Z [0m[32mDownload[0m https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0674764Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0675883Z [0m[32mDownload[0m https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0677074Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0678060Z [0m[32mDownload[0m https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0678950Z [0m[32mDownload[0m https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0680087Z [0m[32mDownload[0m https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0681149Z [0m[32mDownload[0m https://registry.npmjs.org/globby/-/globby-11.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0681857Z [0m[32mDownload[0m https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0682763Z [0m[32mDownload[0m https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0683752Z [0m[32mDownload[0m https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0685247Z [0m[32mDownload[0m https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0686414Z [0m[32mDownload[0m https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0687571Z [0m[32mDownload[0m https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0688920Z [0m[32mDownload[0m https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0689986Z [0m[32mDownload[0m https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0690897Z [0m[32mDownload[0m https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0692047Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0693133Z [0m[32mDownload[0m https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0694110Z [0m[32mDownload[0m https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0694957Z [0m[32mDownload[0m https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0696944Z [0m[32mDownload[0m https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0698041Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0699154Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0700214Z [0m[32mDownload[0m https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0701265Z [0m[32mDownload[0m https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0702263Z [0m[32mDownload[0m https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0703213Z [0m[32mDownload[0m https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0704191Z [0m[32mDownload[0m https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0705592Z [0m[32mDownload[0m https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0706756Z [0m[32mDownload[0m https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0707676Z [0m[32mDownload[0m https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0708501Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0709638Z [0m[32mDownload[0m https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0710717Z [0m[32mDownload[0m https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0711656Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0712575Z [0m[32mDownload[0m https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0713549Z [0m[32mDownload[0m https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0714598Z [0m[32mDownload[0m https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0715545Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0716457Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0717596Z [0m[32mDownload[0m https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0718585Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0719522Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0720438Z [0m[32mDownload[0m https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0721554Z [0m[32mDownload[0m https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0722510Z [0m[32mDownload[0m https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0723387Z [0m[32mDownload[0m https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0724274Z [0m[32mDownload[0m https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0725865Z [0m[32mDownload[0m https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0727063Z [0m[32mDownload[0m https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0727847Z [0m[32mDownload[0m https://registry.npmjs.org/pify/-/pify-4.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0728462Z [0m[32mDownload[0m https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0729469Z [0m[32mDownload[0m https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0730489Z [0m[32mDownload[0m https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0731400Z [0m[32mDownload[0m https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0732283Z [0m[32mDownload[0m https://registry.npmjs.org/slash/-/slash-3.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0733910Z [0m[32mDownload[0m https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0735488Z [0m[32mDownload[0m https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0736586Z [0m[32mDownload[0m https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0737649Z [0m[32mDownload[0m https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0738687Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0739807Z [0m[32mDownload[0m https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0740887Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0741633Z [0m[32mDownload[0m https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0742532Z [0m[32mDownload[0m https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0743745Z [0m[32mDownload[0m https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0745344Z [0m[32mDownload[0m https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0746329Z [0m[32mDownload[0m https://registry.npmjs.org/environment/-/environment-1.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0747432Z [0m[32mDownload[0m https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0748695Z [0m[32mDownload[0m https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0749991Z [0m[32mDownload[0m https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0750843Z [0m[32mDownload[0m https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0751882Z [0m[32mDownload[0m https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0752970Z [0m[32mDownload[0m https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0754058Z [0m[32mDownload[0m https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0754877Z [0m[32mDownload[0m https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0755633Z [0m[32mDownload[0m https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0756489Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0757868Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0758809Z [0m[32mDownload[0m https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0759451Z [0m[32mDownload[0m https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0760242Z [0m[32mDownload[0m https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0761412Z [0m[32mDownload[0m https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0762591Z [0m[32mDownload[0m https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0763234Z [0m[32mDownload[0m https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0763881Z [0m[32mDownload[0m https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0764696Z [0m[32mDownload[0m https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0765805Z [0m[32mDownload[0m https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0766845Z [0m[32mDownload[0m https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0767448Z [0m[32mDownload[0m https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0768063Z [0m[32mDownload[0m https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0768664Z [0m[32mDownload[0m https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0769387Z [0m[32mDownload[0m https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.0770031Z [0m[32mDownload[0m https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1268868Z [0m[32mInitialize[0m eslint-plugin-prettier@5.5.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1418281Z [0m[32mInitialize[0m eslint-visitor-keys@4.2.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1469572Z [0m[32mInitialize[0m glob-parent@6.0.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1585887Z [0m[32mInitialize[0m husky@9.1.7
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1811900Z [0m[32mInitialize[0m natural-compare@1.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1820732Z [0m[32mInitialize[0m debug@4.4.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1850895Z [0m[32mInitialize[0m lodash.merge@4.6.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.1882341Z [0m[32mInitialize[0m escape-string-regexp@4.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.2154207Z [0m[32mInitialize[0m espree@10.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5027328Z [0m[32mInitialize[0m esquery@1.7.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5084006Z [0m[32mInitialize[0m eslint-config-prettier@10.1.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5170851Z [0m[32mInitialize[0m getenv@2.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5276178Z [0m[32mInitialize[0m listr2@9.0.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5277560Z [0m[32mInitialize[0m minimatch@3.1.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5314742Z [0m[32mInitialize[0m commander@14.0.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5463396Z [0m[32mInitialize[0m json-stable-stringify-without-jsonify@1.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5527706Z [0m[32mInitialize[0m find-up@5.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5694190Z [0m[32mInitialize[0m acorn-jsx@5.3.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5739077Z [0m[32mInitialize[0m eslint-scope@8.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5885169Z [0m[32mInitialize[0m links-notation@0.11.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5920054Z [0m[32mInitialize[0m string-argv@0.3.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.5921453Z [0m[32mInitialize[0m term-size@2.2.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6079781Z [0m[32mInitialize[0m cross-spawn@7.0.6
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6080524Z [0m[32mInitialize[0m prettier-linter-helpers@1.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6122317Z [0m[32mInitialize[0m resolve-from@5.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6241711Z [0m[32mInitialize[0m supports-color@7.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6313214Z [0m[32mInitialize[0m ansi-styles@4.3.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6609411Z [0m[32mInitialize[0m lint-staged@16.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6652592Z [0m[32mInitialize[0m string-width@4.2.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6666985Z [0m[32mInitialize[0m get-caller-file@2.0.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6794003Z [0m[32mInitialize[0m imurmurhash@0.1.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6959048Z [0m[32mInitialize[0m lino-env@0.2.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:40.6960748Z [0m[32mInitialize[0m ignore@5.3.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2077755Z [0m[32mInitialize[0m is-glob@4.0.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2078856Z [0m[32mInitialize[0m shebang-command@2.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2247659Z [0m[32mInitialize[0m @types/estree@1.0.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2424864Z [0m[32mInitialize[0m fast-deep-equal@3.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2460572Z [0m[32mInitialize[0m fs-extra@7.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2607072Z [0m[32mInitialize[0m esutils@2.0.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2608273Z [0m[32mInitialize[0m is-extglob@2.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2739525Z [0m[32mInitialize[0m cliui@8.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2884787Z [0m[32mInitialize[0m y18n@5.0.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2902316Z [0m[32mInitialize[0m require-directory@2.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.2949170Z [0m[32mInitialize[0m @eslint-community/regexpp@4.12.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3109396Z [0m[32mInitialize[0m package-manager-detector@0.2.11
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3335231Z [0m[32mInitialize[0m @changesets/cli@2.30.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3504999Z [0m[32mInitialize[0m @eslint/config-array@0.21.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3533929Z [0m[32mInitialize[0m chalk@4.1.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3626309Z [0m[32mInitialize[0m @eslint/object-schema@2.1.7
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3668811Z [0m[32mInitialize[0m tinyexec@1.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3794418Z [0m[32mInitialize[0m ansi-colors@4.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3797987Z [0m[32mInitialize[0m word-wrap@1.2.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3886635Z [0m[32mInitialize[0m @eslint/config-helpers@0.4.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3948880Z [0m[32mInitialize[0m yargs@17.7.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.3960596Z [0m[32mInitialize[0m levn@0.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4028203Z [0m[32mInitialize[0m @changesets/get-dependents-graph@2.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4148582Z [0m[32mInitialize[0m @humanfs/node@0.16.7
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4162682Z [0m[32mInitialize[0m path-exists@4.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4258655Z [0m[32mInitialize[0m import-fresh@3.3.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4356673Z [0m[32mInitialize[0m brace-expansion@1.1.13
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4661573Z [0m[32mInitialize[0m synckit@0.11.12
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.4679600Z [0m[32mInitialize[0m spawndamnit@3.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5062156Z [0m[32mInitialize[0m semver@7.7.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5253693Z [0m[32mInitialize[0m yargs-parser@21.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5254496Z [0m[32mInitialize[0m path-key@3.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5404395Z [0m[32mInitialize[0m @humanfs/core@0.19.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5410806Z [0m[32mInitialize[0m estraverse@5.3.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5494905Z [0m[32mInitialize[0m @eslint-community/eslint-utils@4.9.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5497268Z [0m[32mInitialize[0m fast-json-stable-stringify@2.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5620704Z [0m[32mInitialize[0m @changesets/write@0.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5724331Z [0m[32mInitialize[0m @changesets/assemble-release-plan@6.0.9
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5867689Z [0m[32mInitialize[0m ajv@6.14.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5871457Z [0m[32mInitialize[0m locate-path@6.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.5983426Z [0m[32mInitialize[0m optionator@0.9.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6020158Z [0m[32mInitialize[0m json-schema-traverse@0.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6296221Z [0m[32mInitialize[0m @changesets/errors@0.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6433813Z [0m[32mInitialize[0m type-check@0.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6522453Z [0m[32mInitialize[0m deep-is@0.1.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6523148Z [0m[32mInitialize[0m picomatch@4.0.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6596124Z [0m[32mInitialize[0m @changesets/pre@2.0.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6598675Z [0m[32mInitialize[0m @changesets/git@3.0.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6652235Z [0m[32mInitialize[0m @eslint/eslintrc@3.3.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6653858Z [0m[32mInitialize[0m escalade@3.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6655110Z [0m[32mInitialize[0m file-entry-cache@8.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6701413Z [0m[32mInitialize[0m test-anywhere@0.6.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.6832063Z [0m[32mInitialize[0m @humanwhocodes/retry@0.4.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7003068Z [0m[32mInitialize[0m ms@2.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7066508Z [0m[32mInitialize[0m @manypkg/get-packages@1.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7158539Z [0m[32mInitialize[0m mri@1.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7238311Z [0m[32mInitialize[0m @eslint/core@0.17.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7257277Z [0m[32mInitialize[0m @changesets/get-release-plan@4.0.15
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7343636Z [0m[32mInitialize[0m prelude-ls@1.2.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7368971Z [0m[32mInitialize[0m eslint-visitor-keys@3.4.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7432812Z [0m[32mInitialize[0m esrecurse@4.3.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.7538549Z [0m[32mInitialize[0m read-yaml-file@1.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.8388373Z [0m[32mInitialize[0m eventemitter3@5.0.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.8651190Z [0m[32mInitialize[0m p-filter@2.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.9047711Z [0m[32mInitialize[0m @humanwhocodes/module-importer@1.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.9052346Z [0m[32mInitialize[0m picocolors@1.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.9080437Z [0m[32mInitialize[0m globby@11.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:41.9733634Z [0m[32mInitialize[0m @changesets/should-skip-package@0.1.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:42.0054521Z [0m[32mInitialize[0m @eslint/js@9.39.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:42.0481982Z [0m[32mInitialize[0m enquirer@2.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.1801307Z [0m[32mInitialize[0m @types/json-schema@7.0.15
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.2047752Z [0m[32mInitialize[0m lodash.startcase@4.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.2618898Z [0m[32mInitialize[0m graceful-fs@4.2.11
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.2621211Z [0m[32mInitialize[0m micromatch@4.0.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.3353445Z [0m[32mInitialize[0m resolve-from@4.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.3923215Z [0m[32mInitialize[0m extendable-error@0.1.7
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.5309415Z [0m[32mInitialize[0m acorn@8.16.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.7307404Z [0m[32mInitialize[0m balanced-match@1.0.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.7726034Z [0m[32mInitialize[0m isexe@2.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.7726826Z [0m[32mInitialize[0m is-subdir@1.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.7727521Z [0m[32mInitialize[0m strip-ansi@6.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.8855793Z [0m[32mInitialize[0m parent-module@1.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:43.9261859Z [0m[32mInitialize[0m signal-exit@4.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.0091238Z [0m[32mInitialize[0m @changesets/changelog-git@0.2.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.0096229Z [0m[32mInitialize[0m detect-indent@6.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.0099308Z [0m[32mInitialize[0m globals@14.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.1924601Z [0m[32mInitialize[0m @changesets/config@3.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.1925478Z [0m[32mInitialize[0m strip-json-comments@3.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2171504Z [0m[32mInitialize[0m colorette@2.0.20
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2253120Z [0m[32mInitialize[0m universalify@0.1.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2433574Z [0m[32mInitialize[0m uri-js@4.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2434254Z [0m[32mInitialize[0m fast-diff@1.3.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2437502Z [0m[32mInitialize[0m cli-cursor@5.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2807529Z [0m[32mInitialize[0m @changesets/read@0.6.7
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2809278Z [0m[32mInitialize[0m p-locate@5.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.2904926Z [0m[32mInitialize[0m ansi-styles@6.2.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3036603Z [0m[32mInitialize[0m chardet@2.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3064749Z [0m[32mInitialize[0m fs-extra@8.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3103360Z [0m[32mInitialize[0m jsonfile@4.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3104665Z [0m[32mInitialize[0m iconv-lite@0.7.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3116762Z [0m[32mInitialize[0m concat-map@0.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3164014Z [0m[32mInitialize[0m argparse@2.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3213110Z [0m[32mInitialize[0m keyv@4.5.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3288223Z [0m[32mInitialize[0m @eslint/plugin-kit@0.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3290874Z [0m[32mInitialize[0m color-convert@2.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3342812Z [0m[32mInitialize[0m p-map@2.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3420983Z [0m[32mInitialize[0m log-update@6.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3535002Z [0m[32mInitialize[0m emoji-regex@8.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3684708Z [0m[32mInitialize[0m js-yaml@4.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3686458Z [0m[32mInitialize[0m dir-glob@3.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3735098Z [0m[32mInitialize[0m wrap-ansi@7.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.3962949Z [0m[32mInitialize[0m color-name@1.1.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.4002374Z [0m[32mInitialize[0m shebang-regex@3.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.4328819Z [0m[32mInitialize[0m callsites@3.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.4579937Z [0m[32mInitialize[0m flat-cache@4.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.4998952Z [0m[32mInitialize[0m @changesets/types@4.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5001184Z [0m[32mInitialize[0m fast-levenshtein@2.0.6
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5002121Z [0m[32mInitialize[0m environment@1.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5138145Z [0m[32mInitialize[0m @manypkg/find-root@1.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5188442Z [0m[32mInitialize[0m find-up@4.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5792646Z [0m[32mInitialize[0m @inquirer/external-editor@1.0.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5839002Z [0m[32mInitialize[0m @changesets/types@6.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.5840291Z [0m[32mInitialize[0m ansi-escapes@7.3.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6074816Z [0m[32mInitialize[0m better-path-resolve@1.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6233085Z [0m[32mInitialize[0m which@2.0.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6234166Z [0m[32mInitialize[0m get-east-asian-width@1.5.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6303268Z [0m[32mInitialize[0m @changesets/apply-release-plan@7.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6320951Z [0m[32mInitialize[0m @changesets/logger@0.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6321717Z [0m[32mInitialize[0m restore-cursor@5.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6583846Z [0m[32mInitialize[0m human-id@4.1.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6584687Z [0m[32mInitialize[0m merge2@1.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6585640Z [0m[32mInitialize[0m glob-parent@5.1.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6599177Z [0m[32mInitialize[0m p-limit@3.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6641643Z [0m[32mInitialize[0m slice-ansi@7.1.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6841865Z [0m[32mInitialize[0m reusify@1.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6842723Z [0m[32mInitialize[0m queue-microtask@1.2.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.6844373Z [0m[32mInitialize[0m has-flag@4.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7133201Z [0m[32mInitialize[0m outdent@0.5.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7133875Z [0m[32mInitialize[0m fill-range@7.1.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7134435Z [0m[32mInitialize[0m p-locate@4.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7134974Z [0m[32mInitialize[0m path-type@4.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7135529Z [0m[32mInitialize[0m ansi-regex@6.2.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7206600Z [0m[32mInitialize[0m quansync@0.2.11
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7207591Z [0m[32mInitialize[0m strip-bom@3.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7277338Z [0m[32mInitialize[0m flatted@3.4.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7534156Z [0m[32mInitialize[0m esprima@4.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7545427Z [0m[32mInitialize[0m is-fullwidth-code-point@5.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7592798Z [0m[32mInitialize[0m p-limit@2.3.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7594973Z [0m[32mInitialize[0m to-regex-range@5.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7759188Z [0m[32mInitialize[0m braces@3.0.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7799361Z [0m[32mInitialize[0m sprintf-js@1.0.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7799915Z [0m[32mInitialize[0m array-union@2.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:44.7884623Z [0m[32mInitialize[0m @changesets/parse@0.4.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5339372Z [0m[32mInitialize[0m onetime@7.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5357517Z [0m[32mInitialize[0m mimic-function@5.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5475008Z [0m[32mInitialize[0m strip-ansi@7.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5528250Z [0m[32mInitialize[0m string-width@8.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5561428Z [0m[32mInitialize[0m run-parallel@1.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5764954Z [0m[32mInitialize[0m pify@4.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5962515Z [0m[32mInitialize[0m slice-ansi@8.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.5963228Z [0m[32mInitialize[0m safer-buffer@2.1.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6032809Z [0m[32mInitialize[0m json-buffer@3.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6034716Z [0m[32mInitialize[0m locate-path@5.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6036276Z [0m[32mInitialize[0m is-number@7.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6151965Z [0m[32mInitialize[0m punycode@2.3.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6383015Z [0m[32mInitialize[0m @pkgr/core@0.2.9
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6536212Z [0m[32mInitialize[0m @changesets/get-version-range-type@0.4.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6537427Z [0m[32mInitialize[0m p-try@2.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6538044Z [0m[32mInitialize[0m yocto-queue@0.1.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6777396Z [0m[32mInitialize[0m picomatch@2.3.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6780564Z [0m[32mInitialize[0m emoji-regex@10.6.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6789949Z [0m[32mInitialize[0m is-fullwidth-code-point@3.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6792458Z [0m[32mInitialize[0m slash@3.0.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.6860940Z [0m[32mInitialize[0m ansi-regex@5.0.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.7314267Z [0m[32mInitialize[0m string-width@7.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.7316054Z [0m[32mInitialize[0m is-windows@1.0.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.7473348Z [0m[32mInitialize[0m wrap-ansi@9.0.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.7634101Z [0m[32mInitialize[0m fastq@1.20.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.7638278Z [0m[32mInitialize[0m cli-truncate@5.2.0
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.7827395Z [0m[32mInitialize[0m rfdc@1.4.1
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.8097579Z [0m[32mInitialize[0m @nodelib/fs.stat@2.0.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.8393322Z [0m[32mInitialize[0m js-yaml@3.14.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.8440841Z [0m[32mInitialize[0m @nodelib/fs.walk@1.2.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.8638902Z [0m[32mInitialize[0m @nodelib/fs.scandir@2.1.5
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.8669705Z [0m[32mInitialize[0m fast-glob@3.3.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.8752068Z [0m[32mInitialize[0m argparse@1.0.10
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.9300969Z [0m[32mInitialize[0m prettier@2.8.8
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.9316800Z [0m[32mInitialize[0m yaml@2.8.3
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.9351766Z [0m[32mInitialize[0m @types/node@12.20.55
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:45.9578508Z [0m[32mInitialize[0m prettier@3.8.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:46.0582702Z [0m[32mInitialize[0m @babel/runtime@7.29.2
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:46.9977946Z [0m[32mInitialize[0m eslint@9.39.4
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5228518Z [0m[38;5;245mrunning 58 tests from ./tests/index.test.js[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5239306Z should convert camelCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5241939Z should convert kebab-case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5245579Z should convert snake_case to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5248969Z should convert PascalCase to UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5251863Z should handle already UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5255879Z should convert kebab-case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5259412Z should convert UPPER_CASE to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5260891Z should convert snake_case to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5263169Z should convert PascalCase to camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5266667Z should handle already camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5270356Z should convert camelCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5272525Z should convert UPPER_CASE to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5275844Z should convert PascalCase to kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5277212Z should handle already kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5280213Z should convert camelCase to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5283695Z should convert kebab-case to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5284618Z should convert UPPER_CASE to snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5287653Z should handle already snake_case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5290356Z should convert camelCase to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5293403Z should convert kebab-case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5295084Z should convert snake_case to PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5297746Z should handle already PascalCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5304649Z should find variable in UPPER_CASE ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5308214Z should find variable in camelCase ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5311710Z should find variable in kebab-case ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5314906Z should return default value when not found ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5317397Z should return empty string as default when not specified ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5320678Z should try original key first ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5451047Z should work with minimal configuration ... [0m[32mok[0m [0m[38;5;245m(12ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5501618Z should use CLI arguments with highest priority ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5540994Z should convert kebab-case to camelCase in result ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5549478Z should load .lenv file by default ...
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5550220Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5552007Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5588800Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5589789Z should load .lenv file by default ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5600179Z should handle --configuration flag ...
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5600920Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5601958Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5619942Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5641096Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5642086Z should handle --configuration flag ... [0m[32mok[0m [0m[38;5;245m(5ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5647680Z should prioritize CLI over environment ...
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5648348Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5649322Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5679412Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5680413Z should prioritize CLI over environment ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5720534Z should handle missing .lenv file gracefully ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5729103Z should convert all keys to UPPER_CASE in process.env ...
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5729932Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5731341Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5764175Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5765253Z should convert all keys to UPPER_CASE in process.env ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5803198Z should find env vars in any case format via getenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5840638Z should support disabling lenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5876276Z should support enabling env/dotenvx (deprecated) ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5913222Z should support disabling getenv ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5938411Z should support configuration alias -c ...
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5939114Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5939968Z 📝 Loaded 1 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5959517Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5960141Z should support configuration alias -c ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5970968Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ...
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5971949Z [0m[38;5;245m------- output -------[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.5972943Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6011983Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6025606Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6042565Z 📝 Loaded 3 variables from D:\a\lino-arguments\lino-arguments\js\.test-makeconfig.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6056530Z 📝 Loaded 2 variables from D:\a\lino-arguments\lino-arguments\js\.test-config.lenv
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6078020Z [0m[38;5;245m----- output end -----[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6079311Z should demonstrate full priority: CLI > getenv > --configuration > .lenv ... [0m[32mok[0m [0m[38;5;245m(11ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6120033Z should allow user-defined --version option by calling .version(false) ... [0m[32mok[0m [0m[38;5;245m(4ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6152149Z should allow user-defined --help option ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6188941Z should work with --version in strict mode ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6220184Z should handle --version with boolean type ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6256457Z should allow users to explicitly enable help ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6294202Z should work with multiple custom options including version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6336457Z should allow explicitly enabling built-in --version ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6375051Z should allow explicitly enabling both --version and --help ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6412037Z should allow version with alias ... [0m[32mok[0m [0m[38;5;245m(3ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6443693Z should allow help with alias ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6474762Z should work with both built-in version/help and custom options ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6501158Z should parse simple links notation format ... [0m[32mok[0m [0m[38;5;245m(2ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6506371Z should parse arguments without parentheses ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6510631Z should handle empty input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6513432Z should handle null input ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6518378Z should filter out comments ... [0m[32mok[0m [0m[38;5;245m(0ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6568751Z 
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6569783Z [0m[32mok[0m | 58 passed | 0 failed [0m[38;5;245m(134ms)[0m
+Test (deno on windows-latest)	Run tests (Deno)	2026-04-10T20:47:47.6570200Z 
+Test (deno on windows-latest)	Post Setup Deno	﻿2026-04-10T20:47:47.7947090Z Post job cleanup.
+Test (deno on windows-latest)	Post Setup Deno	2026-04-10T20:47:47.9553092Z Caching is not enabled. Caching is skipped.
+Test (deno on windows-latest)	Post Setup Node.js (for npm install)	﻿2026-04-10T20:47:47.9871595Z Post job cleanup.
+Test (deno on windows-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:48.2574190Z Post job cleanup.
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.5297863Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.5594144Z git version 2.53.0.windows.2
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.5687742Z Temporarily overriding HOME='D:\a\_temp\b70c2990-cb18-43d4-8ba5-2b619cc42fa8' before making global git config changes
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.5689142Z Adding repository directory to the temporary git global config as a safe directory
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.5699548Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.6036851Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:48.6361453Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:49.2363685Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:49.2629542Z http.https://github.com/.extraheader
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:49.2681983Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:49.2997671Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:49.8742499Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (deno on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:49.9059098Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (deno on windows-latest)	Complete job	﻿2026-04-10T20:47:50.4798365Z Cleaning up orphan processes
+Test (deno on windows-latest)	Complete job	2026-04-10T20:47:50.4985566Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (node on windows-latest)	Set up job	﻿2026-04-10T20:47:12.0202903Z Current runner version: '2.333.1'
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0261618Z ##[group]Runner Image Provisioner
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0262647Z Hosted Compute Agent
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0263392Z Version: 20260213.493
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0264270Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0265711Z Build Date: 2026-02-13T00:28:41Z
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0266694Z Worker ID: {712d578c-0069-44ea-bdd9-e3c15ad5cb2c}
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0267598Z Azure Region: eastus
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0268647Z ##[endgroup]
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0270563Z ##[group]Operating System
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0271428Z Microsoft Windows Server 2025
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0272176Z 10.0.26100
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0272812Z Datacenter
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0273520Z ##[endgroup]
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0274144Z ##[group]Runner Image
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0274878Z Image: windows-2025
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0275512Z Version: 20260405.77.1
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0277028Z Included Software: https://github.com/actions/runner-images/blob/win25/20260405.77/images/windows/Windows2025-Readme.md
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0280094Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20260405.77
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0281467Z ##[endgroup]
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0285932Z ##[group]GITHUB_TOKEN Permissions
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0289534Z Actions: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0290299Z ArtifactMetadata: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0291095Z Attestations: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0291674Z Checks: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0292166Z Contents: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0292650Z Deployments: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0293165Z Discussions: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0293602Z Issues: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0294046Z Metadata: read
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0294472Z Models: read
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0294947Z Packages: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0295439Z Pages: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0295921Z PullRequests: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0296437Z RepositoryProjects: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0296919Z SecurityEvents: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0297421Z Statuses: write
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0297902Z ##[endgroup]
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0300857Z Secret source: Actions
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0302145Z Prepare workflow directory
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0687349Z Prepare all required actions
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.0725077Z Getting action download info
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.3980019Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.5146111Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.6673732Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:12.8560310Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (node on windows-latest)	Set up job	2026-04-10T20:47:13.2565970Z Complete job name: Test (node on windows-latest)
+Test (node on windows-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:13.3823583Z ##[group]Run actions/checkout@v4
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3824634Z with:
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3825006Z   repository: link-foundation/lino-arguments
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3825700Z   token: ***
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3826021Z   ssh-strict: true
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3826359Z   ssh-user: git
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3826700Z   persist-credentials: true
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3827074Z   clean: true
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3827416Z   sparse-checkout-cone-mode: true
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3827821Z   fetch-depth: 1
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3828151Z   fetch-tags: false
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3828477Z   show-progress: true
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3828818Z   lfs: false
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3829117Z   submodules: false
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3829455Z   set-safe-directory: true
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.3830014Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5418696Z Syncing repository: link-foundation/lino-arguments
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5420355Z ##[group]Getting Git version info
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.5420964Z Working directory is 'D:\a\lino-arguments\lino-arguments'
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.6170269Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.9805448Z git version 2.53.0.windows.2
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.9860865Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.9882626Z Temporarily overriding HOME='D:\a\_temp\72d6e51d-2c08-463b-8ba2-1f1caee3f034' before making global git config changes
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.9884082Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:13.9897898Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0548532Z Deleting the contents of 'D:\a\lino-arguments\lino-arguments'
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0555554Z ##[group]Initializing the repository
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.0565933Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-arguments\lino-arguments
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.1783567Z Initialized empty Git repository in D:/a/lino-arguments/lino-arguments/.git/
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.1832905Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-arguments
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2404500Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2405599Z ##[group]Disabling automatic garbage collection
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2414380Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2697981Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2698670Z ##[group]Setting up auth
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.2711930Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:14.3000750Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.6255482Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.6545991Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2086903Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2372098Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.7335143Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.7641575Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.7642603Z ##[group]Fetching the repository
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.7655576Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.5836160Z From https://github.com/link-foundation/lino-arguments
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.5839117Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6173678Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6174356Z ##[group]Determining the checkout info
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6175891Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6186414Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6622849Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6901367Z ##[group]Checking out the ref
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.6910710Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7673202Z Switched to a new branch 'main'
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7725541Z branch 'main' set up to track 'origin/main'.
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7772813Z ##[endgroup]
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.8195749Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (node on windows-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.8455663Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (node on windows-latest)	Setup Node.js	﻿2026-04-10T20:47:17.8922654Z ##[group]Run actions/setup-node@v4
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:17.8923807Z with:
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:17.8924007Z   node-version: 20.x
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:17.8924193Z   always-auth: false
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:17.8924381Z   check-latest: false
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:17.8924755Z   token: ***
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:17.8924930Z ##[endgroup]
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:18.1377157Z Found in cache @ C:\hostedtoolcache\windows\node\20.20.2\x64
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:18.1387055Z ##[group]Environment details
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:22.2734684Z node: v20.20.2
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:22.2735073Z npm: 10.8.2
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:22.2735300Z yarn: 1.22.22
+Test (node on windows-latest)	Setup Node.js	2026-04-10T20:47:22.2735969Z ##[endgroup]
+Test (node on windows-latest)	Install dependencies (Node.js)	﻿2026-04-10T20:47:22.3012885Z ##[group]Run npm install
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3013244Z [36;1mnpm install[0m
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3768039Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3768410Z ##[endgroup]
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:32.9199507Z 
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:32.9206742Z > lino-arguments@0.3.0 prepare
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:32.9207109Z > husky || true
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:32.9207226Z 
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0144187Z .git can't be found
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0144790Z added 234 packages, and audited 235 packages in 6s
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0145148Z 
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0145347Z 59 packages are looking for funding
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0145715Z   run `npm fund` for details
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0224744Z 
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0225578Z 7 vulnerabilities (4 moderate, 3 high)
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0226052Z 
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0226312Z To address all issues, run:
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0226734Z   npm audit fix
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0227235Z 
+Test (node on windows-latest)	Install dependencies (Node.js)	2026-04-10T20:47:33.0227669Z Run `npm audit` for details.
+Test (node on windows-latest)	Run tests (Node.js)	﻿2026-04-10T20:47:33.7345061Z ##[group]Run npm test
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:33.7345387Z [36;1mnpm test[0m
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:33.7402136Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:33.7402455Z ##[endgroup]
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.4021109Z 
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.4021745Z > lino-arguments@0.3.0 test
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.4022248Z > node --test tests/
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.4022448Z 
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.5342094Z TAP version 13
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7112578Z # 📝 Loaded 2 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7131520Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7153092Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7178402Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7230302Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7369928Z # 📝 Loaded 1 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7398672Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7417533Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7427184Z # 📝 Loaded 2 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7441228Z # 📝 Loaded 3 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-makeconfig.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7451916Z # 📝 Loaded 2 variables from D:\\a\\lino-arguments\\lino-arguments\\js\\.test-config.lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7763007Z # Subtest: Case Conversion Utilities
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7764293Z     # Subtest: toUpperCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7771162Z         # Subtest: should convert camelCase to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7802139Z         ok 1 - should convert camelCase to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7805477Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7806090Z           duration_ms: 1.4238
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7806598Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7809833Z         # Subtest: should convert kebab-case to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7820458Z         ok 2 - should convert kebab-case to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7823095Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7826722Z           duration_ms: 0.2488
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7835728Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7836611Z         # Subtest: should convert snake_case to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7840147Z         ok 3 - should convert snake_case to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7841114Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7844584Z           duration_ms: 0.1634
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7845178Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7845739Z         # Subtest: should convert PascalCase to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7847763Z         ok 4 - should convert PascalCase to UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7848771Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7849087Z           duration_ms: 0.2344
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7849409Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7849756Z         # Subtest: should handle already UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7850251Z         ok 5 - should handle already UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7850648Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7850907Z           duration_ms: 0.1492
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7851200Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7851437Z         1..5
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7851690Z     ok 1 - toUpperCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7851981Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7852228Z       duration_ms: 2.9616
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7852517Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7852773Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7853027Z     # Subtest: toCamelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7853449Z         # Subtest: should convert kebab-case to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7853985Z         ok 1 - should convert kebab-case to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7854377Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7854632Z           duration_ms: 0.3631
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7859062Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7859422Z         # Subtest: should convert UPPER_CASE to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7877934Z         ok 2 - should convert UPPER_CASE to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7905415Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7905740Z           duration_ms: 0.1486
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7906069Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7906487Z         # Subtest: should convert snake_case to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7907034Z         ok 3 - should convert snake_case to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7907436Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7907701Z           duration_ms: 0.2096
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7908017Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7908387Z         # Subtest: should convert PascalCase to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7908931Z         ok 4 - should convert PascalCase to camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7909342Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7909589Z           duration_ms: 0.2129
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7909877Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7910252Z         # Subtest: should handle already camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7910800Z         ok 5 - should handle already camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7911158Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7911413Z           duration_ms: 0.1815
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7911711Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7911934Z         1..5
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7912187Z     ok 2 - toCamelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7912464Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7912715Z       duration_ms: 2.3076
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7913017Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7913264Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7913514Z     # Subtest: toKebabCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7915121Z         # Subtest: should convert camelCase to kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7915722Z         ok 1 - should convert camelCase to kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.7942084Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8009959Z           duration_ms: 0.3649
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8049817Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8051534Z         # Subtest: should convert UPPER_CASE to kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8055070Z         ok 2 - should convert UPPER_CASE to kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8055965Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8075920Z           duration_ms: 0.2592
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8077179Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8077788Z         # Subtest: should convert PascalCase to kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8078557Z         ok 3 - should convert PascalCase to kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8079496Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8079945Z           duration_ms: 0.154
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8080427Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8080934Z         # Subtest: should handle already kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8082072Z         ok 4 - should handle already kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8082741Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8083183Z           duration_ms: 0.1753
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8083667Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8084062Z         1..4
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8084488Z     ok 3 - toKebabCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8084933Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8085348Z       duration_ms: 1.2095
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8085821Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8086222Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8086617Z     # Subtest: toSnakeCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8087217Z         # Subtest: should convert camelCase to snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8087939Z         ok 1 - should convert camelCase to snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8088536Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8088969Z           duration_ms: 0.2808
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8089468Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8089979Z         # Subtest: should convert kebab-case to snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8090662Z         ok 2 - should convert kebab-case to snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8091224Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8091641Z           duration_ms: 0.1389
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8092087Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8093167Z         # Subtest: should convert UPPER_CASE to snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8093908Z         ok 3 - should convert UPPER_CASE to snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8095682Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8096093Z           duration_ms: 0.119
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8096554Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8097050Z         # Subtest: should handle already snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8097668Z         ok 4 - should handle already snake_case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8098563Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8098967Z           duration_ms: 0.2601
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8099401Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8107788Z         1..4
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8110789Z     ok 4 - toSnakeCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8111316Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8111732Z       duration_ms: 0.9821
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8112202Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8112621Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8112992Z     # Subtest: toPascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8114263Z         # Subtest: should convert camelCase to PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8114845Z         ok 1 - should convert camelCase to PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8115275Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8115852Z           duration_ms: 0.268
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8116231Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8116633Z         # Subtest: should convert kebab-case to PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8117176Z         ok 2 - should convert kebab-case to PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8117923Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8118194Z           duration_ms: 0.1727
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8118497Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8118861Z         # Subtest: should convert snake_case to PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8119387Z         ok 3 - should convert snake_case to PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8119779Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8120034Z           duration_ms: 0.1389
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8120344Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8120675Z         # Subtest: should handle already PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8121157Z         ok 4 - should handle already PascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8121537Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8121780Z           duration_ms: 0.1138
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8122072Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8122305Z         1..4
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8122554Z     ok 5 - toPascalCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8122834Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8123066Z       duration_ms: 0.8392
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8123359Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8123599Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8123809Z     1..5
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8124121Z ok 1 - Case Conversion Utilities
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8125502Z   ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8125759Z   duration_ms: 9.3536
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8126030Z   type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8126274Z   ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8126523Z # Subtest: getenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8126882Z     # Subtest: should find variable in UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8127373Z     ok 1 - should find variable in UPPER_CASE
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8127746Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8127985Z       duration_ms: 0.6808
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8128276Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8128585Z     # Subtest: should find variable in camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8131677Z     ok 2 - should find variable in camelCase
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8137151Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8157063Z       duration_ms: 0.242
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8158664Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8161911Z     # Subtest: should find variable in kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8164945Z     ok 3 - should find variable in kebab-case
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8165973Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8166287Z       duration_ms: 0.2927
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8166620Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8167001Z     # Subtest: should return default value when not found
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8167575Z     ok 4 - should return default value when not found
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8168007Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8168248Z       duration_ms: 0.1866
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8168547Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8168998Z     # Subtest: should return empty string as default when not specified
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8169698Z     ok 5 - should return empty string as default when not specified
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8170176Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8170630Z       duration_ms: 0.1776
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8170910Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8172289Z     # Subtest: should try original key first
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8172739Z     ok 6 - should try original key first
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8173109Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8173361Z       duration_ms: 0.2664
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8173646Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8173874Z     1..6
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8174110Z ok 2 - getenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8174356Z   ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8174603Z   duration_ms: 2.0869
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8174862Z   type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8175092Z   ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8175322Z # Subtest: makeConfig
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8175541Z     # Subtest: Hero Example (defaults)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8175850Z         # Subtest: should work with minimal configuration
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8176182Z         ok 1 - should work with minimal configuration
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8176427Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8176715Z           duration_ms: 10.9977
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8177032Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8177499Z         # Subtest: should use CLI arguments with highest priority
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8178382Z         ok 2 - should use CLI arguments with highest priority
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8178819Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8179095Z           duration_ms: 3.1629
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8179355Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8179605Z         # Subtest: should convert kebab-case to camelCase in result
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8179973Z         ok 3 - should convert kebab-case to camelCase in result
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8180241Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8180406Z           duration_ms: 2.2503
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8180677Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8180914Z         1..3
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8181205Z     ok 1 - Hero Example (defaults)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8181553Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8181807Z       duration_ms: 16.5437
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8182111Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8182379Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8182683Z     # Subtest: Environment Loading Priority
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8182986Z         # Subtest: should load .lenv file by default
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8183286Z         ok 1 - should load .lenv file by default
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8183509Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8183674Z           duration_ms: 4.4805
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8183855Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8184108Z         # Subtest: should handle --configuration flag
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8184825Z         ok 2 - should handle --configuration flag
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8185227Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8185493Z           duration_ms: 4.7382
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8185805Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8186163Z         # Subtest: should prioritize CLI over environment
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8186673Z         ok 3 - should prioritize CLI over environment
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8187072Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8187317Z           duration_ms: 2.5965
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8187620Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8187994Z         # Subtest: should handle missing .lenv file gracefully
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8188912Z         ok 4 - should handle missing .lenv file gracefully
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8189334Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8189573Z           duration_ms: 2.2796
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8189865Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8190101Z         1..4
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8190390Z     ok 2 - Environment Loading Priority
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8190763Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8191000Z       duration_ms: 14.2735
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8191292Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8191545Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8191878Z     # Subtest: Case Conversion in Environment Loading
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8348732Z         # Subtest: should convert all keys to UPPER_CASE in process.env
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8352690Z         ok 1 - should convert all keys to UPPER_CASE in process.env
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8353232Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8353506Z           duration_ms: 2.1394
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8353811Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8354561Z         # Subtest: should find env vars in any case format via getenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8355216Z         ok 2 - should find env vars in any case format via getenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8355679Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8355946Z           duration_ms: 2.2603
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8356257Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8356491Z         1..2
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8356852Z     ok 3 - Case Conversion in Environment Loading
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8357244Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8357490Z       duration_ms: 4.5592
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8357805Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8358046Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8358334Z     # Subtest: Configuration Options
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8358782Z         # Subtest: should support disabling lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8359252Z         ok 1 - should support disabling lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8359636Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8359890Z           duration_ms: 2.3281
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8360201Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8360636Z         # Subtest: should support enabling env/dotenvx (deprecated)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8361287Z         ok 2 - should support enabling env/dotenvx (deprecated)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8361711Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8361969Z           duration_ms: 3.4271
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8362219Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8362558Z         # Subtest: should support disabling getenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8363043Z         ok 3 - should support disabling getenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8365764Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8366069Z           duration_ms: 2.4115
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8366389Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8366779Z         # Subtest: should support configuration alias -c
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8367295Z         ok 4 - should support configuration alias -c
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8367706Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8367964Z           duration_ms: 3.1848
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8368260Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8368491Z         1..4
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8368796Z     ok 4 - Configuration Options
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8369126Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8369380Z       duration_ms: 11.5387
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8369678Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8369951Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8370251Z     # Subtest: Complete Priority Chain
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8370961Z         # Subtest: should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8372094Z         ok 1 - should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8372687Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8372939Z           duration_ms: 8.3887
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8373250Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8373474Z         1..1
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8373770Z     ok 5 - Complete Priority Chain
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8374115Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8374355Z       duration_ms: 8.5369
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8374653Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8374901Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8375238Z     # Subtest: Built-in Flag Conflicts (Issue \#14)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8375958Z         # Subtest: should allow user-defined --version option by calling .version(false)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8376944Z         ok 1 - should allow user-defined --version option by calling .version(false)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8377512Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8377778Z           duration_ms: 2.3181
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8378089Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8378454Z         # Subtest: should allow user-defined --help option
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8379013Z         ok 2 - should allow user-defined --help option
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8379442Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8379719Z           duration_ms: 2.2173
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8380040Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8380415Z         # Subtest: should work with --version in strict mode
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8380981Z         ok 3 - should work with --version in strict mode
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8381404Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8381651Z           duration_ms: 1.9052
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8382934Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8383302Z         # Subtest: should handle --version with boolean type
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8383853Z         ok 4 - should handle --version with boolean type
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8384265Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8384570Z           duration_ms: 1.613
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8384959Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8385473Z         # Subtest: should allow users to explicitly enable help
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8386440Z         ok 5 - should allow users to explicitly enable help
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8386874Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8387115Z           duration_ms: 1.6112
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8387460Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8387940Z         # Subtest: should work with multiple custom options including version
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8388677Z         ok 6 - should work with multiple custom options including version
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8389189Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8389447Z           duration_ms: 2.1455
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8389745Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8389975Z         1..6
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8390292Z     ok 6 - Built-in Flag Conflicts (Issue \#14)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8390684Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8390935Z       duration_ms: 12.0973
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8391227Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8391481Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8391871Z     # Subtest: Explicitly Enabling Built-in Version and Help
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8392525Z         # Subtest: should allow explicitly enabling built-in --version
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8393178Z         ok 1 - should allow explicitly enabling built-in --version
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8393622Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8393873Z           duration_ms: 2.1278
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8394177Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8394643Z         # Subtest: should allow explicitly enabling both --version and --help
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8395381Z         ok 2 - should allow explicitly enabling both --version and --help
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8395884Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8396124Z           duration_ms: 1.4749
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8396422Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8396739Z         # Subtest: should allow version with alias
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8397221Z         ok 3 - should allow version with alias
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8397602Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8397860Z           duration_ms: 1.4692
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8398396Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8398709Z         # Subtest: should allow help with alias
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8399145Z         ok 4 - should allow help with alias
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8399502Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8399735Z           duration_ms: 1.6327
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8400022Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8400498Z         # Subtest: should work with both built-in version/help and custom options
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8401259Z         ok 5 - should work with both built-in version/help and custom options
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8401772Z           ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8402019Z           duration_ms: 1.6032
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8402272Z           ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8402493Z         1..5
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8402869Z     ok 7 - Explicitly Enabling Built-in Version and Help
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8403304Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8403557Z       duration_ms: 8.4924
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8403854Z       type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8404110Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8404308Z     1..7
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8404548Z ok 3 - makeConfig
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8404784Z   ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8405009Z   duration_ms: 76.4327
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8405278Z   type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8405508Z   ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8405827Z # Subtest: parseLinoArguments (legacy)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8406595Z     # Subtest: should parse simple links notation format
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8407142Z     ok 1 - should parse simple links notation format
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8407565Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8407822Z       duration_ms: 2.2935
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8408104Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8408645Z     # Subtest: should parse arguments without parentheses
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8409185Z     ok 2 - should parse arguments without parentheses
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8409552Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8409707Z       duration_ms: 0.4892
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8409876Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8410060Z     # Subtest: should handle empty input
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8410322Z     ok 3 - should handle empty input
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8410520Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8410677Z       duration_ms: 0.2848
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8410973Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8411271Z     # Subtest: should handle null input
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8411696Z     ok 4 - should handle null input
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8412032Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8412277Z       duration_ms: 0.1078
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8412564Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8412821Z     # Subtest: should filter out comments
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8413229Z     ok 5 - should filter out comments
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8413434Z       ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8413576Z       duration_ms: 0.6771
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8413747Z       ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8413879Z     1..5
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8414083Z ok 4 - parseLinoArguments (legacy)
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8414282Z   ---
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8414433Z   duration_ms: 4.0229
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8414680Z   type: 'suite'
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8414906Z   ...
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8523103Z 1..4
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8523559Z # tests 58
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8523949Z # suites 16
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8524344Z # pass 58
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8524903Z # fail 0
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8525190Z # cancelled 0
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8525722Z # skipped 0
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8525950Z # todo 0
+Test (node on windows-latest)	Run tests (Node.js)	2026-04-10T20:47:34.8531765Z # duration_ms 350.3632
+Test (node on windows-latest)	Post Setup Node.js	﻿2026-04-10T20:47:35.0091348Z Post job cleanup.
+Test (node on windows-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:35.2602955Z Post job cleanup.
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.4881286Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.5243538Z git version 2.53.0.windows.2
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.5333338Z Temporarily overriding HOME='D:\a\_temp\e74974dc-de3f-424f-9719-3b70aabb9a84' before making global git config changes
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.5334906Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.5347288Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-arguments\lino-arguments
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.5719222Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:35.6089631Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:36.2227863Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:36.2494599Z http.https://github.com/.extraheader
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:36.2541478Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:36.2861730Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:36.8265361Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on windows-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:36.8565087Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (node on windows-latest)	Complete job	﻿2026-04-10T20:47:37.4078238Z Cleaning up orphan processes
+Test (node on windows-latest)	Complete job	2026-04-10T20:47:37.4120286Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test (node on macos-latest)	Set up job	﻿2026-04-10T20:47:11.8920840Z Current runner version: '2.333.1'
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8936540Z ##[group]Runner Image Provisioner
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8937030Z Hosted Compute Agent
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8937360Z Version: 20260213.493
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8937730Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8938150Z Build Date: 2026-02-13T00:28:41Z
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8938550Z Worker ID: {31d2188d-4f30-4376-815a-90d7c647b066}
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8938960Z Azure Region: westus
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8939290Z ##[endgroup]
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8940070Z ##[group]Operating System
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8940410Z macOS
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8940680Z 15.7.4
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8940940Z 24G517
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8941210Z ##[endgroup]
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8941500Z ##[group]Runner Image
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8941810Z Image: macos-15-arm64
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8942120Z Version: 20260406.0256.1
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8942790Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260406.0256/images/macos/macos-15-arm64-Readme.md
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8943810Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260406.0256
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8944390Z ##[endgroup]
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8946080Z ##[group]GITHUB_TOKEN Permissions
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8947110Z Actions: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8947420Z ArtifactMetadata: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8947740Z Attestations: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8948040Z Checks: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8948360Z Contents: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8948700Z Deployments: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8949030Z Discussions: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8949340Z Issues: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8949670Z Metadata: read
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8949990Z Models: read
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8950300Z Packages: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8950610Z Pages: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8950970Z PullRequests: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8951300Z RepositoryProjects: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8951700Z SecurityEvents: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8952090Z Statuses: write
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8952400Z ##[endgroup]
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8953890Z Secret source: Actions
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.8954340Z Prepare workflow directory
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.9209270Z Prepare all required actions
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:11.9239200Z Getting action download info
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:12.1698580Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:12.5597290Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:12.7906410Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:14.1096700Z Download action repository 'denoland/setup-deno@v2' (SHA:667a34cdef165d8d2b2e98dde39547c9daac7282)
+Test (node on macos-latest)	Set up job	2026-04-10T20:47:15.5314770Z Complete job name: Test (node on macos-latest)
+Test (node on macos-latest)	Run actions/checkout@v4	﻿2026-04-10T20:47:15.5796040Z ##[group]Run actions/checkout@v4
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5796560Z with:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5796800Z   repository: link-foundation/lino-arguments
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5797310Z   token: ***
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5797520Z   ssh-strict: true
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5797720Z   ssh-user: git
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5797950Z   persist-credentials: true
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5798200Z   clean: true
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5798410Z   sparse-checkout-cone-mode: true
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5798670Z   fetch-depth: 1
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5798850Z   fetch-tags: false
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5799070Z   show-progress: true
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5799280Z   lfs: false
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5799470Z   submodules: false
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5799680Z   set-safe-directory: true
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:15.5800210Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0163160Z Syncing repository: link-foundation/lino-arguments
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0165210Z ##[group]Getting Git version info
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0165640Z Working directory is '/Users/runner/work/lino-arguments/lino-arguments'
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0166430Z [command]/opt/homebrew/bin/git version
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.0977690Z git version 2.53.0
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1019530Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1050980Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/5c73fe88-6262-4ae0-b17d-16f491f62ee9/.gitconfig'
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1063990Z Temporarily overriding HOME='/Users/runner/work/_temp/5c73fe88-6262-4ae0-b17d-16f491f62ee9' before making global git config changes
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1073910Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1074950Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1246220Z Deleting the contents of '/Users/runner/work/lino-arguments/lino-arguments'
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1249750Z ##[group]Initializing the repository
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1254870Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-arguments/lino-arguments
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1665620Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1667980Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1668650Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1670210Z hint: call:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1670640Z hint:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1671150Z hint: 	git config --global init.defaultBranch <name>
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1672080Z hint:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1672570Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1673210Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1673870Z hint:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1674220Z hint: 	git branch -m <name>
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1674580Z hint:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1675040Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1675900Z Initialized empty Git repository in /Users/runner/work/lino-arguments/lino-arguments/.git/
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1678900Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1815760Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1816490Z ##[group]Disabling automatic garbage collection
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1828510Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1962850Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1963640Z ##[group]Setting up auth
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.1964260Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.2044440Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.4272520Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.4414440Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.5573460Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.5642880Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.6561480Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.6688030Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.6689790Z ##[group]Fetching the repository
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:16.6704320Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f990d427d8601605daeaf256f1086f34bc3e3db6:refs/remotes/origin/main
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7404190Z From https://github.com/link-foundation/lino-arguments
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7405950Z  * [new ref]         f990d427d8601605daeaf256f1086f34bc3e3db6 -> origin/main
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7502050Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7503040Z ##[group]Determining the checkout info
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7505830Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7506410Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7583400Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7647900Z ##[group]Checking out the ref
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7651000Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.7911940Z Switched to a new branch 'main'
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.8013370Z branch 'main' set up to track 'origin/main'.
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.8317900Z ##[endgroup]
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.8620350Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (node on macos-latest)	Run actions/checkout@v4	2026-04-10T20:47:17.8767180Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Test (node on macos-latest)	Setup Node.js	﻿2026-04-10T20:47:17.9105420Z ##[group]Run actions/setup-node@v4
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:17.9105690Z with:
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:17.9105830Z   node-version: 20.x
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:17.9106000Z   always-auth: false
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:17.9106150Z   check-latest: false
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:17.9106470Z   token: ***
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:17.9106620Z ##[endgroup]
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:18.0807880Z Found in cache @ /Users/runner/hostedtoolcache/node/20.20.2/arm64
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:18.0812390Z ##[group]Environment details
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:18.8857160Z node: v20.20.2
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:18.8921490Z npm: 10.8.2
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:18.8955870Z yarn: 1.22.22
+Test (node on macos-latest)	Setup Node.js	2026-04-10T20:47:18.8997920Z ##[endgroup]
+Test (node on macos-latest)	Install dependencies (Node.js)	﻿2026-04-10T20:47:18.9275590Z ##[group]Run npm install
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:18.9275950Z [36;1mnpm install[0m
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:18.9411660Z shell: /bin/bash -e {0}
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:18.9412430Z ##[endgroup]
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3454510Z 
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3562230Z > lino-arguments@0.3.0 prepare
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3639010Z > husky || true
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.3641540Z 
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4356770Z .git can't be found
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4456860Z added 234 packages, and audited 235 packages in 3s
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4459670Z 
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4461160Z 59 packages are looking for funding
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4463180Z   run `npm fund` for details
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4465120Z 
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4465990Z 7 vulnerabilities (4 moderate, 3 high)
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4466540Z 
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4466800Z To address all issues, run:
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4467590Z   npm audit fix
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4467830Z 
+Test (node on macos-latest)	Install dependencies (Node.js)	2026-04-10T20:47:22.4468190Z Run `npm audit` for details.
+Test (node on macos-latest)	Run tests (Node.js)	﻿2026-04-10T20:47:22.4691290Z ##[group]Run npm test
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.4691810Z [36;1mnpm test[0m
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.4772080Z shell: /bin/bash -e {0}
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.4772370Z ##[endgroup]
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.7607350Z 
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.7619920Z > lino-arguments@0.3.0 test
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.7622300Z > node --test tests/
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.7623170Z 
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.8045010Z TAP version 13
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.8934200Z # 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.8985400Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9060630Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9061870Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9062750Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9218790Z # 📝 Loaded 1 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9254200Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9284600Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9304110Z # 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9331620Z # 📝 Loaded 3 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-makeconfig.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9346860Z # 📝 Loaded 2 variables from /Users/runner/work/lino-arguments/lino-arguments/js/.test-config.lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9608600Z # Subtest: Case Conversion Utilities
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9625090Z     # Subtest: toUpperCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9625660Z         # Subtest: should convert camelCase to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9626600Z         ok 1 - should convert camelCase to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9626990Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9627310Z           duration_ms: 0.783583
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9627590Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9627950Z         # Subtest: should convert kebab-case to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9628380Z         ok 2 - should convert kebab-case to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9768910Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9885670Z           duration_ms: 0.168875
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9973900Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9974620Z         # Subtest: should convert snake_case to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9975140Z         ok 3 - should convert snake_case to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9975550Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9975900Z           duration_ms: 0.075375
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9976230Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9976600Z         # Subtest: should convert PascalCase to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9977040Z         ok 4 - should convert PascalCase to UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9977440Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9977740Z           duration_ms: 0.07475
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9978020Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9980830Z         # Subtest: should handle already UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9983670Z         ok 5 - should handle already UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9986760Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9989580Z           duration_ms: 0.061292
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9996530Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9997960Z         1..5
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9998700Z     ok 1 - toUpperCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:22.9999450Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0000060Z       duration_ms: 1.549875
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0001000Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0002510Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0003190Z     # Subtest: toCamelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0004080Z         # Subtest: should convert kebab-case to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0005470Z         ok 1 - should convert kebab-case to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0005840Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0006120Z           duration_ms: 0.165583
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0007430Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0007760Z         # Subtest: should convert UPPER_CASE to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0008170Z         ok 2 - should convert UPPER_CASE to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0008510Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0008780Z           duration_ms: 0.058166
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0009060Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0009480Z         # Subtest: should convert snake_case to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0009920Z         ok 3 - should convert snake_case to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0010240Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0010670Z           duration_ms: 0.087125
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0011020Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0011450Z         # Subtest: should convert PascalCase to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0011950Z         ok 4 - should convert PascalCase to camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0012510Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0013050Z           duration_ms: 0.191625
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0013330Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0013660Z         # Subtest: should handle already camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0014040Z         ok 5 - should handle already camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0014350Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0014740Z           duration_ms: 0.081458
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0015020Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0015260Z         1..5
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0015520Z     ok 2 - toCamelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0015860Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0016120Z       duration_ms: 0.794125
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0016400Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0016740Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0017050Z     # Subtest: toKebabCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0017820Z         # Subtest: should convert camelCase to kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0018330Z         ok 1 - should convert camelCase to kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0018680Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0018980Z           duration_ms: 0.156667
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0019250Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0019610Z         # Subtest: should convert UPPER_CASE to kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0020020Z         ok 2 - should convert UPPER_CASE to kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0020340Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0020620Z           duration_ms: 0.148792
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0020900Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0021250Z         # Subtest: should convert PascalCase to kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0021660Z         ok 3 - should convert PascalCase to kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0021990Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0022310Z           duration_ms: 0.060416
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0022650Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0024250Z         # Subtest: should handle already kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0025280Z         ok 4 - should handle already kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0025980Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0026660Z           duration_ms: 0.050125
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0027470Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0028330Z         1..4
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0029170Z     ok 3 - toKebabCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0029920Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0030730Z       duration_ms: 0.553709
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0031710Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0032890Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0033710Z     # Subtest: toSnakeCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0034930Z         # Subtest: should convert camelCase to snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0036170Z         ok 1 - should convert camelCase to snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0037210Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0038110Z           duration_ms: 0.162917
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0038830Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0039800Z         # Subtest: should convert kebab-case to snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0042100Z         ok 2 - should convert kebab-case to snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0043220Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0043840Z           duration_ms: 0.056209
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0044570Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0045860Z         # Subtest: should convert UPPER_CASE to snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0046780Z         ok 3 - should convert UPPER_CASE to snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0047550Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0049450Z           duration_ms: 0.042917
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0050140Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0050910Z         # Subtest: should handle already snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0051650Z         ok 4 - should handle already snake_case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0052370Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0052840Z           duration_ms: 0.165375
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0053320Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0054360Z         1..4
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0054910Z     ok 4 - toSnakeCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0055190Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0055430Z       duration_ms: 0.506417
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0055670Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0055890Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0056110Z     # Subtest: toPascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0056540Z         # Subtest: should convert camelCase to PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0056900Z         ok 1 - should convert camelCase to PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0057190Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0057400Z           duration_ms: 0.189459
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0057590Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0057940Z         # Subtest: should convert kebab-case to PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0058440Z         ok 2 - should convert kebab-case to PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0058700Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0058960Z           duration_ms: 0.095417
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0059140Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0059390Z         # Subtest: should convert snake_case to PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0059710Z         ok 3 - should convert snake_case to PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0059930Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0060130Z           duration_ms: 0.05225
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0061080Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0061530Z         # Subtest: should handle already PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0061970Z         ok 4 - should handle already PascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0062230Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0062490Z           duration_ms: 0.043667
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0062820Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0063030Z         1..4
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0063280Z     ok 5 - toPascalCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0063540Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0063740Z       duration_ms: 1.243917
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0063960Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0064110Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0064260Z     1..5
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0064470Z ok 1 - Case Conversion Utilities
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0064740Z   ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0065020Z   duration_ms: 5.2375
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0065520Z   type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0065740Z   ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0066030Z # Subtest: getenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0066270Z     # Subtest: should find variable in UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0066560Z     ok 1 - should find variable in UPPER_CASE
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0066790Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0066950Z       duration_ms: 0.231041
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0067120Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0069360Z     # Subtest: should find variable in camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0069810Z     ok 2 - should find variable in camelCase
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0070040Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0070220Z       duration_ms: 0.078542
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0070420Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0070640Z     # Subtest: should find variable in kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0070940Z     ok 3 - should find variable in kebab-case
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0071160Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0071310Z       duration_ms: 0.100417
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0071480Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0071700Z     # Subtest: should return default value when not found
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0072080Z     ok 4 - should return default value when not found
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0072330Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0072470Z       duration_ms: 0.066167
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0072650Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0072950Z     # Subtest: should return empty string as default when not specified
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0073360Z     ok 5 - should return empty string as default when not specified
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0073620Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0073760Z       duration_ms: 0.056708
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0073940Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0074710Z     # Subtest: should try original key first
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0075070Z     ok 6 - should try original key first
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0075270Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0075410Z       duration_ms: 0.16825
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0075590Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0075710Z     1..6
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0075850Z ok 2 - getenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0076020Z   ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0076170Z   duration_ms: 0.787417
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0076340Z   type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0076480Z   ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0076650Z # Subtest: makeConfig
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0076880Z     # Subtest: Hero Example (defaults)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0077230Z         # Subtest: should work with minimal configuration
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0077550Z         ok 1 - should work with minimal configuration
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0077790Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0077960Z           duration_ms: 5.994542
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0078230Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0078510Z         # Subtest: should use CLI arguments with highest priority
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0078860Z         ok 2 - should use CLI arguments with highest priority
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0079100Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0079350Z           duration_ms: 1.615292
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0079520Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0079780Z         # Subtest: should convert kebab-case to camelCase in result
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0080270Z         ok 3 - should convert kebab-case to camelCase in result
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0092020Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0092220Z           duration_ms: 1.869917
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0092400Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0092550Z         1..3
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0093230Z     ok 1 - Hero Example (defaults)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0093420Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0093590Z       duration_ms: 9.566583
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0093760Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0093910Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0094080Z     # Subtest: Environment Loading Priority
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0094360Z         # Subtest: should load .lenv file by default
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0094650Z         ok 1 - should load .lenv file by default
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0094870Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0095050Z           duration_ms: 2.228667
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0095210Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0095450Z         # Subtest: should handle --configuration flag
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0095740Z         ok 2 - should handle --configuration flag
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0095940Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0096120Z           duration_ms: 2.247584
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0096310Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0096540Z         # Subtest: should prioritize CLI over environment
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0096850Z         ok 3 - should prioritize CLI over environment
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0097070Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0097240Z           duration_ms: 1.504125
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0097410Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0097660Z         # Subtest: should handle missing .lenv file gracefully
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0098000Z         ok 4 - should handle missing .lenv file gracefully
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0098230Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0098380Z           duration_ms: 0.88975
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0098560Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0098710Z         1..4
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0098890Z     ok 2 - Environment Loading Priority
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0099090Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0099220Z       duration_ms: 6.988
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0099370Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0099500Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0099720Z     # Subtest: Case Conversion in Environment Loading
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0100080Z         # Subtest: should convert all keys to UPPER_CASE in process.env
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0100460Z         ok 1 - should convert all keys to UPPER_CASE in process.env
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0100700Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0100830Z           duration_ms: 1.3545
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0100990Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0101310Z         # Subtest: should find env vars in any case format via getenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0101890Z         ok 2 - should find env vars in any case format via getenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0102120Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0102290Z           duration_ms: 1.506875
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0102480Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0102620Z         1..2
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0102820Z     ok 3 - Case Conversion in Environment Loading
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0103020Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0103140Z       duration_ms: 2.93075
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0103290Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0103420Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0104170Z     # Subtest: Configuration Options
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0104560Z         # Subtest: should support disabling lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0104910Z         ok 1 - should support disabling lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0105160Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0105330Z           duration_ms: 3.313458
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0105510Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0105760Z         # Subtest: should support enabling env/dotenvx (deprecated)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0106120Z         ok 2 - should support enabling env/dotenvx (deprecated)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0106350Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0106510Z           duration_ms: 9.623208
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0106660Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0106860Z         # Subtest: should support disabling getenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0107130Z         ok 3 - should support disabling getenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0107320Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0107480Z           duration_ms: 4.69175
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0107640Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0107850Z         # Subtest: should support configuration alias -c
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0108140Z         ok 4 - should support configuration alias -c
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0108690Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0108860Z           duration_ms: 4.239583
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109010Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109130Z         1..4
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109290Z     ok 4 - Configuration Options
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109460Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109590Z       duration_ms: 22.141917
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109790Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0109920Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0110090Z     # Subtest: Complete Priority Chain
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0110490Z         # Subtest: should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0110990Z         ok 1 - should demonstrate full priority: CLI > getenv > --configuration > .lenv
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0111300Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0111460Z           duration_ms: 12.946292
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0111630Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0111750Z         1..1
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0111900Z     ok 5 - Complete Priority Chain
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0112080Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0112210Z       duration_ms: 13.109417
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0112370Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0112500Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0112690Z     # Subtest: Built-in Flag Conflicts (Issue \#14)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0113080Z         # Subtest: should allow user-defined --version option by calling .version(false)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0113550Z         ok 1 - should allow user-defined --version option by calling .version(false)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0113830Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0114010Z           duration_ms: 1.994042
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0114190Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0114410Z         # Subtest: should allow user-defined --help option
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0114710Z         ok 2 - should allow user-defined --help option
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0114920Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0115080Z           duration_ms: 0.777875
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0115230Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0115440Z         # Subtest: should work with --version in strict mode
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0115760Z         ok 3 - should work with --version in strict mode
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0115970Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0116130Z           duration_ms: 0.810875
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0116280Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0116490Z         # Subtest: should handle --version with boolean type
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0117340Z         ok 4 - should handle --version with boolean type
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0117720Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0117890Z           duration_ms: 0.692166
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0118060Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0118290Z         # Subtest: should allow users to explicitly enable help
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0118640Z         ok 5 - should allow users to explicitly enable help
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0118880Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0119040Z           duration_ms: 0.562125
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0119190Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0119460Z         # Subtest: should work with multiple custom options including version
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0119880Z         ok 6 - should work with multiple custom options including version
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0120130Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0120290Z           duration_ms: 0.860541
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0120450Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0120570Z         1..6
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0120760Z     ok 6 - Built-in Flag Conflicts (Issue \#14)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0120960Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0121090Z       duration_ms: 5.881
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0121240Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0121380Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0121610Z     # Subtest: Explicitly Enabling Built-in Version and Help
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0121970Z         # Subtest: should allow explicitly enabling built-in --version
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0122340Z         ok 1 - should allow explicitly enabling built-in --version
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0122580Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0122740Z           duration_ms: 0.595709
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0122900Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0123170Z         # Subtest: should allow explicitly enabling both --version and --help
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0123860Z         ok 2 - should allow explicitly enabling both --version and --help
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0124120Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0124280Z           duration_ms: 0.714542
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0124430Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0124620Z         # Subtest: should allow version with alias
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0124890Z         ok 3 - should allow version with alias
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0125080Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0125240Z           duration_ms: 0.631084
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0125400Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0125590Z         # Subtest: should allow help with alias
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0125830Z         ok 4 - should allow help with alias
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0126020Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0126180Z           duration_ms: 0.740333
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0126330Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0126610Z         # Subtest: should work with both built-in version/help and custom options
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0127040Z         ok 5 - should work with both built-in version/help and custom options
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0127300Z           ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0127460Z           duration_ms: 2.602791
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0127610Z           ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0127740Z         1..5
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0127950Z     ok 7 - Explicitly Enabling Built-in Version and Help
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128170Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128300Z       duration_ms: 5.481916
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128460Z       type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128590Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128700Z     1..7
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128830Z ok 3 - makeConfig
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0128970Z   ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0129090Z   duration_ms: 66.426334
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0129750Z   type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0130120Z   ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0130350Z # Subtest: parseLinoArguments (legacy)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0131180Z     # Subtest: should parse simple links notation format
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0131480Z     ok 1 - should parse simple links notation format
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0131690Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0131830Z       duration_ms: 1.868167
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0131980Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0132190Z     # Subtest: should parse arguments without parentheses
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0132520Z     ok 2 - should parse arguments without parentheses
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0132740Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0133120Z       duration_ms: 0.260292
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0133270Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0133440Z     # Subtest: should handle empty input
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0133670Z     ok 3 - should handle empty input
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0133850Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0133970Z       duration_ms: 0.105917
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0134120Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0134290Z     # Subtest: should handle null input
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0134530Z     ok 4 - should handle null input
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0134700Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0136400Z       duration_ms: 0.039208
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0136730Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0136920Z     # Subtest: should filter out comments
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0137160Z     ok 5 - should filter out comments
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0137330Z       ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0137470Z       duration_ms: 0.423459
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0137630Z       ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0137770Z     1..5
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0138030Z ok 4 - parseLinoArguments (legacy)
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0138250Z   ---
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0138410Z   duration_ms: 2.841541
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0138600Z   type: 'suite'
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0138730Z   ...
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0138880Z 1..4
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139000Z # tests 58
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139120Z # suites 16
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139240Z # pass 58
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139360Z # fail 0
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139480Z # cancelled 0
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139610Z # skipped 0
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139730Z # todo 0
+Test (node on macos-latest)	Run tests (Node.js)	2026-04-10T20:47:23.0139890Z # duration_ms 210.711334
+Test (node on macos-latest)	Post Setup Node.js	﻿2026-04-10T20:47:23.0246390Z Post job cleanup.
+Test (node on macos-latest)	Post Run actions/checkout@v4	﻿2026-04-10T20:47:23.2943970Z Post job cleanup.
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.4601540Z [command]/opt/homebrew/bin/git version
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.4702180Z git version 2.53.0
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.5185460Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/c8312d11-60a4-443a-9f8e-cc1b4ccf5d01/.gitconfig'
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.5249280Z Temporarily overriding HOME='/Users/runner/work/_temp/c8312d11-60a4-443a-9f8e-cc1b4ccf5d01' before making global git config changes
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.5280760Z Adding repository directory to the temporary git global config as a safe directory
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.5343340Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-arguments/lino-arguments
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.5377900Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.5399050Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.6038390Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.6097900Z http.https://github.com/.extraheader
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.6269620Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.6274550Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.7231280Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (node on macos-latest)	Post Run actions/checkout@v4	2026-04-10T20:47:23.7479180Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (node on macos-latest)	Complete job	﻿2026-04-10T20:47:23.8429880Z Cleaning up orphan processes
+Test (node on macos-latest)	Complete job	2026-04-10T20:47:24.2041720Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Release	Set up job	﻿2026-04-10T20:48:09.2519201Z Current runner version: '2.333.1'
+Release	Set up job	2026-04-10T20:48:09.2545300Z ##[group]Runner Image Provisioner
+Release	Set up job	2026-04-10T20:48:09.2546220Z Hosted Compute Agent
+Release	Set up job	2026-04-10T20:48:09.2547004Z Version: 20260213.493
+Release	Set up job	2026-04-10T20:48:09.2547609Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+Release	Set up job	2026-04-10T20:48:09.2548693Z Build Date: 2026-02-13T00:28:41Z
+Release	Set up job	2026-04-10T20:48:09.2549375Z Worker ID: {b6552bb3-7f2c-49d6-9315-e0f90a1195ae}
+Release	Set up job	2026-04-10T20:48:09.2550018Z Azure Region: eastus
+Release	Set up job	2026-04-10T20:48:09.2550624Z ##[endgroup]
+Release	Set up job	2026-04-10T20:48:09.2552070Z ##[group]Operating System
+Release	Set up job	2026-04-10T20:48:09.2552702Z Ubuntu
+Release	Set up job	2026-04-10T20:48:09.2553219Z 24.04.4
+Release	Set up job	2026-04-10T20:48:09.2553679Z LTS
+Release	Set up job	2026-04-10T20:48:09.2554116Z ##[endgroup]
+Release	Set up job	2026-04-10T20:48:09.2554694Z ##[group]Runner Image
+Release	Set up job	2026-04-10T20:48:09.2555246Z Image: ubuntu-24.04
+Release	Set up job	2026-04-10T20:48:09.2555740Z Version: 20260406.80.1
+Release	Set up job	2026-04-10T20:48:09.2557182Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+Release	Set up job	2026-04-10T20:48:09.2558872Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+Release	Set up job	2026-04-10T20:48:09.2559823Z ##[endgroup]
+Release	Set up job	2026-04-10T20:48:09.2560937Z ##[group]GITHUB_TOKEN Permissions
+Release	Set up job	2026-04-10T20:48:09.2563153Z Contents: write
+Release	Set up job	2026-04-10T20:48:09.2563725Z Metadata: read
+Release	Set up job	2026-04-10T20:48:09.2564207Z PullRequests: write
+Release	Set up job	2026-04-10T20:48:09.2564800Z ##[endgroup]
+Release	Set up job	2026-04-10T20:48:09.2567489Z Secret source: Actions
+Release	Set up job	2026-04-10T20:48:09.2568698Z Prepare workflow directory
+Release	Set up job	2026-04-10T20:48:09.2973690Z Prepare all required actions
+Release	Set up job	2026-04-10T20:48:09.3012820Z Getting action download info
+Release	Set up job	2026-04-10T20:48:09.6327103Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Release	Set up job	2026-04-10T20:48:09.8270930Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Release	Set up job	2026-04-10T20:48:10.1124114Z Complete job name: Release
+Release	Run actions/checkout@v4	﻿2026-04-10T20:48:10.1937015Z ##[group]Run actions/checkout@v4
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1938056Z with:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1938532Z   fetch-depth: 0
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1939014Z   repository: link-foundation/lino-arguments
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1939861Z   token: ***
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1940267Z   ssh-strict: true
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1940696Z   ssh-user: git
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1941132Z   persist-credentials: true
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1941629Z   clean: true
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1942061Z   sparse-checkout-cone-mode: true
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1942598Z   fetch-tags: false
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1943053Z   show-progress: true
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1943510Z   lfs: false
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1943920Z   submodules: false
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1944360Z   set-safe-directory: true
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.1945144Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3150996Z Syncing repository: link-foundation/lino-arguments
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3153258Z ##[group]Getting Git version info
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3154124Z Working directory is '/home/runner/work/lino-arguments/lino-arguments'
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3155427Z [command]/usr/bin/git version
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3195603Z git version 2.53.0
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3230459Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3255100Z Temporarily overriding HOME='/home/runner/work/_temp/7d77d3d7-047a-49de-84b2-b2cab96d6feb' before making global git config changes
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3257054Z Adding repository directory to the temporary git global config as a safe directory
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3261632Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3296803Z Deleting the contents of '/home/runner/work/lino-arguments/lino-arguments'
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3300235Z ##[group]Initializing the repository
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3304902Z [command]/usr/bin/git init /home/runner/work/lino-arguments/lino-arguments
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3392420Z hint: Using 'master' as the name for the initial branch. This default branch name
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3393880Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3395051Z hint: to use in all of your new repositories, which will suppress this warning,
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3396548Z hint: call:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3397351Z hint:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3398408Z hint: 	git config --global init.defaultBranch <name>
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3399499Z hint:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3400330Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3401474Z hint: 'development'. The just-created branch can be renamed via this command:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3402254Z hint:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3402669Z hint: 	git branch -m <name>
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3403152Z hint:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3403794Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3404922Z Initialized empty Git repository in /home/runner/work/lino-arguments/lino-arguments/.git/
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3411338Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-arguments
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3449428Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3450285Z ##[group]Disabling automatic garbage collection
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3455643Z [command]/usr/bin/git config --local gc.auto 0
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3490401Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3491827Z ##[group]Setting up auth
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3498009Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3534268Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3821888Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.3854020Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.4088287Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.4121517Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.4350956Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.4387584Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.4388761Z ##[group]Fetching the repository
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.4397377Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7431550Z From https://github.com/link-foundation/lino-arguments
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7433975Z  * [new branch]      changeset-release/manual-19391025857 -> origin/changeset-release/manual-19391025857
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7436796Z  * [new branch]      claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj -> origin/claude/adapt-cicd-publish-01J44V2DMtPscSchmkVg14wj
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7441160Z  * [new branch]      claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq -> origin/claude/use-getenv-npm-package-01Nt3cRMXpLUepTDxw8SGgJq
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7444368Z  * [new branch]      issue-1-171e0c1cad4c  -> origin/issue-1-171e0c1cad4c
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7446746Z  * [new branch]      issue-10-89893ff89d82 -> origin/issue-10-89893ff89d82
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7449075Z  * [new branch]      issue-10-d4419a0e77c2 -> origin/issue-10-d4419a0e77c2
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7451274Z  * [new branch]      issue-13-167bb501b116 -> origin/issue-13-167bb501b116
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7453424Z  * [new branch]      issue-14-555e0cfd6e57 -> origin/issue-14-555e0cfd6e57
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7455624Z  * [new branch]      issue-17-aac47b45095f -> origin/issue-17-aac47b45095f
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7457915Z  * [new branch]      issue-19-c4402d419d95 -> origin/issue-19-c4402d419d95
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7459603Z  * [new branch]      issue-20-535e73c3f5df -> origin/issue-20-535e73c3f5df
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7461275Z  * [new branch]      issue-23-139e66537421 -> origin/issue-23-139e66537421
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7463347Z  * [new branch]      issue-25-05c1d1b27224 -> origin/issue-25-05c1d1b27224
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7465170Z  * [new branch]      issue-27-88fb89a5de9c -> origin/issue-27-88fb89a5de9c
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7467252Z  * [new branch]      issue-6-88ce301275b5  -> origin/issue-6-88ce301275b5
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7469145Z  * [new branch]      issue-6-ed79da598197  -> origin/issue-6-ed79da598197
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7471321Z  * [new branch]      issue-6-ef625c0a060f  -> origin/issue-6-ef625c0a060f
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7473007Z  * [new branch]      main                  -> origin/main
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7474327Z  * [new tag]         v0.1.1                -> v0.1.1
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7475567Z  * [new tag]         v0.2.0                -> v0.2.0
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7477202Z  * [new tag]         v0.2.5                -> v0.2.5
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7478485Z  * [new tag]         v0.2.7                -> v0.2.7
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7479762Z  * [new tag]         v0.2.8                -> v0.2.8
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7481175Z  * [new tag]         v0.3.0                -> v0.3.0
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7501687Z [command]/usr/bin/git branch --list --remote origin/main
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7528940Z   origin/main
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7538177Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7560707Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7566591Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7568810Z ##[group]Determining the checkout info
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7571397Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7572849Z [command]/usr/bin/git sparse-checkout disable
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7610889Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7639798Z ##[group]Checking out the ref
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7643653Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7805814Z Switched to a new branch 'main'
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7808260Z branch 'main' set up to track 'origin/main'.
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7815455Z ##[endgroup]
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7854496Z [command]/usr/bin/git log -1 --format=%H
+Release	Run actions/checkout@v4	2026-04-10T20:48:10.7880195Z f990d427d8601605daeaf256f1086f34bc3e3db6
+Release	Setup Node.js	﻿2026-04-10T20:48:10.8212541Z ##[group]Run actions/setup-node@v4
+Release	Setup Node.js	2026-04-10T20:48:10.8214308Z with:
+Release	Setup Node.js	2026-04-10T20:48:10.8215501Z   node-version: 20.x
+Release	Setup Node.js	2026-04-10T20:48:10.8217348Z   registry-url: https://registry.npmjs.org
+Release	Setup Node.js	2026-04-10T20:48:10.8219043Z   always-auth: false
+Release	Setup Node.js	2026-04-10T20:48:10.8220416Z   check-latest: false
+Release	Setup Node.js	2026-04-10T20:48:10.8221617Z   token: ***
+Release	Setup Node.js	2026-04-10T20:48:10.8222377Z ##[endgroup]
+Release	Setup Node.js	2026-04-10T20:48:11.0075688Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+Release	Setup Node.js	2026-04-10T20:48:11.0081310Z ##[group]Environment details
+Release	Setup Node.js	2026-04-10T20:48:13.8846749Z node: v20.20.2
+Release	Setup Node.js	2026-04-10T20:48:13.8847358Z npm: 10.8.2
+Release	Setup Node.js	2026-04-10T20:48:13.8847717Z yarn: 1.22.22
+Release	Setup Node.js	2026-04-10T20:48:13.8848919Z ##[endgroup]
+Release	Install dependencies	﻿2026-04-10T20:48:13.8975086Z ##[group]Run npm install
+Release	Install dependencies	2026-04-10T20:48:13.8975487Z [36;1mnpm install[0m
+Release	Install dependencies	2026-04-10T20:48:13.9051752Z shell: /usr/bin/bash -e {0}
+Release	Install dependencies	2026-04-10T20:48:13.9052098Z env:
+Release	Install dependencies	2026-04-10T20:48:13.9052379Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+Release	Install dependencies	2026-04-10T20:48:13.9052748Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+Release	Install dependencies	2026-04-10T20:48:13.9053071Z ##[endgroup]
+Release	Install dependencies	2026-04-10T20:48:18.1843319Z 
+Release	Install dependencies	2026-04-10T20:48:18.1852654Z > lino-arguments@0.3.0 prepare
+Release	Install dependencies	2026-04-10T20:48:18.1853753Z > husky || true
+Release	Install dependencies	2026-04-10T20:48:18.1854383Z 
+Release	Install dependencies	2026-04-10T20:48:18.2303030Z .git can't be found
+Release	Install dependencies	2026-04-10T20:48:18.2303910Z added 234 packages, and audited 235 packages in 4s
+Release	Install dependencies	2026-04-10T20:48:18.2304398Z 
+Release	Install dependencies	2026-04-10T20:48:18.2304686Z 59 packages are looking for funding
+Release	Install dependencies	2026-04-10T20:48:18.2305255Z   run `npm fund` for details
+Release	Install dependencies	2026-04-10T20:48:18.2400112Z 
+Release	Install dependencies	2026-04-10T20:48:18.2400900Z 7 vulnerabilities (4 moderate, 3 high)
+Release	Install dependencies	2026-04-10T20:48:18.2401440Z 
+Release	Install dependencies	2026-04-10T20:48:18.2401831Z To address all issues, run:
+Release	Install dependencies	2026-04-10T20:48:18.2402480Z   npm audit fix
+Release	Install dependencies	2026-04-10T20:48:18.2402862Z 
+Release	Install dependencies	2026-04-10T20:48:18.2403224Z Run `npm audit` for details.
+Release	Update npm for OIDC trusted publishing	﻿2026-04-10T20:48:18.2673223Z ##[group]Run node ../scripts/setup-npm.mjs
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:18.2673661Z [36;1mnode ../scripts/setup-npm.mjs[0m
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:18.2695011Z shell: /usr/bin/bash -e {0}
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:18.2695278Z env:
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:18.2695528Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:18.2695860Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:18.2696128Z ##[endgroup]
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:20.6568159Z 10.8.2
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:20.6621842Z Current npm version: 10.8.2
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.7291573Z 
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.7292474Z removed 64 packages, and changed 111 packages in 3s
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.7299146Z 
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.7306025Z 15 packages are looking for funding
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.7306947Z   run `npm fund` for details
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.8419450Z 11.12.1
+Release	Update npm for OIDC trusted publishing	2026-04-10T20:48:23.8465730Z Updated npm version: 11.12.1
+Release	Check for changesets	﻿2026-04-10T20:48:23.8556865Z ##[group]Run # Count changeset files (excluding README.md and config.json)
+Release	Check for changesets	2026-04-10T20:48:23.8557450Z [36;1m# Count changeset files (excluding README.md and config.json)[0m
+Release	Check for changesets	2026-04-10T20:48:23.8557980Z [36;1mCHANGESET_COUNT=$(find .changeset -name "*.md" ! -name "README.md" | wc -l)[0m
+Release	Check for changesets	2026-04-10T20:48:23.8558431Z [36;1mecho "Found $CHANGESET_COUNT changeset file(s)"[0m
+Release	Check for changesets	2026-04-10T20:48:23.8558923Z [36;1mecho "has_changesets=$([[ $CHANGESET_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT[0m
+Release	Check for changesets	2026-04-10T20:48:23.8581505Z shell: /usr/bin/bash -e {0}
+Release	Check for changesets	2026-04-10T20:48:23.8581749Z env:
+Release	Check for changesets	2026-04-10T20:48:23.8581981Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+Release	Check for changesets	2026-04-10T20:48:23.8582317Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+Release	Check for changesets	2026-04-10T20:48:23.8582576Z ##[endgroup]
+Release	Check for changesets	2026-04-10T20:48:23.8647867Z Found 0 changeset file(s)
+Release	Post Setup Node.js	﻿2026-04-10T20:48:23.8787527Z Post job cleanup.
+Release	Post Run actions/checkout@v4	﻿2026-04-10T20:48:24.0504101Z Post job cleanup.
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1465338Z [command]/usr/bin/git version
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1504310Z git version 2.53.0
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1551145Z Temporarily overriding HOME='/home/runner/work/_temp/d850782d-e466-4cf7-8211-1e60f6930b6f' before making global git config changes
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1552792Z Adding repository directory to the temporary git global config as a safe directory
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1564902Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-arguments/lino-arguments
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1602324Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1635959Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1868642Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1891081Z http.https://github.com/.extraheader
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1903911Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.1935892Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.2165003Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Release	Post Run actions/checkout@v4	2026-04-10T20:48:24.2198228Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Release	Complete job	﻿2026-04-10T20:48:24.2534080Z Cleaning up orphan processes
+Release	Complete job	2026-04-10T20:48:24.2804047Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


### PR DESCRIPTION
## Summary

Fixes #29

The JavaScript CI/CD pipeline has not published to npm since version 0.2.5 (Dec 2025). The npm registry shows `lino-arguments@0.2.5` while `package.json` has `0.3.0`. Meanwhile Rust releases work correctly (`rust_0.3.0`).

## Root Causes

1. **Release job skips publish when no changesets exist** — The `release` job only publishes when `version-and-commit.mjs` runs (requires changesets). If a version was committed and tagged but never published to npm, the pipeline has no way to detect and retry the publish.

2. **Tag prefix migration gap** — PR #28 switched JS tags from `v` prefix to `js_` prefix, but no migration path was created for existing `v`-prefixed tags.

## Changes

- **`.github/workflows/js.yml`**: Added `Check if current version needs publishing` step that queries npm registry independently of changeset state. Also added `Ensure release tag exists` step to handle tag prefix migration from `v` to `js_`.
- **`docs/case-studies/issue-29/`**: Full case study with timeline, root cause analysis, CI log archives, and npm/git state data.

## How It Works

After merge, on the next push to main that triggers JS CI/CD:

1. Release job checks npm for `lino-arguments@0.3.0` — not found → `needs_publish=true`
2. Publish step runs → publishes v0.3.0 to npm
3. Tag migration creates `js_0.3.0` from existing `v0.3.0` tag
4. GitHub release `[JavaScript] 0.3.0` is created

Future releases continue to work through the normal changeset flow.

## Test Plan

- [x] Verified workflow logic traces correctly for all scenarios (new changeset, no changeset + unpublished, no changeset + already published)
- [ ] CI passes on this PR
- [ ] After merge: verify `npm view lino-arguments@0.3.0` returns the version
- [ ] After merge: verify `js_0.3.0` tag and GitHub release exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)